### PR TITLE
fix(grid-column): [grid-column] Console warning when grid data is empty but default slot reading deep level field

### DIFF
--- a/packages/vue/src/grid/src/column/src/column.ts
+++ b/packages/vue/src/grid/src/column/src/column.ts
@@ -164,6 +164,11 @@ export default defineComponent({
   },
   render() {
     const { slots, firstRow, columnConfig } = this
+
+    if (!firstRow || Object.keys(firstRow).length == 0) {
+      return h("div")
+    }
+    
     let slotVnode
 
     try {


### PR DESCRIPTION
fix(#1279)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 1279

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
