### PR TITLE
feat: tiny-react event module, imitate vue event system

### DIFF
--- a/packages/react-common/src/event.js
+++ b/packages/react-common/src/event.js
@@ -1,0 +1,95 @@
+import { eventBus } from './utils'
+
+const $busMap = new Map()
+
+export const emit = (props) => (evName, ...args) => {
+  const reactEvName = 'on'
+    + evName.substr(0, 1).toUpperCase()
+    + evName.substr(1)
+
+  if (props[reactEvName] && typeof props[reactEvName] === 'function') {
+    props[reactEvName](...args)
+  }
+  else {
+    const $bus = $busMap.get(props)
+    if ($bus) {
+      $bus.emit(evName, ...args)
+    }
+  }
+}
+export const on = (props) => (evName, callback) => {
+  if ($busMap.get(props)) {
+    const $bus = $busMap.get(props)
+    $bus.on(evName, callback)
+  }
+  else {
+    const $bus = eventBus()
+    $bus.on(evName, callback)
+    $busMap.set(props, $bus)
+  }
+}
+export const off = (props) => (evName, callback) => {
+  const $bus = $busMap.get(props)
+  if (!$bus) return
+  $bus.off(evName, callback)
+}
+export const once = (props) => (evName, callback) => {
+  let $bus = null
+  const onceCallback = (...args) => {
+    callback(...args)
+    $bus && $bus.off(evName, onceCallback)
+  }
+
+  if ($busMap.get(props)) {
+    $bus = $busMap.get(props)
+    $bus.on(evName, onceCallback)
+  }
+  else {
+    $bus = eventBus()
+    $bus.on(evName, onceCallback)
+    $busMap.set(props, $bus)
+  }
+}
+export const emitEvent = (vm) => {
+  const broadcast = (vm, componentName, eventName, ...args) => {
+    const children = vm.$children
+
+    Array.isArray(children)
+      && children.forEach((child) => {
+        const name = child.$options && child.$options.componentName
+        const component = child
+
+        if (name === componentName) {
+          component.emit(eventName, ...args)
+          // todo: 调研 component.$emitter
+          // component.$emitter && component.$emitter.emit(eventName, params)
+        }
+        else {
+          broadcast(child, componentName, eventName, ...args)
+        }
+      })
+  }
+
+  return {
+    dispatch(componentName, eventName, ...args) {
+      let parent = vm.parent
+      if (parent.type === null) return
+      let name = parent.$options && parent.$options.componentName
+      while (parent && parent.type && (!name || name !== componentName)) {
+        parent = parent.parent
+
+        if (parent)
+          name = parent.$options && parent.$options.componentName
+      }
+
+      if (parent) {
+        parent.emit(eventName, ...args)
+        // fix: VUE3下事件参数为数组，VUE2下事件参数不是数组，这里修改为和VUE2兼容
+        // parent.$emitter && parent.$emitter.emit(...[eventName].concat(params))
+      }
+    },
+    broadcast(componentName, eventName, ...args) {
+      broadcast(vm, componentName, eventName, ...args)
+    }
+  }
+}


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, in the Vue version of the component, Vue's own event system is used. You can register events on the component by using the "on," "emit," "once," and "off" methods on the component instance.

## What is the new behavior?

In React, the current approach to emitting events is by adding methods named in the form of "onClick" to the props to listen for events.

The emit method can check if the event exists in the props, retrieve it, and execute the corresponding event listener.

However, the "on" method cannot be modified through props. Therefore, event listeners must be placed in a specific location, and these event listeners can be accessed through the component. Therefore, you can use a map to associate event listeners with components, and later, "once" and "off" can be implemented based on the event bus and map.

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


# PR中文描述
## PR清单 
请检查您的 PR 是否满足以下要求：

- [x] 提交消息遵循我们的[提交消息指南](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] 添加了对更改的测试（用于错误修复/功能）
- [ ] 文档已添加/更新（用于错误修复/功能）

## pr类型
这个 PR 带来了什么样的改变？

- [ ] 错误修正
- [X] 特征
- [ ] 代码风格更新（格式、局部变量）
- [ ] 重构（无功能更改，无 api 更改）
- [ ] 构建相关变更
- [ ] CI 相关变更
- [ ] 文档内容变更
- [ ] 其他...请描述：

## 行为

目前 vue 版的组件用的是 vue 自身的事件系统，可以通过组件实例上的 on、emit、once、off 方法去组件身上注册事件。

而react 当前的 emit 是通过 props 里添加 onClick 这种形式命名的方法去监听事件。

emit 方法就可通过判断 props 里是否有该事件，去拿到并执行该事件监听函数。

然而，on 方法是不能通过在props 里做修改的，所以 on 必须得将事件监听放在一个地方，而且这个事件监听是可以通过该组件去获取的，那么就可以通过 map 将事件监听和组件对应上，后面的 once 和 off 都可以基于事件总线和 map 去实现。

## 此 PR 是否引入了重大更改？

- [x] 是的
- [ ] 不



#### API

- emit
```js
(props) => (evName: string)
```
- on 
```js
(props) => (evName: string, evHandler: Function)
```
- once
```js
(props) => (evName: string, evHandler: Function)
```
- off
```js
(props) => (evName: string, evHandler: Function)
```

example
```js
function App(props) {

  const event = {
    emit: emit(props),
    on: on(props),
    once: once(props),
    off: off(props)
  }

  useEffect(() => {
    event.emit('mounted') // actually emit onMounted event handler
  }, [])

  const eat = () => console.log('eat');

  useEffect(() => {
    event.on('eat', eat);
  })

  const eatOnce = () => {
    emit('eat')
    off('eat', eat)
  };

  return (<div onClick={eatOnce}>吃</div>)
}
```

- emitEvent

```js
(vm) => {
  dispatch(componentName: string, eventName: string, ...args),
  broadcast(componentName: string, eventName: string, ...args)
}
```

dispatch: emit events on parent
broadcast: emit events on children