### PR TITLE
feat(components): [drawer] enable open event

### DIFF
--- a/examples/sites/demos/apis/drawer.js
+++ b/examples/sites/demos/apis/drawer.js
@@ -181,6 +181,18 @@ export default {
       ],
       events: [
         {
+          name: 'open',
+          type: '()=> void',
+          defaultValue: '',
+          desc: {
+            'zh-CN': '打开抽屉事件',
+            'en-US': ''
+          },
+          mode: ['pc', 'mobile-first'],
+          pcDemo: 'open-event',
+          mfDemo: ''
+        },
+        {
           name: 'close',
           type: '()=> void',
           defaultValue: '',

--- a/examples/sites/demos/apis/drawer.js
+++ b/examples/sites/demos/apis/drawer.js
@@ -182,7 +182,7 @@ export default {
       events: [
         {
           name: 'open',
-          type: '()=> void',
+          type: '() => void',
           defaultValue: '',
           desc: {
             'zh-CN': '打开抽屉事件',
@@ -194,7 +194,7 @@ export default {
         },
         {
           name: 'close',
-          type: '()=> void',
+          type: '() => void',
           defaultValue: '',
           desc: {
             'zh-CN': '关闭抽屉事件',
@@ -206,7 +206,7 @@ export default {
         },
         {
           name: 'confirm',
-          type: '()=> void',
+          type: '() => void',
           defaultValue: '',
           desc: {
             'zh-CN': '确认事件，设置 :show-footer="true" 时有效',

--- a/examples/sites/demos/pc/app/drawer/open-event-composition-api.vue
+++ b/examples/sites/demos/pc/app/drawer/open-event-composition-api.vue
@@ -1,0 +1,27 @@
+<template>
+  <div>
+    <tiny-button @click="fn" type="primary"> 打开事件示例 </tiny-button>
+    <tiny-drawer title="标题" :show-footer="true" :visible="visible" @update:visible="visible = $event" @open="open">
+      <div style="height: 200px; text-align: center">
+        <br />
+        <br />
+        <span>内容区域</span>
+      </div>
+    </tiny-drawer>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { Drawer as TinyDrawer, Button as TinyButton, Modal } from '@opentiny/vue'
+
+const visible = ref(false)
+
+function fn() {
+  visible.value = true
+}
+
+function open() {
+  Modal.message('打开事件')
+}
+</script>

--- a/examples/sites/demos/pc/app/drawer/open-event.spec.ts
+++ b/examples/sites/demos/pc/app/drawer/open-event.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test'
+
+test('打开事件', async ({ page }) => {
+  page.on('pageerror', (exception) => expect(exception).toBeNull())
+  await page.goto('drawer#open-event')
+
+  const message = page.locator('.tiny-modal.type__message').filter({ hasText: '打开事件' }).first()
+
+  await page.getByRole('button', { name: '打开事件示例' }).click()
+  await expect(message).toBeVisible()
+})

--- a/examples/sites/demos/pc/app/drawer/open-event.vue
+++ b/examples/sites/demos/pc/app/drawer/open-event.vue
@@ -1,0 +1,36 @@
+<template>
+  <div>
+    <tiny-button @click="fn" type="primary"> 打开事件示例 </tiny-button>
+    <tiny-drawer title="标题" :show-footer="true" :visible="visible" @update:visible="visible = $event" @open="open">
+      <div style="height: 200px; text-align: center">
+        <br />
+        <br />
+        <span>内容区域</span>
+      </div>
+    </tiny-drawer>
+  </div>
+</template>
+
+<script>
+import { Drawer, Button, Modal } from '@opentiny/vue'
+
+export default {
+  components: {
+    TinyDrawer: Drawer,
+    TinyButton: Button
+  },
+  data() {
+    return {
+      visible: false
+    }
+  },
+  methods: {
+    fn() {
+      this.visible = true
+    },
+    open() {
+      Modal.message('打开事件')
+    }
+  }
+}
+</script>

--- a/examples/sites/demos/pc/app/drawer/webdoc/drawer.js
+++ b/examples/sites/demos/pc/app/drawer/webdoc/drawer.js
@@ -186,6 +186,18 @@ export default {
       codeFiles: ['footer-slot.vue']
     },
     {
+      demoId: 'open-event',
+      name: {
+        'zh-CN': '打开事件',
+        'en-US': ''
+      },
+      desc: {
+        'zh-CN': '<p>打开抽屉事件。</p>',
+        'en-US': ''
+      },
+      codeFiles: ['open-event.vue']
+    },
+    {
       demoId: 'close-event',
       name: {
         'zh-CN': '关闭事件',

--- a/packages/renderless/src/drawer/index.ts
+++ b/packages/renderless/src/drawer/index.ts
@@ -36,6 +36,7 @@ export const watchToggle =
   (bool: boolean) => {
     setTimeout(() => {
       emit('update:visible', bool)
+      bool && emit('open')
     }, 0)
   }
 

--- a/packages/renderless/src/drawer/vue.ts
+++ b/packages/renderless/src/drawer/vue.ts
@@ -23,7 +23,7 @@ import type {
   IDrawerCT
 } from '@/types'
 
-export const api = ['state', 'close', 'confirm', 'handleClose']
+export const api = ['state', 'open', 'close', 'confirm', 'handleClose']
 
 export const renderless = (
   props: IDrawerProps,

--- a/packages/renderless/src/drawer/vue.ts
+++ b/packages/renderless/src/drawer/vue.ts
@@ -23,7 +23,7 @@ import type {
   IDrawerCT
 } from '@/types'
 
-export const api = ['state', 'open', 'close', 'confirm', 'handleClose']
+export const api = ['state', 'close', 'confirm', 'handleClose']
 
 export const renderless = (
   props: IDrawerProps,

--- a/packages/vue/src/drawer/src/pc.vue
+++ b/packages/vue/src/drawer/src/pc.vue
@@ -130,6 +130,7 @@ export default {
     'beforeClose',
     'tipsProps'
   ],
+  emits: ['update:visible', 'open', 'close', 'confirm'],
   setup(props, context) {
     return setup({ props, context, renderless, api })
   }


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1387 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `open` event for the drawer component with multi-language descriptions and support for both PC and mobile-first modes.
  - Added a Vue component demonstrating the `open` event, complete with a button to trigger the event and a drawer displaying a message when opened.

- **Bug Fixes**
  - Ensured consistent spacing in type definitions for `close` and `confirm` events.

- **Tests**
  - Added a test case for the `open` event in a drawer using Playwright.

- **Documentation**
  - Updated documentation to include descriptions for the new `open` event in multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->