### PR TITLE
feat(react): Add related operations to the fiber tree

### DIFF
--- a/packages/react-common/src/fiber.js
+++ b/packages/react-common/src/fiber.js
@@ -72,9 +72,22 @@ function collectRefs(fiber) {
   }, {})
 }
 
-function getParentFiber(fiber, isFirst = true) {
-  if (typeof fiber.type !== 'string' && !isFirst) return fiber
+const parentMap = new WeakMap()
+export function getParentFiber(fiber, isFirst = true, child = fiber) {
+  if (parentMap.has(child)) return parentMap.get(child)
+  if (typeof fiber.type !== 'string' && !isFirst) {
+    parentMap.set(child, fiber)
+    return fiber
+  }
   return getParentFiber(fiber.return, false)
+}
+
+export function creatFiberCombine(fiber) {
+  return {
+    fiber,
+    refs: fiber && collectRefs(fiber.child),
+    children: fiber && collectChildren(fiber.child),
+  }
 }
 
 export function useFiber() {
@@ -95,15 +108,7 @@ export function useFiber() {
 
   return {
     ref,
-    parent: {
-      fiber: parent,
-      refs: parent && collectRefs(parent.child),
-      children: parent && collectChildren(parent.child),
-    },
-    current: {
-      fiber: current,
-      refs: current && collectRefs(current.child),
-      children: current && collectChildren(current.child),
-    }
+    parent: creatFiberCombine(parent),
+    current: creatFiberCombine(current)
   }
 }

--- a/packages/react-common/src/fiber.js
+++ b/packages/react-common/src/fiber.js
@@ -1,0 +1,109 @@
+import { useRef, useEffect, useState } from 'react'
+
+function getFiberByDom(dom) {
+  const key = Object.keys(dom).find((key) => {
+    return (
+      key.startsWith('__reactFiber$') || // react 17+
+      key.startsWith('__reactInternalInstance$')
+    ) // react <17
+  })
+
+  return dom[key]
+}
+
+function traverseFiber(fiber, breaker, handler) {
+  if (!fiber) return
+  typeof handler === 'function' && handler(fiber)
+  if (typeof breaker !== 'function') {
+    breaker = () => { }
+  }
+  traverseFiber(fiber.sibling, breaker, handler)
+  breaker(fiber) || traverseFiber(fiber.child, breaker, handler)
+}
+
+function collectFiber(fiber, collector, mapper) {
+  const collect = []
+  traverseFiber(
+    fiber,
+    ({ type }) => typeof type !== 'string',
+    (fiber) => {
+      if (typeof collector === 'function' && collector(fiber)) {
+        collect.push(fiber)
+      }
+    }
+  )
+  return typeof mapper === 'function'
+    ? collect.map(mapper)
+    : collect
+}
+
+function collectChildren(fiber) {
+  return collectFiber(fiber, (fiber) => {
+    return fiber.type && typeof fiber.type !== 'string'
+  })
+}
+
+function collectRefs(fiber) {
+  return collectFiber(
+    fiber,
+    (fiber) => {
+      if (typeof fiber.type === 'string') {
+        return fiber.stateNode.getAttribute('v_ref')
+      }
+      else {
+        return fiber.memoizedProps.v_ref
+      }
+    },
+    (fiber) => {
+      if (typeof fiber.type === 'string') {
+        return {
+          [fiber.stateNode.getAttribute('v_ref')]: fiber.stateNode
+        }
+      }
+      else {
+        return {
+          [fiber.memoizedProps.v_ref]: fiber
+        }
+      }
+    }
+  ).reduce((pre, cur) => {
+    Object.assign(pre, cur)
+    return pre
+  }, {})
+}
+
+function getParentFiber(fiber, isFirst = true) {
+  if (typeof fiber.type !== 'string' && !isFirst) return fiber
+  return getParentFiber(fiber.return, false)
+}
+
+export function useFiber() {
+  const ref = useRef()
+  const [parent, setParent] = useState()
+  const [current, setCurrent] = useState()
+  useEffect(() => {
+    if (ref.current) {
+      const current_fiber = getFiberByDom(ref.current)
+      setParent(
+        getParentFiber(
+          current_fiber.return
+        )
+      )
+      setCurrent(current_fiber.return)
+    }
+  }, [])
+
+  return {
+    ref,
+    parent: {
+      fiber: parent,
+      refs: parent && collectRefs(parent.child),
+      children: parent && collectChildren(parent.child),
+    },
+    current: {
+      fiber: current,
+      refs: current && collectRefs(current.child),
+      children: current && collectChildren(current.child),
+    }
+  }
+}


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Some operations on the react feeder tree include:

-Obtain fiber nodes through dom

-Traversing a fiber tree based on boundaries

-Collect component children

-Collect component refs

Finally, based on these functions, they are integrated into fiber hook functions. This custom hook is responsible for calling react hooks to determine the execution timing of these fiber functions, and finally returns some information about the fiber.

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


# PR中文描述
## PR清单 
请检查您的 PR 是否满足以下要求：

- [x] 提交消息遵循我们的[提交消息指南](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] 添加了对更改的测试（用于错误修复/功能）
- [ ] 文档已添加/更新（用于错误修复/功能）

## pr类型
这个 PR 带来了什么样的改变？

- [ ] 错误修正
- [X] 特征
- [ ] 代码风格更新（格式、局部变量）
- [ ] 重构（无功能更改，无 api 更改）
- [ ] 构建相关变更
- [ ] CI 相关变更
- [ ] 文档内容变更
- [ ] 其他...请描述：

## 行为

对 react-fiber 树的一些操作，包括：
  - 通过 dom 获取 fiber 节点
  - 根据边界遍历 fiber 树
  - 收集组件 children
  - 收集组件 refs
  最后，根据这些功能整合为 fiber 钩子函数，该 custom-hook 负责调用 react-hooks 决定上面这些 fiber 功能的执行时机，最后返回fiber 的一些信息。

## 此 PR 是否引入了重大更改？

- [x] 是的
- [ ] 不



#### API

### - getFiberByDom

通过 dom 节点获取该 dom 在 fiber 上对应的节点

Obtain the corresponding node of the dom on the fiber through the dom node

```js
function App() {
  const ref = useRef();

  useEffect(() => {
    if(ref.current) {
      const curFiber = getFiberByDom(ref.current).return
    }
  }, [])

  return (<div ref={ref}></div>)
}
```

### - traverseFiber

通过一些条件，遍历 fiber 树，只会向 child 和 sibling 遍历

By passing some conditions, traversing the fiber tree will only traverse the

```js
traverseFiber(
  fiber: FiberNode,
  breaker: () => bool,
  handler: (fiber) => {}
)
```
  - fiber： 遍历的起点，一般从当前组件的根节点开始
  - breaker：中断遍历的函数，如果当前节点满足 breaker(fiber) === true，那么不会再向 child 遍历
  - handler：遍历到每一个 fiber 节点会触发该函数，参数是遍历到的 fiber 节点

比如：遍历当前组件，组件边界为组件
```js
traverseFiber(
  rootFiber,
  breaker: (fiber) => typeof fiber.type !== 'string',
  handler: (fiber) => { console.log(fiber) }
)
```

### - collectFiber

在 traverseFiber 的基础上实现的，收集当前组件满足条件的 fiber 节点

Implemented on the basis of traverseFiber, collecting fiber nodes that meet the current component's conditions

```js
collectFiber(
  fiber: FiberNode,
  collector: (fiber) => bool,
  mapper: (fiber) => any
) => Array<any>
```

  - fiber：组件的根节点
  - collector：收集器函数，满足 collector(fiber) === true 的 fiber 节点会被收集在结果数组上
  - mapper：[].map 的回调，最后如果存在会对结果数组做一层转化。

### - collectChildren

在 collectFiber 基础上实现的收集当前组件的孩子节点

Collection of child nodes for the current component based on collectFiber

```js
collectChildren(
  fiber: FiberNode
)
```

  - fiber：组件的根节点

### - collectRefs

在 collectFiber 基础上实现的收集当前组件被 v_ref 标记的节点，v_ref 既可以标记原生节点，也可以标记组件节点。

The collection of current components based on collectFiber is implemented by v_ Node marked with ref, v_ Ref can mark both native nodes and component nodes.

```js
collectRefs(
  fiber: FiberNode
)
```
  - fiber：组件的根节点

### - getParentFiber

从当前组件节点递归遍历获取父亲组件节点

Recursively traverse from the current component node to obtain the parent component node

```js
getParentFiber(
  fiber: FiberNode
)
```

  - fiber: 当前组件节点，一般是 rootFiber.return

### - useFiber

首次返回 

```js
{ref: {current: null}, parent: null, current: null}
```

useEffect(() => {}, []) 的时候 setParent 和 setCurrent，下次组件更新的时候，parent 和 current 出现值

```js
{
  ref: {current: rootDomNode}, 
  parent: {
    fiber: parentFiber,
    refs: parentRefs,
    childRen: parentChildren
  }, 
  current: {
    fiber: curFiber,
    refs: curRefs,
    childRen: curChildren  
  }
}
```

```js
const {ref, parent, children} = useFiber()

useEffect(() => {
  if(parent && children) {
    console.log(parent, children)
  } 
}, [parent, children])
```

