### PR TITLE
fix(picker): fix mobile breakpoint cannot use pc datepicker and timep…

### DIFF
--- a/packages/renderless/src/picker/index.ts
+++ b/packages/renderless/src/picker/index.ts
@@ -66,7 +66,7 @@ export const watchMobileVisible =
 export const watchPickerVisible =
   ({ api, vm, dispatch, emit, props, state, nextTick }) =>
   (value) => {
-    if (props.readonly || state.pickerDisabled || state.isMobileScreen) return
+    if (props.readonly || state.pickerDisabled || state.isMobileMode) return
 
     if (value) {
       api.showPicker()
@@ -912,9 +912,9 @@ export const handleFocus =
     const type = state.type
 
     if (DATEPICKER.TriggerTypes.includes(type)) {
-      if (state.isMobileScreen && state.isDateMobileComponent) {
+      if (state.isMobileMode && state.isDateMobileComponent) {
         api.dateMobileToggle(true)
-      } else if (state.isMobileScreen && state.isTimeMobileComponent) {
+      } else if (state.isMobileMode && state.isTimeMobileComponent) {
         api.timeMobileToggle(true)
       } else {
         state.pickerVisible = true

--- a/packages/renderless/src/picker/vue.ts
+++ b/packages/renderless/src/picker/vue.ts
@@ -143,7 +143,7 @@ const initState = ({ api, reactive, vm, computed, props, utils, parent, breakpoi
     labelTooltip: '',
     displayOnlyTooltip: '',
     isDisplayOnly: computed(() => props.displayOnly || (parent.tinyForm || {}).displayOnly),
-    isMobileScreen: computed(() => breakpoint.current.value === 'default'),
+    isMobileMode: computed(() => vm.$mode.includes('mobile')),
     dateMobileOption: {
       visible: false,
       type: props.type,

--- a/packages/vue/src/picker/src/mobile-first.vue
+++ b/packages/vue/src/picker/src/mobile-first.vue
@@ -17,7 +17,7 @@
       :tabindex="tabindex"
       v-else-if="!state.ranged"
       data-tag="tiny-date-editor"
-      :readonly="state.isMobileScreen || !editable || readonly || state.type === 'dates' || state.type === 'week'"
+      :readonly="state.isMobileMode || !editable || readonly || state.type === 'dates' || state.type === 'week'"
       :disabled="state.pickerDisabled"
       :size="state.pickerSize"
       :name="name"
@@ -49,7 +49,7 @@
       </template>
       <template #suffix>
         <i data-tag="icon" class="flex items-center cursor-pointer">
-          <transition v-if="!state.isMobileScreen" name="tiny-transition-icon-scale-in">
+          <transition v-if="!state.isMobileMode" name="tiny-transition-icon-scale-in">
             <component
               :is="state.showClose ? clearIcon : null"
               @click="handleClickIcon"
@@ -106,7 +106,7 @@
           :title="state.displayValue && state.displayValue[0]"
           :disabled="state.pickerDisabled"
           v-bind="state.firstInputId"
-          :readonly="state.isMobileScreen || !editable || readonly"
+          :readonly="state.isMobileMode || !editable || readonly"
           :name="name && name[0]"
           @input="handleStartInput"
           @change="handleStartChange"
@@ -136,7 +136,7 @@
           :title="state.displayValue && state.displayValue[1]"
           :disabled="state.pickerDisabled"
           v-bind="state.secondInputId"
-          :readonly="state.isMobileScreen || !editable || readonly"
+          :readonly="state.isMobileMode || !editable || readonly"
           :name="name && name[1]"
           @input="handleEndInput"
           @change="handleEndChange"
@@ -146,7 +146,7 @@
         />
         <i
           @click="handleClickIcon"
-          v-if="!state.isMobileScreen && state.haveTrigger"
+          v-if="!state.isMobileMode && state.haveTrigger"
           data-tag="tiny-input__icon tiny-range__close-icon"
           :class="gcls('close-icon')"
         >
@@ -183,7 +183,7 @@
     </div>
     <!-- 大屏面板 -->
     <component
-      v-if="!state.isMobileScreen"
+      v-if="!state.isMobileMode"
       :is="state.panel"
       :step="step"
       :show-week-number="showWeekNumber"
@@ -197,7 +197,7 @@
     ></component>
     <!-- 小屏 - 日期面板 -->
     <tiny-date-picker-mobile
-      v-if="state.isMobileScreen && state.isDateMobileComponent"
+      v-if="state.isMobileMode && state.isDateMobileComponent"
       ref="datePickerMobile"
       v-model="state.dateMobileOption.value"
       :title="title"
@@ -217,7 +217,7 @@
     </tiny-date-picker-mobile>
     <!-- 小屏 - 时间面板 -->
     <tiny-time-picker-mobile
-      v-if="state.isMobileScreen && state.isTimeMobileComponent"
+      v-if="state.isMobileMode && state.isTimeMobileComponent"
       ref="datePickerMobile"
       v-model="state.timeMobileOption.value"
       :title="title"


### PR DESCRIPTION
…icker

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The timepicker and datepicker can not be used at mobile screen breakpoints.

Issue Number: #1599 

## What is the new behavior?

Used at mobile screen breakpoint correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal logic to use `state.isMobileMode` instead of `state.isMobileScreen` for better clarity and consistency in mobile mode checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->