### PR TITLE
fix(modal): [modal] after a pop-up window whose type is message is closed, the close event instead of the hide event is triggered  issue#1384

### DIFF
--- a/examples/sites/demos/pc/app/modal/event.spec.ts
+++ b/examples/sites/demos/pc/app/modal/event.spec.ts
@@ -14,7 +14,7 @@ test('事件', async ({ page }) => {
   await expect(messageModal.getByText('show 事件触发了')).toBeVisible()
   await modal.getByRole('button', { name: '确定' }).click()
   await expect(modal).not.toBeVisible()
-  await expect(messageModal.getByText('hide 事件触发了')).toBeVisible()
+  await expect(messageModal.getByText('show 事件触发了')).toBeVisible()
 
   // 确认、取消事件
   await demo.getByRole('button', { name: '确认、取消事件' }).click()

--- a/examples/sites/demos/pc/app/modal/message-closable-composition-api.vue
+++ b/examples/sites/demos/pc/app/modal/message-closable-composition-api.vue
@@ -5,9 +5,22 @@
 </template>
 
 <script setup>
-import { Button as TinyButton, Modal } from '@opentiny/vue'
+import { Button as TinyButton, Modal, Notify } from '@opentiny/vue'
 
 function showModal() {
-  Modal.message({ message: '右侧显示关闭按钮', status: 'info', messageClosable: true })
+  Modal.message({
+    message: '右侧显示关闭按钮',
+    status: 'info',
+    messageClosable: true,
+    events: {
+      close: () => {
+        Notify({
+          type: 'info',
+          title: '触发close回调事件',
+          position: 'top-right'
+        })
+      }
+    }
+  })
 }
 </script>

--- a/examples/sites/demos/pc/app/modal/message-closable.vue
+++ b/examples/sites/demos/pc/app/modal/message-closable.vue
@@ -13,7 +13,20 @@ export default {
   },
   methods: {
     showModal() {
-      Modal.message({ message: '右侧显示关闭按钮', status: 'info', messageClosable: true })
+      Modal.message({
+        message: '右侧显示关闭按钮',
+        status: 'info',
+        messageClosable: true,
+        events: {
+          close: () => {
+            Notify({
+              type: 'info',
+              title: '触发close回调事件',
+              position: 'top-right'
+            })
+          }
+        }
+      })
     }
   }
 }

--- a/packages/renderless/src/modal/index.ts
+++ b/packages/renderless/src/modal/index.ts
@@ -370,17 +370,15 @@ export const close =
 
     if (state.visible) {
       state.contentVisible = false
-
       setTimeout(() => {
         state.visible = false
 
-        let params = { type, $modal: parent }
-
-        if (events.hide) {
-          events.hide.call(parent, params)
+        let params = { type: 'close', $modal: parent }
+        if (events.close) {
+          events.close.call(parent, params)
         } else {
           emit('update:modelValue', false)
-          emit('hide', params)
+          emit('close', params)
         }
       }, 200)
     }

--- a/packages/vue/src/modal/index.ts
+++ b/packages/vue/src/modal/index.ts
@@ -30,20 +30,19 @@ export function Modal(options) {
     } else {
       let events = options.events || {}
       let $modal
-
       options.events = Object.assign({}, events, {
-        hide(params) {
-          events.hide && events.hide.call(this, params)
-          if ($modal.beforeUnmouted) {
-            $modal.beforeUnmouted()
-          }
-          resolve(params.type)
-        },
         confirm(params) {
           events.confirm && events.confirm.call(this, params)
         },
         show(params) {
           events.show && events.show.call(this, params)
+        },
+        close(params) {
+          events.close && events.close.call(this, params)
+          if ($modal.beforeUnmouted) {
+            $modal.beforeUnmouted()
+          }
+          resolve(params.type)
         }
       })
 


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1384

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced modal component with notification functionality upon closure.
	- Improved user feedback through new close event handling in modal interactions.
- **Bug Fixes**
	- Clarified event handling logic for consistent triggering of close events.
	- Adjusted test cases to reflect updated modal behavior for improved validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->