### PR TITLE
fix(modal): [modal] after the window size is changed, the window is displayed in the center

### DIFF
--- a/examples/sites/demos/pc/app/modal/footer-slot-composition-api.vue
+++ b/examples/sites/demos/pc/app/modal/footer-slot-composition-api.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="content">
     <tiny-button @click="visible = !visible" :reset-time="0">自定义底部</tiny-button>
-    <tiny-modal v-model="visible" show-footer>
+    <tiny-modal v-model="visible" footer-dragable show-footer>
       <template #footer>
         <tiny-button>自定义底部信息</tiny-button>
       </template>

--- a/examples/sites/demos/pc/app/modal/footer-slot.vue
+++ b/examples/sites/demos/pc/app/modal/footer-slot.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="content">
     <tiny-button @click="visible = !visible" :reset-time="0">自定义底部</tiny-button>
-    <tiny-modal v-model="visible" show-footer>
+    <tiny-modal v-model="visible" footer-dragable show-footer>
       <template #footer>
         <tiny-button>自定义底部信息</tiny-button>
       </template>

--- a/packages/renderless/package.json
+++ b/packages/renderless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/vue-renderless",
-  "version": "3.18.1",
+  "version": "3.18.2",
   "private": true,
   "description": "An enterprise-class UI component library, support both Vue.js 2 and Vue.js 3, as well as PC and mobile.",
   "author": "OpenTiny Team",

--- a/packages/renderless/src/modal/index.ts
+++ b/packages/renderless/src/modal/index.ts
@@ -140,6 +140,7 @@ export const beforeUnmouted =
     isMobileFirstMode && off(window, 'resize', api.resetDragStyle)
     off(document, 'keydown', api.handleGlobalKeydownEvent)
     off(window, 'hashchange', api.handleHashChange)
+    off(window, 'resize', api.resetModalViewPosition)
     api.removeMsgQueue()
     api.hideScrollbar()
 

--- a/packages/renderless/src/modal/index.ts
+++ b/packages/renderless/src/modal/index.ts
@@ -294,13 +294,13 @@ export const open =
             } else {
               modalBoxElem.style.left = `${clientVisibleWidth / 2 - modalBoxElem.offsetWidth / 2}px`
             }
-
             if (
               modalBoxElem.offsetHeight + modalBoxElem.offsetTop + (props.marginSize as number) >
               clientVisibleHeight
             ) {
               modalBoxElem.style.top = `${props.marginSize}px`
             }
+            on(window, 'resize', api.resetModalViewPosition)
           }
 
           if (props.fullscreen) {
@@ -918,4 +918,12 @@ export const showScrollbar = (lockScrollClass) => () => {
 
 export const hideScrollbar = (lockScrollClass) => () => {
   removeClass(document.body, lockScrollClass)
+}
+
+export const resetModalViewPosition = (api: IModalApi) => () => {
+  const modalBoxElement = api.getBox()
+  const viewportWindow = getViewportWindow()
+  let clientVisibleWidth =
+    viewportWindow.document.documentElement.clientWidth || viewportWindow.document.body.clientWidth
+  modalBoxElement.style.left = `${clientVisibleWidth / 2 - modalBoxElement.offsetWidth / 2}px`
 }

--- a/packages/renderless/src/modal/index.ts
+++ b/packages/renderless/src/modal/index.ts
@@ -924,7 +924,7 @@ export const hideScrollbar = (lockScrollClass) => () => {
 export const resetModalViewPosition = (api: IModalApi) => () => {
   const modalBoxElement = api.getBox()
   const viewportWindow = getViewportWindow()
-  let clientVisibleWidth =
+  const clientVisibleWidth =
     viewportWindow.document.documentElement.clientWidth || viewportWindow.document.body.clientWidth
   modalBoxElement.style.left = `${clientVisibleWidth / 2 - modalBoxElement.offsetWidth / 2}px`
 }

--- a/packages/renderless/src/modal/vue.ts
+++ b/packages/renderless/src/modal/vue.ts
@@ -37,6 +37,7 @@ import {
   cancelEvent,
   open,
   resetDragStyle,
+  resetModalViewPosition,
   computedBoxStyle,
   handleHashChange,
   showScrollbar,
@@ -64,7 +65,8 @@ export const api = [
   'cancelEvent',
   'open',
   'beforeUnmouted',
-  'resetDragStyle'
+  'resetDragStyle',
+  'resetModalViewPosition'
 ]
 
 export const renderless = (
@@ -120,6 +122,7 @@ export const renderless = (
     mousedownEvent: mousedownEvent({ api, nextTick, props, state, emit, isMobileFirstMode }),
     dragEvent: dragEvent({ api, emit, parent, props, state }),
     resetDragStyle: resetDragStyle(api),
+    resetModalViewPosition: resetModalViewPosition(api),
     computedBoxStyle: computedBoxStyle({ props, isMobileFirstMode }),
     watchVisible: watchVisible({ api, props }),
     hideScrollbar: hideScrollbar(lockScrollClass),

--- a/packages/renderless/types/modal.type.ts
+++ b/packages/renderless/types/modal.type.ts
@@ -63,6 +63,7 @@ export interface IModalApi {
   mousedownEvent: (event: MouseEvent) => void
   dragEvent: (event: MouseEvent) => void
   resetDragStyle: () => void
+  resetModalViewPosition: () => void
 }
 
 export type IModalRenderlessParamUtils = ISharedRenderlessParamUtils<IModalConstants>


### PR DESCRIPTION
…nter

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new `footer-dragable` property for the modal, allowing users to drag the footer for improved layout flexibility.
	- Added a `resetModalViewPosition` function to dynamically adjust the modal's position based on viewport size, enhancing responsiveness.

- **Bug Fixes**
	- Improved modal positioning logic to ensure it remains centered and respects margin sizes during window resizing.
	
- **Chores**
	- Updated the version of the `@opentiny/vue-renderless` package from `3.18.1` to `3.18.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->