### PR TITLE
fix(vue): [grid] fix multi toolbar can not get tableColumns config

### DIFF
--- a/packages/vue/src/grid/src/grid/grid.ts
+++ b/packages/vue/src/grid/src/grid/grid.ts
@@ -447,7 +447,11 @@ export default defineComponent({
       if (type === 'pageSizeChangeCallback') {
         this._pageSizeChangeCallback = callback
       } else if (type === 'updateCustomsCallback') {
-        this._updateCustomsCallback = callback
+        // 表格可能有多个工具栏，因此工具栏个性化配置的回调应该是个数组
+        if (!this._updateCustomsCallback) {
+          this._updateCustomsCallback = []
+        }
+        this._updateCustomsCallback.push(callback)
       }
     },
     // 从缓存获取实例
@@ -460,8 +464,10 @@ export default defineComponent({
     handleColumnInitReady() {
       // 如果存在更新工具栏动态列回调，就执行
       if (this._updateCustomsCallback) {
-        this._updateCustomsCallback()
-        this._updateCustomsCallback = null
+        this._updateCustomsCallback.forEach((fn) => {
+          fn()
+        })
+        this._updateCustomsCallback = []
       }
     },
     handleRowClassName(params) {

--- a/packages/vue/src/grid/src/grid/grid.ts
+++ b/packages/vue/src/grid/src/grid/grid.ts
@@ -448,9 +448,7 @@ export default defineComponent({
         this._pageSizeChangeCallback = callback
       } else if (type === 'updateCustomsCallback') {
         // 表格可能有多个工具栏，因此工具栏个性化配置的回调应该是个数组
-        if (!this._updateCustomsCallback) {
-          this._updateCustomsCallback = []
-        }
+        this._updateCustomsCallback = this._updateCustomsCallback || []
         this._updateCustomsCallback.push(callback)
       }
     },


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

问题根因：

toolbar逻辑进行过调整：
![image](https://github.com/opentiny/tiny-vue/assets/26026184/0aa0b471-683b-4448-8ff4-799ac387f5d9)
之前是自己拿到tableFullColumn后调用updateCustoms更新表格配置信息，因此多工具栏情况下都可以获取到表格配置。
调整后，toolbar依赖表格回调更新配置信息，但是表格中只保留了一个回调，因此多工具栏下，只有最后一个工具栏可以获取到表格配置信息。
解决方案:
updateCustomsCallback保存一个数组。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced grid component to support multiple toolbar customizations by allowing multiple callback functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->