### PR TITLE
ci(test-e2e):  add github actions for E2E Testing

### DIFF
--- a/.github/workflows/test-e2e-all.yml
+++ b/.github/workflows/test-e2e-all.yml
@@ -1,0 +1,89 @@
+name: E2E Test ALL
+run-name: E2E Test All
+on:
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch-test-all:
+    name: Dispatch All Test
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1/8, 2/8, 3/8, 4/8, 5/8, 6/8, 7/8, 8/8]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: |
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - name: Install dependencies
+        run: pnpm i --no-frozen-lockfile
+
+      - name: dev start
+        run: pnpm dev & sleep 5
+      - name: update playwright
+        run: pnpm recursive update @playwright/test
+      - name: Install Playwright browsers
+        run: pnpm install:browser --with-deps chromium
+      - name: Run Playwright tests
+        run: pnpm test:e2e3 --shard=${{ matrix.shard }} --reporter=blob
+
+      - name: Upload blob report to GitHub Actions Artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: all-blob-reports
+          path: examples/vue3/blob-report
+          retention-days: 0.5
+
+  dispatch-test-all-merge-reports:
+    name: 'Merge Reports After Dispatch All Test'
+    # Merge reports after playwright-tests, even if some shards have failed
+    if: always()
+    needs: [dispatch-test-all]
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: |
+          npm install -g @playwright/test
+
+      - name: Download blob reports from GitHub Actions Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: all-blob-reports
+          path: all-blob-reports
+
+      - name: Merge into HTML Report
+        run: playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v3
+        with:
+          name: html-report--attempt-${{ github.run_attempt }}
+          path: playwright-report
+          retention-days: 7

--- a/.github/workflows/test-e2e-dispatch.yml
+++ b/.github/workflows/test-e2e-dispatch.yml
@@ -1,0 +1,55 @@
+name: E2E Test Dispatch
+run-name: E2E Test Dispatch--${{ inputs.testDemos }}--
+on:
+  workflow_dispatch:
+    inputs:
+      testDemos:
+        description: |
+          Name of directory from "examples/sites/demos/pc/app",
+          such as `input, alert`.
+        required: true
+        type: string
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: true
+jobs:
+  dispatch-tests:
+    name: Dispatch Tests
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: |
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - name: Install dependencies
+        run: pnpm i --no-frozen-lockfile
+
+      - name: dev start
+        run: pnpm dev & sleep 5
+
+      - name: Install Playwright browsers
+        run: pnpm install:browser --with-deps chromium
+
+      - name: Run Playwright tests
+        run: |
+          testDemos="${{ inputs.testDemos }}"
+          components=${testDemos//,/' '}
+          pnpm test:e2e3 $components --reporter=line

--- a/.github/workflows/test-e2e-pr.yml
+++ b/.github/workflows/test-e2e-pr.yml
@@ -1,0 +1,69 @@
+name: E2E Test PR
+run-name: E2E Test PR--${{ github.event.pull_request.title }}
+on:
+  pull_request:
+    branches: [dev, release, main]
+    types: [opened, reopened, synchronize, edited]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  pr-test:
+    name: PR E2E Test
+    runs-on: ubuntu-latest
+    env:
+      TEST_COMPONENTS: ''
+    steps:
+      - name: Parse Title
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const prTitle = '${{ github.event.pull_request.title }}'
+            const regex = /\[(.*?)\]/
+            const matches = prTitle.match(regex)
+            if (matches && matches.length > 1 && matches[1]) {
+              let components = matches[1].split(',').map(c => `${c.trim()}/`).filter(c => c)
+              components = [...new Set(components)].slice(0, 3).join(' ')
+              core.exportVariable('TEST_COMPONENTS', components)
+            } else {
+              core.setFailed('Missing components to be tested. Title must be like "fix(components): [input, alert] fix xxx bug", component name comes from "examples/sites/demos/pc/app". Please read our contributing guide')
+            }
+      - uses: actions/checkout@v3
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Cache Playwright Installation
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: |
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm i --no-frozen-lockfile
+
+      - name: dev start
+        run: pnpm dev & sleep 5
+
+      - name: Install Playwright browsers
+        run: pnpm install:browser --with-deps chromium
+
+      - name: E2E Test
+        run: pnpm test:e2e3 ${{ env.TEST_COMPONENTS }} --reporter=line


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
###  Add 3 GitHub actions
![图片](https://github.com/opentiny/tiny-vue/assets/104079404/5bbaab13-24c7-4dc7-82ac-c42a2db920fc)

### E2E Test ALL 
All E2E tests will be run and relevant Playwright reports will be available after the run.
![图片](https://github.com/opentiny/tiny-vue/assets/104079404/8ab5b069-d00b-402a-848a-4a235e1cb726)
![图片](https://github.com/opentiny/tiny-vue/assets/104079404/e57fa776-4a25-47db-97d6-b46695276e02)

### E2E Test Dispatch
We can select which test cases to run.
![图片](https://github.com/opentiny/tiny-vue/assets/104079404/4797b40d-02c0-45d2-a9fc-bb23b066cc68)

### E2E Test PR 
E2E test will be pulled up when PR is submitted.
![图片](https://github.com/opentiny/tiny-vue/assets/104079404/ecaaa114-48f5-41d0-bc82-61be9ef206e4)
The github action will read the title's component information, such as the following test case that will test inputs:
![图片](https://github.com/opentiny/tiny-vue/assets/104079404/3f6c48d3-8c66-4607-93d5-c9a7950513bc)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
