### PR TITLE
feat(react): simulate Vue Composite API

### DIFF
--- a/packages/react-common/src/vue-hooks.js
+++ b/packages/react-common/src/vue-hooks.js
@@ -1,0 +1,118 @@
+import { useRef } from 'react'
+import { useReload } from './reactive'
+
+function Create(target) {
+  Object.keys(target).forEach(key => {
+    this[key] = target[key]
+  })
+}
+function Readonly(target) {
+  Create.call(this, target)
+}
+
+const useDepChange = (dependencies) => {
+  let isDepChange = false
+  const pre_dep = useRef()
+  if (!pre_dep.current) {
+    isDepChange = true
+  }
+  else {
+    for (let i in dependencies) {
+      if (pre_dep.current[i] !== dependencies[i]) {
+        isDepChange = true
+        break
+      }
+    }
+  }
+  pre_dep.current = dependencies
+  return isDepChange
+}
+
+export const nextTick = (callback) => {
+  queueMicrotask(callback)
+}
+
+export const ref = (value) => {
+  const reload = useReload()
+  const proxy = useRef()
+  if (!proxy.current) {
+    proxy.current = new Proxy({
+      value
+    }, {
+      get(target, property) {
+        if (property !== 'value') return
+        return target[property]
+      },
+      set(target, property, newVal) {
+        if (property !== 'value') return true
+        target[property] = newVal
+        reload()
+        return true
+      }
+    })
+  }
+  return proxy.current
+}
+
+export const computed = (getter, dependencies) => {
+  if (typeof getter !== 'function') return
+  const memoried = useRef()
+  const isDepChange = useDepChange(dependencies)
+  if (isDepChange) {
+    memoried.current = getter()
+  }
+  return memoried.current
+}
+
+export const readonly = (target) => {
+  const proxy = useRef()
+  if (!proxy.current) {
+    proxy.current = new Proxy(new Readonly(target), {
+      get: (target, property) => target[property],
+      set: () => true
+    })
+  }
+  return proxy.current
+}
+
+export const watchEffect = (effect, dependencies, options) => {
+  const cache = useRef()
+  const isDepChange = useDepChange(dependencies)
+  if (!cache.current) cache.current = { effect: true }
+  const { flush } = options || { flust: 'pre' }
+  const onCleanUp = (callback) => cache.current.clean = callback
+  if (cache.current.effect && isDepChange) {
+    const clean = cache.current.clean
+    typeof clean === 'function' && clean()
+    if (flush === 'pre') {
+      effect(onCleanUp)
+    }
+    else if (flush === 'sync') {
+      effect(onCleanUp)
+    }
+    else {
+      nextTick(() => {
+        effect(onCleanUp)
+      })
+    }
+  }
+  return () => cache.current.effect = false
+}
+
+export const watchPostEffect = (effect, dependencies) => watchEffect(effect, dependencies, { flush: 'post' })
+
+export const watch = (source, callback) => {
+  const cache = useRef()
+  let source_value
+  if (Array.isArray(source)) {
+    source_value = source.map((item) => typeof item === 'function' && item())
+  }
+  else {
+    source_value = [(typeof source === 'function' && source())]
+  }
+  const isDepChange = useDepChange(source_value)
+  if (!cache.current) cache.current = { clear: false }
+  if (isDepChange && cache.current.clear) callback(source_value, cache.current.pre)
+  cache.current.pre = source_value
+  return () => cache.current.clear = true
+}


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Composite API functions for simulating Vue

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


# PR中文描述
## PR清单 
请检查您的 PR 是否满足以下要求：

- [x] 提交消息遵循我们的[提交消息指南](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] 添加了对更改的测试（用于错误修复/功能）
- [ ] 文档已添加/更新（用于错误修复/功能）

## pr类型
这个 PR 带来了什么样的改变？

- [ ] 错误修正
- [X] 特征
- [ ] 代码风格更新（格式、局部变量）
- [ ] 重构（无功能更改，无 api 更改）
- [ ] 构建相关变更
- [ ] CI 相关变更
- [ ] 文档内容变更
- [ ] 其他...请描述：

## 行为

模拟 vue 的 组合式 api 函数

## 此 PR 是否引入了重大更改？

- [x] 是的
- [ ] 不



#### API

### - const nextTick = (callback)

和 vue 的用法一致

Consistent with the usage of Vue

### - const ref = (value)

和 vue 一致，但是在模版中需要 .value 使用，也需要 .value 去修改值，.value 的修改会触发组件更新

Same as Vue, but in the template,. value is required to be used, and. value is also required to modify the value. Modifying. value will trigger component updates

### - const computed = (getter, dependencies)

计算函数，和 vue 不同的是，vue 可以自动收集依赖，react 需要手动。
所以第二个参数传入依赖，如果不穿，每次刷新都会计算。类似于 useMemo

### - const readonly = (target)

返回一个对象的只读代理，该代理忽视所有修改。

### - const watchEffect = (effect, dependencies, options)

和 vue 不同的是依赖需要手动传入，没有 flush: 'sync' 模式，默认每次组件函数刷新并依赖改变时执行 effect，flush: 'post' 模式的话，会在组件渲染后执行 effect。

### - const watchPostEffect = (effect, dependencies)

watchEffect 的 flust: 'post' 模式

### - const watch = (source, callback)

数据源 source 变化，触发 callback，source 可以是 getter 函数，或者 getter 数组。