### PR TITLE
fix(theme): Fix the abnormal background color of the official website component title

### DIFF
--- a/examples/sites/src/tools/storage.js
+++ b/examples/sites/src/tools/storage.js
@@ -63,7 +63,7 @@ const useAutoStore = (type, key, defaultValue) => {
     typeMatcher[type][key] = curr
   })
 
-  if (refVar.value === null) refVar.value = defaultValue
+  if (typeof refVar.value === 'undefined' || refVar.value === null) refVar.value = defaultValue
   return refVar
 }
 

--- a/examples/sites/src/tools/storage.js
+++ b/examples/sites/src/tools/storage.js
@@ -63,7 +63,8 @@ const useAutoStore = (type, key, defaultValue) => {
     typeMatcher[type][key] = curr
   })
 
-  if (typeof refVar.value === 'undefined' || refVar.value === null) refVar.value = defaultValue
+  refVar.value = refVar.value ?? defaultValue
+  
   return refVar
 }
 

--- a/examples/sites/src/tools/storage.js
+++ b/examples/sites/src/tools/storage.js
@@ -62,7 +62,8 @@ const useAutoStore = (type, key, defaultValue) => {
   watch(refVar, (curr, prev) => {
     typeMatcher[type][key] = curr
   })
-  if (typeof refVar.value === 'undefined') refVar.value = defaultValue
+
+  if (refVar.value === null) refVar.value = defaultValue
   return refVar
 }
 


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

在查看官网时发现官网在 mac 深色主题下，组件文档标题的背景显示异常。

<img width="1439" alt="image" src="https://github.com/opentiny/tiny-vue/assets/52314078/c0ca81b1-8475-41df-b9e1-23ad9ceb9769">

测试发现好像是因为 appData.theme 未正确设置初始值导致。

因为 `localStorage.getItem` 获取不到值会返回 `null`


<img width="306" alt="image" src="https://github.com/opentiny/tiny-vue/assets/52314078/21f90c52-92ea-40dc-9e1a-3ef8c2b2efe7">

修改后展示正常

<img width="969" alt="image" src="https://github.com/opentiny/tiny-vue/assets/52314078/6a78e8e6-04b2-4fda-9060-033866266f3d">

但我还是好奇主题变量为什么会自动改变，因为我没有找到哪里有监听系统的主题变化。













