### PR TITLE
feat: data responsive core, registering responsive objects through us…

### DIFF
--- a/packages/react-common/src/reactive.js
+++ b/packages/react-common/src/reactive.js
@@ -31,7 +31,7 @@ const reactive = (
       })
 
       if (typeof targetVal === 'object') {
-        return reactive(targetVal, handler, path, rootStaticObject)
+        return reactive(targetVal, handler, _path, rootStaticObject)
       }
       return targetVal
     },

--- a/packages/react-common/src/reactive.js
+++ b/packages/react-common/src/reactive.js
@@ -1,0 +1,96 @@
+import { useState, useRef } from 'react'
+
+// 响应式核心
+const reactiveMap = new WeakMap()
+const reactive = (
+  staticObject,
+  handler = {},
+  path = [],
+  rootStaticObject = staticObject
+) => {
+  reactiveMap.has(staticObject) || reactiveMap.set(staticObject, new Proxy(staticObject, {
+    get(
+      target,
+      property,
+      receiver
+    ) {
+      const targetVal = target[property]
+      const _path = [...path, property]
+      const res = typeof targetVal === 'object'
+        ? reactive(targetVal, handler, _path, rootStaticObject)
+        : targetVal
+
+      // 监听访问
+      handler.get && handler.get({
+        result: res,
+        root: rootStaticObject,
+        path: _path,
+        target,
+        property,
+        receiver
+      })
+
+      if (typeof targetVal === 'object') {
+        return reactive(targetVal, handler, path, rootStaticObject)
+      }
+      return targetVal
+    },
+    set(
+      target,
+      property,
+      value,
+      receiver
+    ) {
+      const _path = [...path, property]
+
+      // 监听修改
+      handler.set && handler.set({
+        target,
+        property,
+        receiver,
+        root: rootStaticObject,
+        path: _path,
+        newVal: value,
+        oldVal: target[property]
+      })
+
+      target[property] = value
+      return true
+    }
+  }))
+
+  return reactiveMap.get(staticObject)
+}
+
+const useReload = () => {
+  const setReload = useState(false)[1]
+  return () => setReload(pre => !pre)
+}
+
+const isObject = (val) => val !== null && typeof val === 'object'
+
+// 用于从 hooks 链表中查找 reactive 生成的 state
+export function Reactive(obj) {
+  Object.keys(obj).forEach(key => {
+    this[key] = obj[key]
+  })
+}
+
+export const useReactive = (initalObject) => {
+  if (!isObject(initalObject)) {
+    return initalObject
+  }
+  const memoried = useRef()
+  const proxy = useRef()
+  const reload = useReload()
+  // 只调用一次
+  if (!memoried.current && !proxy.current) {
+    memoried.current = new Reactive(initalObject)
+    proxy.current = reactive(memoried.current, {
+      set() {
+        reload()
+      }
+    })
+  }
+  return proxy.current
+}


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the new behavior?

Add useReactive in tiny-react to generate and respond to objects, with the ability to respond deeply.

The responsive core proxies objects through proxy.

If the proxy is to object properties, recursively call to create a new proxy.

If the object has been proxied before, return the proxy from the map.

Callbacks can be registered in both get and set to execute methods such as setState.

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


# PR中文描述
## PR清单 
请检查您的 PR 是否满足以下要求：

- [x] 提交消息遵循我们的[提交消息指南](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] 添加了对更改的测试（用于错误修复/功能）
- [ ] 文档已添加/更新（用于错误修复/功能）

## pr类型
这个 PR 带来了什么样的改变？

- [ ] 错误修正
- [X] 特征
- [ ] 代码风格更新（格式、局部变量）
- [ ] 重构（无功能更改，无 api 更改）
- [ ] 构建相关变更
- [ ] CI 相关变更
- [ ] 文档内容变更
- [ ] 其他...请描述：

## 行为

在 tiny-react 中添加 useReactive，用于生成和响应式对象，具备深层响应的能力。

响应式核心通过 proxy 代理对象。
如果代理到对象属性，递归调用创建新的代理。
如果之前代理过该对象，从 map 中返回该代理。
在 get 和 set 中都可以注册回调，去执行 setState 等方法。

## 此 PR 是否引入了重大更改？

- [x] 是的
- [ ] 不



#### API

- reactiveMap

```js
const reactiveMap: WeakMap = new WeakMap();
```

通过被代理的静态对象存储已经代理过的对象，避免每次深层响应都去创建新的代理对象。

By storing objects that have already been proxied through static objects being proxied, it avoids creating new proxy objects every time a deep response occurs.

- reactive

```js
reactive = (
  staticObject,
  handler = {
    get(){},
    set(){}
  },
  path = [],
  rootStaticObject = staticObject
) => Proxy(Reactive)
```

返回代理对象，该对象可以进行深层代理，并且在 get 和 set 时可以注册回调，但是不能拦截更改或读取。
Returns a proxy object that can be deeply proxied and can register callbacks during get and set, but cannot intercept changes or reads.

- useReload

```js
const reload = useReload()

() => reload() // 刷新组件
```

用于刷新组件，通过一个 bool 状态去操作，让组件重新读取状态对象的属性，而不是将状态对象重新结构合并，减少这层消耗。

Used to refresh components and operate through a bool state, allowing the component to re read the properties of the state object instead of restructuring and merging the state object to reduce this layer of consumption.

- isObject

```js
const isObject = (val) => val !== null && typeof val === 'object'
```

用于判断被代理的对象是否真的是一个对象，如果不是就直接原路返回。

Used to determine whether the object being proxied is truly an object, and if it is not, it will be returned directly in the original path.

- Reactive

将一个字面量对象创建为 Reactive 实例，用户在 hooks 链表中查找首个 useReactive 创建的响应式对象。

Create a literal object as a Reactive instance, and the user searches for the first responsive object created by useReactive in the hooks linked list.

- useReactive

```js
const state = useReactive({
  text: '一句话'
});

const changeText = (val) => state.text = val
```

在 reactive 的基础上接入了 hooks 封装为 useReactive，实现在 react 数据响应式。

On the basis of reactive, hooks are integrated and encapsulated as useReactive, achieving responsive response in the reactive data.