### PR TITLE
Revert "fix(crypto): [crypto] use nanoid instead to support SSR"

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,6 @@
     "echarts-liquidfill": "3.1.0",
     "echarts-wordcloud": "2.0.0",
     "fastdom": "1.0.11",
-    "nanoid": "^5.0.7",
     "shepherd.js": "11.0.1",
     "streamsaver": "2.0.6"
   },

--- a/packages/renderless/src/common/string.ts
+++ b/packages/renderless/src/common/string.ts
@@ -13,7 +13,6 @@
 import { isPlainObject, isNumber, isNumeric, isNull } from './type'
 import { getObj, toJsonStr } from './object'
 import { toFixed, Decimal } from './decimal'
-import { nanoid } from 'nanoid'
 
 /**
  * 文本替换格式类型
@@ -242,9 +241,8 @@ export const fillChar = (string, length, append, chr = '0') => {
 }
 
 export const random = () => {
-  const randomString = nanoid(8)
-  const randomValue = parseInt(randomString, 16)
-  return randomValue / 16 ** randomString.length
+  let MAX_UINT32_PLUS_ONE = 4294967296
+  return window.crypto.getRandomValues(new window.Uint32Array(1))[0] / MAX_UINT32_PLUS_ONE
 }
 
 /**


### PR DESCRIPTION
Reverts opentiny/tiny-vue#1860

The random numbers generated by nanoid may contain dashes and underscores. After being converted to numbers by parseInt, they will become NaN, which is inconsistent with the logic of the original getRandomValues function.

```ts
import { nanoid } from 'nanoid'

const random = () => {
  let MAX_UINT32_PLUS_ONE = 4294967296
  return window.crypto.getRandomValues(new window.Uint32Array(1))[0] / MAX_UINT32_PLUS_ONE
}

const randomNanoid = () => {
  const randomString = nanoid(8)
  console.log('randomString', randomString)
  
  const randomValue = parseInt(randomString, 16)
  console.log('randomValue', randomValue)
  return randomValue / 16 ** randomString.length
}

console.log('random', random())
console.log('randomNanoid', randomNanoid())
```

![image](https://github.com/user-attachments/assets/3d3a8aea-cf1f-4338-be2e-d03c4373d6c0)
