### PR TITLE
fix(drawer): fix the issue that content can not display when using v-if

### DIFF
--- a/packages/vue/src/drawer/package.json
+++ b/packages/vue/src/drawer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/vue-drawer",
-  "version": "3.17.1",
+  "version": "3.17.2",
   "description": "",
   "main": "lib/index.js",
   "module": "index.ts",

--- a/packages/vue/src/drawer/src/pc.vue
+++ b/packages/vue/src/drawer/src/pc.vue
@@ -88,7 +88,7 @@
             :class="['tiny-drawer__body', { 'flex flex-col': flex }, 'drawer-body']"
           >
             <slot>
-              <slot-wrapper :node="customSlots.default"></slot-wrapper>
+              <slot-wrapper :node="customSlots?.default"></slot-wrapper>
             </slot>
           </div>
 


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved slot handling in the drawer component to gracefully manage null values, ensuring smoother user interactions.

- **Chores**
  - Updated the version number of `@opentiny/vue-drawer` to `3.17.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->