### PR TITLE
chore: fix contact link url in issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Questions or need help
-    url: https://github.com/opentiny/ui-vue/discussions
+    url: https://github.com/opentiny/tiny-vue/discussions
     about: Add this WeChat(opentiny-official), we will invite you to the WeChat discussion group later.


### PR DESCRIPTION
# PR

修复问题：提交 Issue 时，点击 `Questions or need help` 后面的 `Open` 按钮，跳转链接地址错误。

![image](https://github.com/user-attachments/assets/026b5dd4-22e2-4edf-989a-131dac1eafd7)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the contact link in the GitHub issue templates to direct users to the new repository for discussions.

- **Documentation**
	- Changed the URL in the issue template configuration, aligning it with the updated project branding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->