### PR TITLE
feat(components):[tree-menu]The placeholder of the search box can be customized

### DIFF
--- a/examples/sites/demos/pc/app/tree-menu/webdoc/tree-menu.js
+++ b/examples/sites/demos/pc/app/tree-menu/webdoc/tree-menu.js
@@ -273,6 +273,16 @@ export default {
           'demoId': 'accordion'
         },
         {
+          'name': 'placeholder',
+          'type': 'string',
+          'defaultValue': '请输入内容进行筛选',
+          'desc': {
+            'zh-CN': '自定义搜索框placeholder',
+            'en-US': 'Custom search box placeholder.'
+          },
+          'demoId': ''
+        },
+        {
           'name': 'allow-drag',
           'type': 'Function(params)',
           'defaultValue': '',

--- a/packages/vue/src/tree-menu/src/pc.vue
+++ b/packages/vue/src/tree-menu/src/pc.vue
@@ -18,7 +18,7 @@
     <tiny-input
       v-if="showFilter"
       v-model="state.filterText"
-      :placeholder="t('ui.treeMenu.placeholder')"
+      :placeholder="placeholder || t('ui.treeMenu.placeholder')"
       :prefix-icon="searchIcon"
     />
     <tiny-tree
@@ -97,6 +97,10 @@ export default defineComponent({
     IconArrow: iconLeftWardArrow()
   },
   props: {
+    placeholder: {
+      default: '',
+      type: String
+    },
     data: Array,
     nodeKey: String,
     defaultExpandAll: Boolean,


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [√] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [√] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The search box placeholder for tree-menu can only use default values and cannot be customized

Issue Number: #589

## What is the new behavior?

 The search box placeholder of the tree-menu component can be customized

## Does this PR introduce a breaking change?

- [ ] Yes
- [√] No


## Other information
