### PR TITLE
feat(react): Add a virtual machine like proxy for fiber component nodes

### DIFF
--- a/packages/react-common/src/vm.js
+++ b/packages/react-common/src/vm.js
@@ -1,0 +1,98 @@
+import { useFiber, getParentFiber, creatFiberCombine } from './fiber.js'
+import {
+  getEventByReactProps,
+  getAttrsByReactProps
+} from './resolve-props.js'
+import { Reactive } from './reactive.js'
+import { emit, on, off, once } from './event.js'
+
+const vmProxy = {
+  $parent: ({ fiber }) => createVmProxy(
+    creatFiberCombine(
+      getParentFiber(fiber)
+    )
+  ),
+  $el: ({ fiber }) => fiber.child?.stateNode,
+  $refs: ({ refs, fiber }) => createRefsProxy(refs, fiber.constructor),
+  $children: ({ children }) => children.map((fiber) => createVmProxy(
+    creatFiberCombine(
+      getParentFiber(fiber)
+    )
+  )),
+  $listeners: ({ fiber }) => getEventByReactProps(fiber.memoizedProps),
+  $attrs: ({ fiber }) => getAttrsByReactProps(fiber.memoizedProps),
+  $slots: ({ fiber }) => fiber.memoizedProps.slots,
+  $scopedSlots: ({ fiber }) => fiber.memoizedProps.slots,
+  $options: ({ fiber }) => ({ componentName: fiber.type.name }),
+  $constants: ({ fiber }) => fiber.memoizedProps._constants,
+  $template: ({ fiber }) => fiber.memoizedProps.tiny_template,
+  $renderless: ({ fiber }) => fiber.memoizedProps.tiny_renderless,
+  $mode: () => 'pc',
+  state: ({ fiber }) => findStateInHooks(fiber.memoizedState),
+  $type: ({ fiber }) => fiber.type,
+  $service: (_, vm) => vm.state?.$service,
+  $emit: ({ fiber }) => emit(fiber.memoizedProps),
+  $on: ({ fiber }) => on(fiber.memoizedProps),
+  $once: ({ fiber }) => once(fiber.memoizedProps),
+  $off: ({ fiber }) => off(fiber.memoizedProps),
+  $set: () => (target, propName, value) => target[propName] = value
+}
+
+const vmProxyMap = new WeakMap()
+function createVmProxy(fiberCombine) {
+  if (!vmProxyMap.has(fiberCombine)) {
+    vmProxyMap.set(fiberCombine, new Proxy(fiberCombine, {
+      get(
+        target,
+        property,
+        receiver
+      ) {
+        if (!vmProxy[property]) {
+          return target.fiber.memoizedProps[property]
+        }
+        return vmProxy[property](target, receiver)
+      }
+    }))
+  }
+  return vmProxyMap.get(fiberCombine)
+}
+
+function createRefsProxy(refs, FiberNode) {
+  return new Proxy(refs, {
+    get(
+      target,
+      property
+    ) {
+      if (target[property] instanceof FiberNode) {
+        return createVmProxy(
+          creatFiberCombine(target[property])
+        )
+      }
+      else {
+        return target[property]
+      }
+    }
+  })
+}
+
+function findStateInHooks(hookStart) {
+  let curHook = hookStart
+  // find state from hooks chain by Constructor Reactive
+  while (curHook) {
+    const refCurrent = curHook.memoizedState && curHook.memoizedState.current
+    if (refCurrent instanceof Reactive) break
+    curHook = curHook.next
+  }
+  return curHook
+    && curHook.memoizedState
+    && curHook.memoizedState.current
+}
+
+export function useVm() {
+  const { ref, current, parent } = useFiber()
+  return {
+    ref,
+    current: current.fiber && createVmProxy(current),
+    parent: parent.fiber && createVmProxy(parent)
+  }
+}


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Added proxy for fiber component nodes, simulating the VM and parent objects of Vue

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


# PR中文描述
## PR清单 
请检查您的 PR 是否满足以下要求：

- [x] 提交消息遵循我们的[提交消息指南](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] 添加了对更改的测试（用于错误修复/功能）
- [ ] 文档已添加/更新（用于错误修复/功能）

## pr类型
这个 PR 带来了什么样的改变？

- [ ] 错误修正
- [X] 特征
- [ ] 代码风格更新（格式、局部变量）
- [ ] 重构（无功能更改，无 api 更改）
- [ ] 构建相关变更
- [ ] CI 相关变更
- [ ] 文档内容变更
- [ ] 其他...请描述：

## 行为

添加了对 fiber 组件节点的代理，模拟了 vue 的 vm 对象和 parent 对象

## 此 PR 是否引入了重大更改？

- [x] 是的
- [ ] 不



#### API

### - vmProxy

vm 的代理对象，访问哪个属性就去调用 vm 身上的哪个方法

### - vmProxyMap

缓存重复访问 vm 代理对象，减少内存消耗

### - createVmProxy

通过 vmProxy 创建代理对象，

### - createRefsProxy

创建 refs 对象的代理，如果是原生 dom 直接返回，如果是 fiber 组件节点，就创建 vm 代理

### - findStateInHooks

在 组件 fiber 节点的 hooks 链表中去查找 useReactive 定义的状态对象

### - useVm

vm hooks 函数，通过调用 useFiber 得到 当前组件的 fiebr 节点和父亲节点，然后调用代理方法生成对 fiber 的 vm 代理对象。


```js
const {ref, current, parent} = useVm();
if(current) {
  console.log(current.$el)
  console.log(current.$refs[refName])
}
```

### - vmProxy

```js
const vmProxy = {
  $parent: 当前组件的父亲代理
  $el: 当前组件的根元素
  $refs: 当前组件被 ref 标记元素的列表
  $children: 当前组件的子组件
  $listeners: 当前组件的事件监听器
  $attrs: 当前组件的 attrs
  $slots: 当前组件的 插槽
  $scopedSlots: 当前组件的 
  $options: 当前组件配置对象
  $constants: 当前组件静态变量
  $template: 当前组件的侵入模版
  $renderless: 当前组件的侵入逻辑
  $mode: 当前组件的模式是 pc、mobile 还是 mf
  state: 当前组件通过 useReactive 首次定义的状态
  $type: 当前组件的函数
  $service: 状态里定义的请求方法
  $emit: 事件触发函数，触发定义在当前组件的事件
  $on: 事件绑定函数，给当前组件绑定事件
  $once: 一次性事件绑定
  $off: 移除事件
  $set: 编程式动态添加或修改状态
}
```