### PR TITLE
docs(guide): fix alert out of bounds

### DIFF
--- a/examples/sites/demos/app/guide/arror-position.vue
+++ b/examples/sites/demos/app/guide/arror-position.vue
@@ -1,15 +1,7 @@
 <template>
   <div>
-    <div class="guide-content">
-      <tiny-alert
-        class="pos"
-        :closable="false"
-        type="success"
-        size="large"
-        description="提交结果页用于反馈一系列操作任务的处理结果。"
-      >
-      </tiny-alert>
-    </div>
+    <tiny-alert class="pos" :closable="false" type="success" size="large" description="提交结果页用于反馈一系列操作任务的处理结果。">
+    </tiny-alert>
     <div class="guide-title">
       <tiny-button plain @click="stepStart1">默认</tiny-button>
       <tiny-button plain @click="stepStart2">上居中</tiny-button>
@@ -115,9 +107,5 @@ export default {
   display: flex;
   justify-content: space-around;
   margin-top: 20px;
-  width: 600px;
-}
-.guide-content {
-  width: 600px;
 }
 </style>

--- a/examples/sites/demos/app/guide/dom-hight-composition-api.vue
+++ b/examples/sites/demos/app/guide/dom-hight-composition-api.vue
@@ -8,12 +8,7 @@
         <tiny-button plain class="hight3">新手引导3</tiny-button>
         <tiny-alert class="hight4" :closable="false" description="type 为默认值 info"></tiny-alert>
         <div class="hight11 tiny-hight-content-item">
-          <tiny-alert
-            type="success"
-            size="large"
-            :closable="false"
-            description="提交结果页用于反馈一系列操作任务的处理结果。"
-          >
+          <tiny-alert type="success" size="large" :closable="false" description="提交结果页用于反馈一系列操作任务的处理结果。">
             <tiny-button size="mini" type="primary">继续提交</tiny-button>
             <tiny-button size="mini">取消操作</tiny-button>
           </tiny-alert>
@@ -76,11 +71,12 @@ function stepStart() {
 <style scoped>
 .tiny-hight-content {
   height: 500px;
-  widows: 500px;
 }
+
 .tiny-hight-content-item {
   margin-top: 200px;
 }
+
 .hight4 {
   width: auto;
   height: 36px;

--- a/examples/sites/demos/app/guide/dom-hight.vue
+++ b/examples/sites/demos/app/guide/dom-hight.vue
@@ -8,12 +8,7 @@
         <tiny-button plain class="hight3">新手引导3</tiny-button>
         <tiny-alert class="hight4" :closable="false" description="type 为默认值 info"></tiny-alert>
         <div class="hight11 tiny-hight-content-item">
-          <tiny-alert
-            type="success"
-            size="large"
-            :closable="false"
-            description="提交结果页用于反馈一系列操作任务的处理结果。"
-          >
+          <tiny-alert type="success" size="large" :closable="false" description="提交结果页用于反馈一系列操作任务的处理结果。">
             <tiny-button size="mini" type="primary">继续提交</tiny-button>
             <tiny-button size="mini">取消操作</tiny-button>
           </tiny-alert>
@@ -87,11 +82,12 @@ export default {
 <style scoped>
 .tiny-hight-content {
   height: 500px;
-  widows: 500px;
 }
+
 .tiny-hight-content-item {
   margin-top: 200px;
 }
+
 .hight4 {
   width: auto;
   height: 36px;


### PR DESCRIPTION
# PR
### 问题：
官网示例“引导框箭头距离”中的alert超出demo框范围
https://opentiny.design/tiny-vue/zh-CN/os-theme/components/guide#arror-position
![image](https://github.com/opentiny/tiny-vue/assets/103343025/ad3ab53d-0df1-4502-9749-3f4cb605cb81)
### 修复结果：
![image](https://github.com/opentiny/tiny-vue/assets/103343025/5cdc3172-958e-4a5c-b3d5-9649b8edd56f)
同时去掉剩下几个demo里alert组件的无用样式

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
