### PR TITLE
fix:When nesting using Split, the mouse direction on the left and right split line is wrong when the upper and lower division is nested

### DIFF
--- a/packages/theme/src/split/index.less
+++ b/packages/theme/src/split/index.less
@@ -182,6 +182,7 @@
       top: 50%;
       height: 100%;
       width: 10px;
+      cursor: var(--ti-split-trigger-con-col-cursor);
     }
 
     .@{split-prefix-cls}-collapse-bar {


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
![current](https://github.com/opentiny/tiny-vue/assets/67041206/2adee509-14ad-4189-9f18-2558b70cb672)


## What is the new behavior?
![new](https://github.com/opentiny/tiny-vue/assets/67041206/f460e195-62f0-4b1c-a688-753fd78dea80)

## Related Issues
close #327 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
This is my first time to submit a pr, please forgive me if I do not do well