### PR TITLE
fix(tree): [tree] fix tree showLine props's bug ,  sometimes the line is too long

### DIFF
--- a/packages/theme/src/tree/index.less
+++ b/packages/theme/src/tree/index.less
@@ -224,13 +224,12 @@
     .@{tree-node-prefix-cls}__children {
       overflow: visible !important;
       transition: 0.3s opacity ease-in-out;
+      position: relative;
 
       &
         .@{tree-node-prefix-cls}__wrapper:not(:last-child)
         > .@{tree-node-prefix-cls}
         > .@{tree-node-prefix-cls}__children {
-        position: relative;
-
         .@{tree-node-prefix-cls}__children-indent {
           height: 100%;
           position: absolute;


### PR DESCRIPTION
… long

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
tree组件的某一个子节点的treeNode过多时， showLine:true时， 会显示那个**子节点的最后一项的连接线变得非常长**。
是由于连接线的height:100%， 而它最近的relative元素好像是上级节点，高度就变得高了

原来relative加在了  tree-node__children  :not(:last-child) 上了， 不明白为什么这样。  
把relative加给所有的 tree-node__children , 似乎能解决这个问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced layout behavior of tree structure by modifying CSS styles for child elements.
	- Improved visual hierarchy and interaction of tree nodes through refined CSS structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->