### PR TITLE
fix: fix pnpm site error

### DIFF
--- a/internals/cli/package.json
+++ b/internals/cli/package.json
@@ -8,6 +8,7 @@
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "7.16.7",
     "@opentiny-internal/unplugin-virtual-template": "workspace:*",
+    "@opentiny/vue-vite-template2jsx": "workspace:*",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-commonjs": "^24.0.1",
     "@types/fs-extra": "^11.0.1",


### PR DESCRIPTION
# PR

The `pnpm site` command fails with the following error message:

```
Error: Cannot find module '@opentiny/vue-vite-template2jsx'
Require stack:
- /tiny-vue/internals/cli/src/commands/build/build-ui-solid.ts
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added `@opentiny/vue-vite-template2jsx` to the project dependencies to support JSX templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->