### PR TITLE
fix(grid): [grid] fix nested grid context menu error

### DIFF
--- a/packages/vue/src/grid/src/menu/src/methods.ts
+++ b/packages/vue/src/grid/src/menu/src/methods.ts
@@ -124,7 +124,10 @@ export default {
 
       if (eventTargetNode.flag) {
         let cell = eventTargetNode.targetElem
-        let column = this.getColumnNode(cell).item
+        let column = this.getColumnNode(cell)?.item
+        if (!column) {
+          return
+        }
         let typePrefix = `${layout}-`
         Object.assign(eventParams, { cell, column, columnIndex: this.getColumnIndex(column) })
 

--- a/packages/vue/src/grid/src/table/src/methods.ts
+++ b/packages/vue/src/grid/src/table/src/methods.ts
@@ -420,15 +420,15 @@ const Methods = {
     if (!cell) {
       return null
     }
-    let { isGroup, fullColumnIdData, tableFullColumn } = this
-    let dataColid = cell.getAttribute('data-colid')
+    const { isGroup, fullColumnIdData, tableFullColumn } = this
+    const dataColid = cell.getAttribute('data-colid')
+    const colCache = fullColumnIdData?.[dataColid]
     if (isGroup) {
       let matches = findTree(tableFullColumn, (column) => column.id === dataColid, headerProps)
       if (matches) {
         return matches
       }
-    } else {
-      let colCache = fullColumnIdData[dataColid]
+    } else if (colCache) {
       return {
         index: colCache.index,
         item: colCache.column,


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
问题根因：
![image](https://github.com/opentiny/tiny-vue/assets/26026184/74e0f77d-5d15-4ee2-8761-7b062767c8eb)
![image](https://github.com/opentiny/tiny-vue/assets/26026184/ad3bb166-a3f8-46ac-a580-2e292a2795df)


表格右键菜单实现通过监听document的contextmenu事件实现，当点击鼠标右键时，所有表格都会触发对应的事件，表格内部通过判断event.target是否为本表格内容来决定是否展示菜单。
嵌套表格由于dom元素也在外层表格内部，因此符合条件展示菜单，但是外部表格实例获取不到嵌套表格相关的列配置，因此导致报错

解决方案：
获取列配置时加入兼容逻辑，如果获取不到列配置，则不展示菜单。
