### PR TITLE
fix(grid): [grid] fix empty slot error when is-center-empty is set

### DIFF
--- a/packages/vue/src/grid/package.json
+++ b/packages/vue/src/grid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opentiny/vue-grid",
   "type": "module",
-  "version": "3.18.1",
+  "version": "3.18.2",
   "description": "",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/vue/src/grid/src/table/src/table.ts
+++ b/packages/vue/src/grid/src/table/src/table.ts
@@ -103,7 +103,9 @@ function mergeTreeConfig(_vm) {
 }
 
 const renderEmptyPartFn = (opt) => {
-  const { _vm, tableData, $slots, renderEmpty } = opt
+  const { _vm, tableData } = opt
+  const { $grid = {}, renderEmpty } = _vm
+  const { $slots } = $grid
   return () => {
     let emptyPartVnode = null
     let { computerTableBodyHeight } = _vm
@@ -272,21 +274,13 @@ function getRenderer(opt) {
     visibleColumn
   } = opt
   const { $grid, ctxMenuStore, editRules, filterStore, footerData, footerMethod, hasFilter, hasTip, height, id } = _vm
-  const {
-    isCtxMenu,
-    isResizable,
-    renderEmpty,
-    scrollbarHeight,
-    selectToolbarStore,
-    tooltipContentOpts,
-    vaildTipOpts,
-    validOpts
-  } = _vm
+  const { isCtxMenu, isResizable, scrollbarHeight, selectToolbarStore, tooltipContentOpts, vaildTipOpts, validOpts } =
+    _vm
   const { selectToolbar, renderedToolbar } = $grid
 
   const renderHeader = () =>
     showHeader ? h(GridHeader, { ref: 'tableHeader', props, class: _vm.viewCls('tableHeader') }) : [null]
-  const renderEmptyPart = renderEmptyPartFn({ _vm, tableData, $slots, renderEmpty })
+  const renderEmptyPart = renderEmptyPartFn({ _vm, tableData })
   const renderFooter = renderFooterFn({ _vm, showFooter, footerData, footerMethod, tableColumn, visibleColumn, vSize })
   const renderResizeBar = renderResizeBarFn({ _vm, isResizable, overflowX, scrollbarHeight })
   const arg1 = { hasFilter, optimizeOpts, filterStore, isCtxMenu, ctxMenuStore, hasTip, tooltipContentOpts }


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `@opentiny/vue-grid` package to version `3.18.2`, which may include minor improvements and bug fixes.
  
- **Bug Fixes**
	- Enhanced the efficiency and clarity of grid-related property access in the table component, potentially improving performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->