### PR TITLE
fix: fix layout asider layer error on mobile mode

### DIFF
--- a/examples/sites/src/style.css
+++ b/examples/sites/src/style.css
@@ -6,9 +6,9 @@ html {
 :root {
   --docs-markdown-top-body-zindex: 99;
   --docs-tabs-header-zindex: 100;
-  --float-settings-zindex: 999;
+  --docs-float-settings-zindex: 999;
   --docs-header-zindex: 200;
-  --layout-sider-zindex: 201;
+  --docs-layout-sider-zindex: 201;
 }
 
 .tinyui-design-header {

--- a/examples/sites/src/style.css
+++ b/examples/sites/src/style.css
@@ -3,10 +3,18 @@ html {
   font-size: 16px;
 }
 
+:root {
+  --docs-markdown-top-body-zindex: 99;
+  --docs-tabs-header-zindex: 100;
+  --float-settings-zindex: 999;
+  --docs-header-zindex: 200;
+  --layout-sider-zindex: 201;
+}
+
 .tinyui-design-header {
   z-index: 1000 !important;
 }
 
-.tiny-grid td,.tiny-grid th { 
+.tiny-grid td,.tiny-grid th {
   vertical-align: middle;
 }

--- a/examples/sites/src/views/components/components.vue
+++ b/examples/sites/src/views/components/components.vue
@@ -710,7 +710,7 @@ export default defineComponent({
 .docs-header {
   position: sticky;
   top: 0;
-  z-index: 200;
+  z-index: var(--docs-header-zindex);
   padding: var(--ti-common-space-4x) var(--ti-common-space-10x);
   background-color: #fff;
   box-shadow: var(--ti-common-space-3x) 0 var(--ti-common-space-5x) var(--ti-common-space-6) rgba(0, 0, 0, 0.06);
@@ -723,7 +723,7 @@ export default defineComponent({
   }
 
   .markdown-top-body {
-    z-index: 99;
+    z-index: var(--docs-markdown-top-body-zindex);
     font-size: var(--ti-common-font-size-1);
     transition: all ease-in-out 0.3s;
 
@@ -771,7 +771,7 @@ export default defineComponent({
     :deep(> .tiny-tabs__header) {
       position: sticky;
       top: 90px;
-      z-index: 100;
+      z-index: var(--docs-tabs-header-zindex);
       background-color: #fff;
 
       &::after {

--- a/examples/sites/src/views/components/float-settings.vue
+++ b/examples/sites/src/views/components/float-settings.vue
@@ -261,7 +261,7 @@ export default defineComponent({
   display: flex;
   flex-direction: column;
   column-gap: var(--ti-common-space-3x);
-  z-index: 999;
+  z-index: var(--float-settings-zindex);
   transition: all 0.3s linear;
 
   &.float-settings--aside {

--- a/examples/sites/src/views/components/float-settings.vue
+++ b/examples/sites/src/views/components/float-settings.vue
@@ -261,7 +261,7 @@ export default defineComponent({
   display: flex;
   flex-direction: column;
   column-gap: var(--ti-common-space-3x);
-  z-index: var(--float-settings-zindex);
+  z-index: var(--docs-float-settings-zindex);
   transition: all 0.3s linear;
 
   &.float-settings--aside {

--- a/examples/sites/src/views/layout/layout.vue
+++ b/examples/sites/src/views/layout/layout.vue
@@ -386,7 +386,7 @@ export default defineComponent({
   }
   #layoutSider.showMenu {
     display: block !important;
-    z-index: 9;
+    z-index: var(--layout-sider-zindex);
   }
 }
 </style>

--- a/examples/sites/src/views/layout/layout.vue
+++ b/examples/sites/src/views/layout/layout.vue
@@ -386,7 +386,7 @@ export default defineComponent({
   }
   #layoutSider.showMenu {
     display: block !important;
-    z-index: var(--layout-sider-zindex);
+    z-index: var(--docs-layout-sider-zindex);
   }
 }
 </style>


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

layout asider cannot be covered by docs content.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1766 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced CSS custom properties for dynamic management of z-index values across multiple components, enhancing layout control and flexibility.

- **Bug Fixes**
	- Normalized spacing in the `.tiny-grid` table cells for improved consistency in styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->