### PR TITLE
refactor: A constructor name should not start with a lowercase letter but a uppercase

### DIFF
--- a/examples/docs/newsrc/uses/useMonaco.js
+++ b/examples/docs/newsrc/uses/useMonaco.js
@@ -2,9 +2,9 @@ import * as monaco from 'monaco-editor'
 import { hooks } from '@opentiny/vue-common'
 // monaco ESM模块集成说明 ： https://github.com/microsoft/monaco-editor/blob/main/docs/integrate-esm.md#using-vite
 // https://github.com/vitejs/vite/discussions/1791#discussioncomment-321046
-import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker'
+import HtmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker'
 self.MonacoEnvironment = {
-  getWorker: () => new htmlWorker()
+  getWorker: () => new HtmlWorker()
 }
 
 export function useMonaco(selector) {


### PR DESCRIPTION
A constructor name should not start with a lowercase letter but a uppercase.

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/ui-vue/blob/main/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
