### PR TITLE
fix[DatePicker]: [DatePicker]fix the tabindex's default value to 0

### DIFF
--- a/packages/vue/src/date-picker/src/index.ts
+++ b/packages/vue/src/date-picker/src/index.ts
@@ -66,7 +66,7 @@ export const datePickerProps = {
 
   tabindex: {
     type: String,
-    default: '1'
+    default: '0'
   },
   timeFormat: String,
   suffixIcon: Object,


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
当我在Form 表单中尝试使用tab键来访问datePicker元素的时候，发现它的优先级是不对的，认为设置为0比较合理。
这样子当用户使用form-item的时候，通过tab键来访问可聚焦元素，访问的顺序就是它们在dom中的顺序。
如以下的伪代码，在表单中，当datePicker 的默认值为1时，用户通过tab来访问表单的顺序就不是从上到下了
```
<input tabindex="0"></input>  // 该元素tabindex的默认值为0
<datePicker tabindex="1"><datePicker> // tabindex的默认值为1
<input tabindex="0"></input> // 该元素tabindex的默认值为0
```

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
