### PR TITLE
fix(grid-toolbar): [grid] fix toolbar ref name error

### DIFF
--- a/packages/vue/src/grid-toolbar/package.json
+++ b/packages/vue/src/grid-toolbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/vue-grid-toolbar",
-  "version": "3.17.1",
+  "version": "3.17.2",
   "description": "",
   "main": "lib/index.js",
   "module": "index.ts",

--- a/packages/vue/src/grid-toolbar/src/custom.vue
+++ b/packages/vue/src/grid-toolbar/src/custom.vue
@@ -86,7 +86,12 @@
                 </tiny-grid-column>
               </tiny-grid>
             </tiny-tab-item>
-            <tiny-tab-item class="tabs-body-item" :title="t('ui.grid.individuation.tabs.other.title')" name="other">
+            <tiny-tab-item
+              v-if="other"
+              class="tabs-body-item"
+              :title="t('ui.grid.individuation.tabs.other.title')"
+              name="other"
+            >
               <tiny-alert
                 class="tiny-grid-custom__alert"
                 :description="t('ui.grid.individuation.tabs.other.tips')"
@@ -299,11 +304,11 @@ export default defineComponent({
     showFixed() {
       return (this as any).$grid
     },
-    TinyTable() {
-      return ((this as any).$grid && (this as any).$grid.$refs.TinyTable) || {}
+    tinyTable() {
+      return ((this as any).$grid && (this as any).$grid.$refs.tinyTable) || {}
     },
     isGroup() {
-      return this.TinyTable.isGroup
+      return this.tinyTable.isGroup
     },
     historyConfig() {
       const multipleHistory =


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added conditional rendering for `tiny-tab-item` in the grid toolbar.

- **Refactor**
  - Renamed `TinyTable` method to `tinyTable` for consistency.

- **Chores**
  - Updated `@opentiny/vue-grid-toolbar` package version from 3.17.1 to 3.17.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->