### PR TITLE
feat(react): add render stack to build parent-child relationship

### DIFF
--- a/packages/react-common/src/index.ts
+++ b/packages/react-common/src/index.ts
@@ -55,7 +55,7 @@ export const useSetup = ({
   // renderless 作为 setup 的结果，最后要将结果挂在 vm 上
   let setupResult = useExcuteOnce(() => {
     const render = typeof reactiveProps.tiny_renderless === 'function' ? reactiveProps.tiny_renderless : renderless
-    const { dispath, broadcast } = emitEvent(vm)
+    const { dispatch, broadcast } = emitEvent(vm)
 
     const utils = {
       vm,
@@ -63,7 +63,7 @@ export const useSetup = ({
       emit: emit(reactiveProps),
       constants,
       nextTick,
-      dispath,
+      dispatch,
       broadcast,
       t() { },
       mergeClass,

--- a/packages/react-common/src/render-stack.ts
+++ b/packages/react-common/src/render-stack.ts
@@ -1,0 +1,7 @@
+const renderStack = []
+
+export const getParent = () => renderStack[renderStack.length - 1]
+
+export const EnterStack = (props) => renderStack.push(props)
+
+export const LeaveStack = () => renderStack.pop()

--- a/packages/react-common/src/render-stack.ts
+++ b/packages/react-common/src/render-stack.ts
@@ -1,7 +1,15 @@
 const renderStack = []
 
-export const getParent = () => renderStack[renderStack.length - 1]
+export const getParent = () => renderStack[renderStack.length - 1] || ({})
 
-export const EnterStack = (props) => renderStack.push(props)
+export const getRoot = () => renderStack[0] || ({})
 
-export const LeaveStack = () => renderStack.pop()
+export const EnterStack = (props) => {
+  renderStack.push(props)
+  return ''
+}
+
+export const LeaveStack = () => {
+  renderStack.pop()
+  return ''
+}


### PR DESCRIPTION
# PR

add render stack to build parent-child relationship

we can know who is parent brefore render by this way:

``` js
const renderStack = []

export const getParent = () => renderStack[renderStack.length - 1]

export const EnterStack = (props) => renderStack.push(props)

export const LeaveStack = () => renderStack.pop()
```

```jsx
function Child() {
 const parent = getParent() // { vm: {} }
 return ''
}

function Parent() {
 const vm = {}
 return (<>
  <EnterStack vm={vm} />
  <Child />
  <LeaveStack/>
</>)
}
```

这段代码是为了在渲染过程中建立父子关系，并且在渲染过程中知道当前组件的父组件。它使用了一个名为renderStack的数组来存储渲染过程中的组件信息。

getParent函数用于获取当前组件的父组件。它通过返回renderStack数组的最后一个元素来实现，即renderStack[renderStack.length - 1]。

EnterStack函数用于将当前组件的信息添加到renderStack数组中。它接受一个参数props，并将其推入renderStack数组。

LeaveStack函数用于在组件渲染完成后将其信息从renderStack数组中移除。它使用pop()方法将数组的最后一个元素弹出。

在示例代码中，Parent组件中创建了一个名为vm的对象，并通过EnterStack函数将其添加到renderStack数组中。然后，在Parent组件的子组件Child中，可以通过调用getParent()函数获取到Parent组件的信息，即{ vm: {} }。