### PR TITLE
fix: fix type: "module" must need js file extensions

### DIFF
--- a/packages/renderless/build.config.ts
+++ b/packages/renderless/build.config.ts
@@ -1,0 +1,11 @@
+import { defineBuildConfig } from 'unbuild'
+
+export default defineBuildConfig({
+  entries: [
+    {
+      builder: 'mkdist',
+      input: './src/'
+    }
+  ],
+  clean: true
+})

--- a/packages/renderless/build.config.ts
+++ b/packages/renderless/build.config.ts
@@ -1,10 +1,16 @@
 import { defineBuildConfig } from 'unbuild'
+import { version } from './package.json'
 
 export default defineBuildConfig({
   entries: [
     {
       builder: 'mkdist',
-      input: './src/'
+      input: './src/',
+      esbuild: {
+        define: {
+          'process.env.RUNTIME_VERSION': JSON.stringify(version)
+        }
+      }
     }
   ],
   clean: true

--- a/packages/renderless/package.json
+++ b/packages/renderless/package.json
@@ -30,7 +30,9 @@
     "./*": "./src/*"
   },
   "scripts": {
-    "build": "unbuild",
+    "build": "pnpm build:code && pnpm build:dts",
+    "build:code": "unbuild",
+    "build:dts": "tsup",
     "build:fast": "npm run build && npm run release",
     "postversion": "pnpm build",
     "release": "esno ./scripts/postbuild.ts && shx cp README.md dist"
@@ -41,6 +43,7 @@
   },
   "devDependencies": {
     "esno": "^4.7.0",
+    "tsup": "7.2.0",
     "unbuild": "^2.0.0"
   }
 }

--- a/packages/renderless/package.json
+++ b/packages/renderless/package.json
@@ -30,7 +30,7 @@
     "./*": "./src/*"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "unbuild",
     "build:fast": "npm run build && npm run release",
     "postversion": "pnpm build",
     "release": "esno ./scripts/postbuild.ts && shx cp README.md dist"
@@ -41,6 +41,6 @@
   },
   "devDependencies": {
     "esno": "^4.7.0",
-    "tsup": "7.2.0"
+    "unbuild": "^2.0.0"
   }
 }

--- a/packages/renderless/tsup.config.ts
+++ b/packages/renderless/tsup.config.ts
@@ -1,22 +1,9 @@
 import { defineConfig } from 'tsup'
-import { version } from './package.json'
 
 export default defineConfig([
   {
-    entry: ['src/**/*.ts'],
-    bundle: false,
-    clean: true,
-    format: ['esm'],
-    dts: false,
-    outExtension: () => ({ js: '.js' }),
-    esbuildOptions(options) {
-      if (options.define) options.define['process.env.RUNTIME_VERSION'] = JSON.stringify(version)
-    }
-  },
-  {
     entry: ['types/*.type.ts'],
     bundle: false,
-    clean: true,
     outDir: 'dist/types',
     external: ['@opentiny/vue-icon', '@opentiny/vue-common'],
     dts: {


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

missing js file extensions on import statement

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #569

## What is the new behavior?

generated renderless file import statement could contains js file extensions

`cd packages/renderless`

run `pnpm build`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Better than #1880

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a streamlined build configuration that enhances the build process.
	- Transitioned to a new build tool for improved performance and compatibility.
	- Added new scripts for more granular control over code building and type definition generation.

- **Bug Fixes**
	- Clean-up process implemented to ensure that previous build artifacts do not interfere with new builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->