### PR TITLE
feat: prompt the contributor to contributing guide when the e2e test …

### DIFF
--- a/.github/workflows/test-e2e-pr.yml
+++ b/.github/workflows/test-e2e-pr.yml
@@ -10,13 +10,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pr-test:
-    name: PR E2E Test
+  parse-components:
+    name: Parse Affected Components
     runs-on: ubuntu-latest
-    env:
-      TEST_COMPONENTS: ''
+    outputs:
+      testComponents: ${{ steps.parseTitle.outputs.testComponents }}
     steps:
       - name: Parse Title
+        id: parseTitle
         uses: actions/github-script@v6
         with:
           script: |
@@ -26,10 +27,26 @@ jobs:
             if (matches && matches.length > 1 && matches[1]) {
               let components = matches[1].split(',').map(c => `${c.trim()}/`).filter(c => c)
               components = [...new Set(components)].slice(0, 3).join(' ')
-              core.exportVariable('TEST_COMPONENTS', components)
+              core.exportVariable('testComponents', components)
             } else {
-              core.setFailed('Missing components to be tested. Title must be like "fix(components): [input, alert] fix xxx bug", component name comes from "examples/sites/demos/pc/app". Please read our contributing guide')
+              const warningString =`
+              **[warning]** The component to be tested is missing. (This warning is from ${{ github.workflow }})
+
+              The title of the Pull request should look like "fix(vue-renderless): [action-menu, alert] fix xxx bug".
+              
+              Please make sure you've read our [contributing guide](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
+              `
+              core.warning(warningString)
+              github.rest.issues.createComment({ issue_number: context.issue.number, owner: context.repo.owner, repo: context.repo.repo, body: warningString })
             }
+  pr-test:
+    if: ${{ needs.parse-components.outputs.testComponents }}
+    name: PR E2E Test
+    needs: parse-components
+    runs-on: ubuntu-latest
+    env:
+      TEST_COMPONENTS: ${{ needs.parse-components.outputs.testComponents }}
+    steps:
       - uses: actions/checkout@v3
       - name: Setup pnpm
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
The e2e test will fail when the component is not declared in the title of the PR.

没有在PR的标题中声明组件时，e2e测试将会失败。

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
The e2e test will be skipped when no component is declared in the title of the PR.
Each time the e2e test pipeline skips, a warning from the bot will be added under the PR.

没有在PR的标题中声明组件时，e2e测试将会跳过。
每次e2e测试流水线跳过时，会在PR下添加来自机器人的警告。

![图片](https://github.com/opentiny/tiny-vue/assets/104079404/95f0f7f4-eff4-4c64-b97f-0fefbe2a12d6)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
