### PR TITLE
feat(vue): [button-group] add empty slot

### DIFF
--- a/examples/sites/demos/apis/button-group.js
+++ b/examples/sites/demos/apis/button-group.js
@@ -172,6 +172,17 @@ export default {
           mode: ['pc', 'mobile-first'],
           pcDemo: 'slot-default',
           mfDemo: ''
+        },
+        {
+          name: 'empty',
+          type: '',
+          defaultValue: '',
+          desc: {
+            'zh-CN': '自定义数据为空时展示内容',
+            'en-US': 'customize content when data is empty'
+          },
+          mode: ['pc'],
+          pcDemo: 'slot-empty'
         }
       ]
     }

--- a/examples/sites/demos/pc/app/button-group/slot-empty-composition-api.vue
+++ b/examples/sites/demos/pc/app/button-group/slot-empty-composition-api.vue
@@ -2,7 +2,9 @@
   <div>
     <tiny-button-group :data="groupData" v-model="checkedVal"></tiny-button-group>
     <tiny-button-group :data="groupData" v-model="checkedVal">
-      <span class="custom-empty">自定义空数据</span>
+      <template #empty>
+        <span class="custom-empty">自定义空数据</span>
+      </template>
     </tiny-button-group>
   </div>
 </template>

--- a/examples/sites/demos/pc/app/button-group/slot-empty.vue
+++ b/examples/sites/demos/pc/app/button-group/slot-empty.vue
@@ -2,7 +2,9 @@
   <div>
     <tiny-button-group :data="groupData" v-model="checkedVal"></tiny-button-group>
     <tiny-button-group :data="groupData" v-model="checkedVal">
-      <span class="custom-empty">自定义空数据</span>
+      <template #empty>
+        <span class="custom-empty">自定义空数据</span>
+      </template>
     </tiny-button-group>
   </div>
 </template>

--- a/examples/sites/demos/pc/app/button-group/webdoc/button-group.js
+++ b/examples/sites/demos/pc/app/button-group/webdoc/button-group.js
@@ -113,12 +113,12 @@ export default {
     {
       demoId: 'slot-empty',
       name: {
-        'zh-CN': '空数据插槽',
-        'en-US': 'Empty slot'
+        'zh-CN': '空数据',
+        'en-US': 'No data'
       },
       desc: {
-        'zh-CN': '<p>当数据为空时，默认会显示暂无数据，通过默认插槽自定义内容。</p>',
-        'en-US': '<p>When the data is empty, customize the content via the <code>empty</code> slot.</p>'
+        'zh-CN': '<p>当数据为空时，默认会显示"暂无数据"，通过 <code>empty</code> 插槽自定义内容。</p>',
+        'en-US': '<p>Show "No data" when the data is empty, customize the content via the <code>empty</code> slot.</p>'
       },
       codeFiles: ['slot-empty.vue']
     },

--- a/examples/sites/demos/pc/app/button-group/webdoc/button-group.js
+++ b/examples/sites/demos/pc/app/button-group/webdoc/button-group.js
@@ -116,6 +116,9 @@ export default {
         'zh-CN': '空数据',
         'en-US': 'No data'
       },
+      metaData: {
+        new: '3.17.1'
+      },
       desc: {
         'zh-CN': '<p>当数据为空时，默认会显示"暂无数据"，通过 <code>empty</code> 插槽自定义内容。</p>',
         'en-US': '<p>Show "No data" when the data is empty, customize the content via the <code>empty</code> slot.</p>'

--- a/packages/vue/src/button-group/package.json
+++ b/packages/vue/src/button-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/vue-button-group",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "description": "",
   "main": "lib/index.js",
   "module": "index.ts",

--- a/packages/vue/src/button-group/src/pc.vue
+++ b/packages/vue/src/button-group/src/pc.vue
@@ -106,7 +106,9 @@
           </li>
         </ul>
       </template>
-      <span v-else class="tiny-button-group--empty"> {{ t('ui.buttonGroup.noData') }} </span>
+      <span v-else class="tiny-button-group--empty">
+        <slot name="empty">{{ t('ui.buttonGroup.noData') }}</slot>
+      </span>
     </slot>
   </div>
 </template>


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added customization for content display when data is empty in the button group component.
  
- **Bug Fixes**
  - Improved translations for "Empty slot" feature with clearer instructions.

- **Documentation**
  - Updated version to 3.17.1 for the `@opentiny/vue-button-group` package.
  - Revised Chinese and English descriptions for empty data customization in demo files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->