### PR TITLE
fix(tooltip): [tooltip]Resolve issue with unclickable area caused by …

### DIFF
--- a/packages/theme/src/tooltip/index.less
+++ b/packages/theme/src/tooltip/index.less
@@ -75,6 +75,7 @@
 
         &::after {
           bottom: 1px;
+          overflow: hidden;
           margin-left: var(--ti-tooltip-popper-neg-border-width);
           border-top-color: var(--ti-tooltip-popper-border-color);
           border-bottom-width: 0;


### PR DESCRIPTION
…arrow in Tooltip component

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
When I click the 'Show Code' button, I sometimes find that the button does not trigger. The reason is that when the tooltip is positioned as 'top,' part of the button becomes unclickable due to the tooltip's arrow.

Before the fix: The button was unclickable in certain areas due to the tooltip's arrow when positioned at 'top.'
After the fix: The button is fully clickable, and the issue caused by the tooltip's arrow has been resolved.

### The red area is unclickable：
![3333](https://github.com/user-attachments/assets/2a9fe775-2a32-4ca0-8db2-b725e5432d9f)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
