### PR TITLE
fix: vue-test-uitls destory should be destroy

### DIFF
--- a/internals/vue-test-utils/src/index.ts
+++ b/internals/vue-test-utils/src/index.ts
@@ -5,7 +5,7 @@ const mount = (inputComponent: any, options: MountingOptions<any> = {}) => {
   let mount$ = _mount
 
   if (isVue2) {
-    ;(options as any).localVue = createLocalVue()
+    ; (options as any).localVue = createLocalVue()
 
     if (options.props) {
       options.propsData = options.props
@@ -25,7 +25,7 @@ const mount = (inputComponent: any, options: MountingOptions<any> = {}) => {
   const wrapper = mount$(inputComponent, options)
 
   if (isVue2) {
-    wrapper.unmount = (wrapper as any).destory
+    wrapper.unmount = (wrapper as any).destroy
   }
 
   return wrapper


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: no issue

## What is the new behavior?

in `internals/vue-test-utils/src/index.ts`, the `wrapper.destory` should be `wrapper.destroy`

accord to: https://test-utils.vuejs.org/migration/#destroy-is-now-unmount-to-match-Vue-3

<img width="665" alt="image" src="https://github.com/opentiny/tiny-vue/assets/44194929/b7ae8ca8-be2f-4d21-90eb-5456b9044e57">


## Does this PR introduce a breaking change?

- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected typos in method names related to Vue version detection to improve stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->