### PR TITLE
fix(dropdown): [dropdown] Fix the issue of dropdown component causing warning messages in the console: Component emitted event "is-disabled" but it is neither declared in the emits option

### DIFF
--- a/packages/vue/src/dropdown/src/pc.vue
+++ b/packages/vue/src/dropdown/src/pc.vue
@@ -91,7 +91,7 @@ export default defineComponent({
     },
     suffixIcon: Object
   },
-  emits: ['visible-change', 'item-click', 'button-click', 'menu-item-click', 'handle-click'],
+  emits: ['visible-change', 'item-click', 'button-click', 'menu-item-click', 'is-disabled', 'handle-click'],
   setup(props, context) {
     return setup({ props, context, renderless, api, h })
   },


### PR DESCRIPTION
修复控制台警告，chunk-V4VCV3RI.js?v=ca970103:1670 [Vue warn]: Component emitted event "is-disabled" but it is neither declared in the emits option nor as an "onIs-disabled" prop.

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
