### PR TITLE
fix(docs): add beta logo to solve the problem of incomplete text display

### DIFF
--- a/examples/sites/src/views/components/VersionTip.vue
+++ b/examples/sites/src/views/components/VersionTip.vue
@@ -116,6 +116,10 @@ export default defineComponent({
     },
     extendTip: {
       type: Object as PropType<Ii18nString>
+    },
+    isFromMenu: {
+      type: Boolean,
+      default: false
     }
   },
   setup(props) {
@@ -154,9 +158,15 @@ export default defineComponent({
       return goingStages.map(([stage, des]) => des.replace('{version}', getVersion(stage as STAGE))).join('，')
     }
 
-    const tagContentComputed = computed(() =>
-      isStableComputed.value ? props.meta[currentStageComputed.value] : currentStageComputed.value
-    )
+    const tagContentComputed = computed(() => {
+      const result = isStableComputed.value ? props.meta[currentStageComputed.value] : currentStageComputed.value
+      // 菜单上需要显示Beta标识，防止占用过多文字空间
+      if (props.isFromMenu && result === STAGE.experimental) {
+        return 'Beta'
+      } else {
+        return result
+      }
+    })
 
     const tipComputed = computed(() => {
       if (props.tip) return getWord(props.tip['zh-CN'], props.tip['en-US']) as string

--- a/examples/sites/src/views/layout/layout.vue
+++ b/examples/sites/src/views/layout/layout.vue
@@ -30,6 +30,7 @@
                 :meta="data.meta"
                 v-bind="data.versionTipOption"
                 render-type="tag"
+                :is-from-menu="true"
               >
               </version-tip>
             </div>


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `VersionTip` component to display a specific label ('Beta') when rendered from a menu context.
	- Introduced a new property `isFromMenu` to improve contextual awareness in the app's UI.
	- Updated the layout to bind the `isFromMenu` property to the `version-tip` component for better functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->