### PR TITLE
fix(fluent-editor): fix better-table module

### DIFF
--- a/packages/fluent-editor/src/config.ts
+++ b/packages/fluent-editor/src/config.ts
@@ -118,3 +118,45 @@ export const ICONS_CONFIG: { [key: string]: any } = {
   help: HELP_ICON,
   screenshot: SCREENSHOT_ICON,
 }
+
+export const TABLE_RIGHT_MENU_CONFIG = {
+  copyCells: {
+    text: LANG_CONF['copy-cells']
+  },
+  copyTable: {
+    text: LANG_CONF['copy-table']
+  },
+  cutCells: {
+    text: LANG_CONF['cut-cells']
+  },
+  emptyCells: {
+    text: LANG_CONF['empty-cells']
+  },
+  insertRowUp: {
+    text: LANG_CONF['insert-row-up']
+  },
+  insertRowDown: {
+    text: LANG_CONF['insert-row-down']
+  },
+  insertColumnLeft: {
+    text: LANG_CONF['insert-column-left']
+  },
+  insertColumnRight: {
+    text: LANG_CONF['insert-column-right']
+  },
+  mergeCells: {
+    text: LANG_CONF['merge-cells']
+  },
+  unMergeCells: {
+    text: LANG_CONF['unmerge-cells']
+  },
+  deleteRow: {
+    text: LANG_CONF['delete-row']
+  },
+  deleteColumn: {
+    text: LANG_CONF['delete-column']
+  },
+  deleteTable: {
+    text: LANG_CONF['delete-table']
+  }
+};

--- a/packages/fluent-editor/src/fluent-editor.ts
+++ b/packages/fluent-editor/src/fluent-editor.ts
@@ -1,5 +1,5 @@
 import Quill from 'quill'
-import { FONT_FAMILY_CONFIG, FONT_SIZE_CONFIG, ICONS_CONFIG } from './config'
+import { FONT_FAMILY_CONFIG, FONT_SIZE_CONFIG, ICONS_CONFIG, TABLE_RIGHT_MENU_CONFIG } from './config'
 import Counter from './counter' // 字符统计
 import CustomClipboard from './custom-clipboard' // 粘贴板
 import CustomImage from './custom-image/BlotFormatter' // 图片
@@ -45,6 +45,15 @@ const registerModules = function () {
           redo() {
             this.quill.history.redo()
           },
+          'better-table': function() {
+            this.quill.getModule('better-table').insertTable(3, 3)
+          },
+        }
+      },
+      'better-table': {
+        operationMenu: {
+          items: TABLE_RIGHT_MENU_CONFIG,
+          color: true
         }
       }
     }

--- a/packages/fluent-editor/src/table/modules/table-operation-menu.ts
+++ b/packages/fluent-editor/src/table/modules/table-operation-menu.ts
@@ -42,13 +42,12 @@ const MENU_ITEMS_DEFAULT = {
       dom.remove();
     }
   },
-  // tofix
-  // cutCells: {
-  //   text: 'Cut Cells',
-  //   handler() {
-  //     this.onCopy('cut');
-  //   }
-  // },
+  cutCells: {
+    text: 'Cut Cells',
+    handler() {
+      this.onCopy('cut');
+    }
+  },
   emptyCells: {
     text: 'Empty Cells',
     handler() {
@@ -207,7 +206,7 @@ const MENU_ITEMS_DEFAULT = {
     }
   },
 
-  unmergeCells: {
+  unMergeCells: {
     text: 'Split Cells',
     handler() {
       const tableContainer = Quill.find(this.table);


### PR DESCRIPTION
# PR

修复点击工具栏表格图标无法插入表格的问题。

表格效果：

![image](https://github.com/user-attachments/assets/73335332-4be9-4dcf-b9c2-25b264ad8078)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration for table operations, enhancing the right-click menu functionality in the editor.
	- Added a method to insert a 3x3 table directly through the editor interface, improving usability.
	- Reinstated the ability to cut cells from the table operation menu.

- **Improvements**
	- Renamed menu item for clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->