### PR TITLE
fix(pop-confirm): [pop-confirm]  remove m funtion from  pc template

### DIFF
--- a/packages/vue/src/popconfirm/src/pc.vue
+++ b/packages/vue/src/popconfirm/src/pc.vue
@@ -8,7 +8,7 @@
         trigger="manual"
         :width="width"
         :title="title"
-        :popper-class="['tiny-popconfirm-popover', customClass]"
+        :popper-class="'tiny-popconfirm-popover ' + customClass"
         :popper-options="popperOptions"
         :append-to-body="popperAppendToBody"
         :reference="reference"

--- a/packages/vue/src/popconfirm/src/pc.vue
+++ b/packages/vue/src/popconfirm/src/pc.vue
@@ -8,7 +8,7 @@
         trigger="manual"
         :width="width"
         :title="title"
-        :popper-class="'tiny-popconfirm-popover ' + customClass"
+        :popper-class="'tiny-popconfirm-popover ' + (customClass || '')"
         :popper-options="popperOptions"
         :append-to-body="popperAppendToBody"
         :reference="reference"

--- a/packages/vue/src/popconfirm/src/pc.vue
+++ b/packages/vue/src/popconfirm/src/pc.vue
@@ -8,7 +8,7 @@
         trigger="manual"
         :width="width"
         :title="title"
-        :popper-class="m('tiny-popconfirm-popover', customClass)"
+        :popper-class="['tiny-popconfirm-popover', customClass]"
         :popper-options="popperOptions"
         :append-to-body="popperAppendToBody"
         :reference="reference"


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
去掉 pc模板中的 m函数

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Enhanced the way CSS classes are applied to the popconfirm component, improving readability and maintainability.
	- The updated method for defining class names allows for better separation and handling of multiple classes.
	- Simplified class name construction to prevent formatting issues when custom classes are not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->