### PR TITLE
fix(modal): [modal] empty str title should not be visible

### DIFF
--- a/examples/sites/demos/pc/app/modal/basic-usage.spec.ts
+++ b/examples/sites/demos/pc/app/modal/basic-usage.spec.ts
@@ -19,7 +19,7 @@ test('基本用法', async ({ page }) => {
   // 成功提示框
   await page.getByRole('button', { name: /成功提示框/ }).click()
   await expect(modal).toHaveClass(/status__success/)
-  await expect(modal.locator('.tiny-modal__header svg').first()).toHaveClass(/tiny-icon-success/)
+  await expect(modal.locator('.tiny-modal__header svg').first()).toHaveClass(/tiny-modal-svg__success/)
   await page.getByRole('button', { name: /确定/, exact: true }).click()
   await expect(page.locator('.tiny-modal.type__alert.status__success')).not.toBeVisible()
 

--- a/examples/sites/demos/pc/app/modal/lock-view.spec.ts
+++ b/examples/sites/demos/pc/app/modal/lock-view.spec.ts
@@ -5,6 +5,11 @@ test('锁住页面', async ({ page }) => {
   await page.goto('modal#lock-view')
 
   const modal = page.locator('.tiny-modal.active')
+
+  // 新版示例页单示例无滚动条，先展开代码保证有滚动条
+  await page.locator('.i-ti-code').click()
+  await page.waitForTimeout(100)
+
   await page.getByRole('button', { name: '不锁界面 且 隐藏遮罩层' }).click()
   await expect(modal).not.toHaveClass(/lock__view/)
 

--- a/examples/sites/demos/pc/app/modal/title-composition-api.vue
+++ b/examples/sites/demos/pc/app/modal/title-composition-api.vue
@@ -1,11 +1,16 @@
 <template>
-  <tiny-button @click="btnClick" :reset-time="0">自定义标题</tiny-button>
+  <tiny-button @click="customClick" :reset-time="0">自定义标题</tiny-button>
+  <tiny-button @click="noTitleClick" :reset-time="0">无标题</tiny-button>
 </template>
 
 <script setup>
 import { Button as TinyButton, Modal } from '@opentiny/vue'
 
-function btnClick() {
+function customClick() {
   Modal.alert({ message: '自定义标题', title: '自定义标题' })
+}
+
+function noTitleClick() {
+  Modal.alert({ message: '无标题', title: '' })
 }
 </script>

--- a/examples/sites/demos/pc/app/modal/title.spec.ts
+++ b/examples/sites/demos/pc/app/modal/title.spec.ts
@@ -1,10 +1,19 @@
 import { test, expect } from '@playwright/test'
 
-test('标题', async ({ page }) => {
+test('自定义标题', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
   await page.goto('modal#title')
 
   const modal = page.locator('.tiny-modal.active')
   await page.getByRole('button', { name: '自定义标题' }).click()
   await expect(modal.locator('.tiny-modal__header')).toHaveText('自定义标题')
+})
+
+test('无标题', async ({ page }) => {
+  page.on('pageerror', (exception) => expect(exception).toBeNull())
+  await page.goto('modal#title')
+
+  const modal = page.locator('.tiny-modal.active')
+  await page.getByRole('button', { name: '无标题' }).click()
+  await expect(modal.locator('.tiny-modal__title')).not.toBeVisible()
 })

--- a/examples/sites/demos/pc/app/modal/title.vue
+++ b/examples/sites/demos/pc/app/modal/title.vue
@@ -1,5 +1,6 @@
 <template>
-  <tiny-button @click="btnClick" :reset-time="0">自定义标题</tiny-button>
+  <tiny-button @click="customClick" :reset-time="0">自定义标题</tiny-button>
+  <tiny-button @click="noTitleClick" :reset-time="0">无标题</tiny-button>
 </template>
 
 <script>
@@ -10,8 +11,12 @@ export default {
     TinyButton: Button
   },
   methods: {
-    btnClick() {
+    customClick() {
       Modal.alert({ message: '自定义标题', title: '自定义标题' })
+    },
+
+    noTitleClick() {
+      Modal.alert({ message: '无标题', title: '' })
     }
   }
 }

--- a/packages/vue/src/modal/src/mobile.vue
+++ b/packages/vue/src/modal/src/mobile.vue
@@ -105,13 +105,15 @@ export default defineComponent({
                     }
                   },
                   [
-                    h(
-                      'span',
-                      {
-                        class: 'tiny-mobile-modal__title'
-                      },
-                      title || t('ui.alert.title')
-                    ),
+                    title !== ''
+                      ? h(
+                          'span',
+                          {
+                            class: 'tiny-mobile-modal__title'
+                          },
+                          title || t('ui.alert.title')
+                        )
+                      : null,
                     resize
                       ? h(zoomLocat ? iconMinscreenLeft() : iconFullscreenLeft(), {
                           class: ['tiny-mobile-modal__zoom-btn', 'trigger__btn'],

--- a/packages/vue/src/modal/src/mobile.vue
+++ b/packages/vue/src/modal/src/mobile.vue
@@ -48,9 +48,6 @@ export default defineComponent({
     'width',
     'zIndex'
   ],
-  components: {
-    Button
-  },
   provide() {
     return { dialog: this }
   },

--- a/packages/vue/src/modal/src/pc.vue
+++ b/packages/vue/src/modal/src/pc.vue
@@ -183,13 +183,15 @@ export default defineComponent({
                           ]
                         )
                       : null,
-                    h(
-                      'span',
-                      {
-                        class: 'tiny-modal__title'
-                      },
-                      title || t('ui.alert.title')
-                    ),
+                    title !== ''
+                      ? h(
+                          'span',
+                          {
+                            class: 'tiny-modal__title'
+                          },
+                          title || t('ui.alert.title')
+                        )
+                      : null,
                     resize
                       ? h(zoomLocat ? iconMinscreenLeft() : iconFullscreenLeft(), {
                           class: ['tiny-modal__zoom-btn', 'trigger__btn'],


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1856 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a button option for displaying a modal without a title, allowing for more flexible user interactions.
	- Enhanced test coverage for modal title scenarios, including customizable titles and scenarios without titles.

- **Bug Fixes**
	- Improved test stability by ensuring UI elements are fully rendered before assertions are made.

- **Refactor**
	- Updated button click handlers for better descriptive naming and functionality.

- **Style**
	- Conditional rendering of modal titles to improve user interface responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->