### PR TITLE
fix(modal): User feedback: When the Modal is closed after a user switches to another page, the close event is triggered by mistake.

### DIFF
--- a/examples/sites/demos/apis/modal.js
+++ b/examples/sites/demos/apis/modal.js
@@ -529,7 +529,7 @@ export default {
             'en-US': 'This event is triggered when the window is closed'
           },
           mode: ['pc', 'mobile', 'mobile-first'],
-          pcDemo: 'hide-event',
+          pcDemo: 'event',
           mobileDemo: 'hide-event',
           mfDemo: ''
         },

--- a/packages/vue/src/modal/index.ts
+++ b/packages/vue/src/modal/index.ts
@@ -37,7 +37,10 @@ export function Modal(options) {
           if ($modal.beforeUnmouted) {
             $modal.beforeUnmouted()
           }
-          resolve(params.type)
+          // 不关闭弹窗，直接切换路由，导致错误触发close事件
+          if (params.type !== 'close') {
+            resolve(params.type)
+          }
         },
         confirm(params) {
           events.confirm && events.confirm.call(this, params)


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
