### PR TITLE
fix: fix extra highlight color when press button in mobile mode

### DIFF
--- a/packages/theme-mobile/src/button/index.less
+++ b/packages/theme-mobile/src/button/index.less
@@ -14,6 +14,10 @@
 @import '../custom.less';
 @import './vars.less';
 
+:root {
+  -webkit-tap-highlight-color: transparent;
+}
+
 @button-prefix-cls: ~'@{css-prefix}mobile-button';
 @svg-prefix-cls: ~'@{css-prefix}svg';
 


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #505 

## What is the new behavior?

Clicking should not result in a light blue highlight color on mobile.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

None