### PR TITLE
fix(timeline): [time-line] fix console error about `event click undefined`

### DIFF
--- a/packages/vue/src/time-line/src/pc.vue
+++ b/packages/vue/src/time-line/src/pc.vue
@@ -25,17 +25,17 @@
           <template #active-node-desc="slotScoped">
             <slot name="active-node-desc" :node="slotScoped.node"></slot>
           </template>
-          <template #top="node">
-            <slot name="top" :slot-scope="node.slotScope"></slot>
+          <template #top="slotNode">
+            <slot name="top" :slot-scope="slotNode.slotScope"></slot>
           </template>
-          <template #bottom="node">
-            <slot name="bottom" :slot-scope="node.slotScope"></slot>
+          <template #bottom="slotNode">
+            <slot name="bottom" :slot-scope="slotNode.slotScope"></slot>
           </template>
-          <template #left="node">
-            <slot name="left" :slot-scope="node.slotScope"></slot>
+          <template #left="slotNode">
+            <slot name="left" :slot-scope="slotNode.slotScope"></slot>
           </template>
-          <template #right="node">
-            <slot name="right" :slot-scope="node.slotScope"></slot>
+          <template #right="slotNode">
+            <slot name="right" :slot-scope="slotNode.slotScope"></slot>
           </template>
         </tiny-timeline-item>
       </slot>
@@ -47,7 +47,6 @@
 <script lang="ts">
 import { renderless, api } from '@opentiny/vue-renderless/time-line/vue'
 import { props, setup, defineComponent } from '@opentiny/vue-common'
-import { iconYes, iconClose } from '@opentiny/vue-icon'
 import '@opentiny/vue-theme/steps/index.less'
 import TimelineItem from '@opentiny/vue-timeline-item'
 import type { ITimelineApi } from '@opentiny/vue-renderless/types/time-line.type'
@@ -75,8 +74,6 @@ export default defineComponent({
     'shape'
   ],
   components: {
-    IconYes: iconYes(),
-    IconClose: iconClose(),
     TinyTimelineItem: TimelineItem
   },
   setup(props, context) {

--- a/packages/vue/src/time-line/src/pc.vue
+++ b/packages/vue/src/time-line/src/pc.vue
@@ -11,7 +11,7 @@
  -->
 <template>
   <div :class="['tiny-steps', { 'is-horizontal': horizontal && !vertical, 'tiny-steps--mini': size === 'mini' }]">
-    <div :class="state.computedWrapperClass" @click="contentClick">
+    <div :class="state.computedWrapperClass">
       <slot>
         <tiny-timeline-item
           v-for="(node, index) in state.nodes"


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

using the Timeline component will cause Vue@2.6.14 runtime error

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1197 

## What is the new behavior?

The Timeline component could work seamlessly on both Vue 2 and Vue 3.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The main issue is that the `contentClick` function is referenced in the `pc.vue` template without being defined there.

Vue 3, however, addresses this by transforming the code to `onClick: _cache[0] || (_cache[0] = (...args) => _ctx.contentClick && _ctx.contentClick(...args))`, ensuring the runtime executes successfully. In this setup, if `_ctx.contentClick` is undefined, it simply runs an empty function once.

On the other hand, Vue 2 translates it to `on: {"click": _vm.contentClick"}`, so if `_vm.contentClick` is undefined, an error occurs.
