### PR TITLE
fix(fluent-editor): fix link and img render error

### DIFF
--- a/packages/renderless/src/common/xss.ts
+++ b/packages/renderless/src/common/xss.ts
@@ -22,7 +22,7 @@ let xssOptions = {
   enableUrl: true,
   html: {
     whiteList: {
-      a: ['class', 'style', 'contenteditable', 'data-id', 'data-title', 'data-size', 'data-last-modified'],
+      a: ['class', 'style', 'contenteditable', 'data-id', 'data-title', 'data-size', 'data-last-modified', 'href'],
       address: ['class', 'style'],
       area: ['class', 'style'],
       article: ['class', 'style'],
@@ -74,7 +74,7 @@ let xssOptions = {
       header: ['class', 'style'],
       hr: ['class', 'style'],
       i: ['class', 'style', 'data-image-id', 'data-image'],
-      img: ['class', 'style', 'devui-editorx-image', 'style', 'data-image-id'],
+      img: ['class', 'style', 'devui-editorx-image', 'style', 'data-image-id', 'src'],
       input: ['class', 'style', 'data-formula', 'data-link', 'data-video'],
       ins: ['class', 'style'],
       li: ['class', 'style'],


### PR DESCRIPTION
# PR

https://github.com/opentiny/tiny-vue/blob/3e24748c27e20ee178c180db58bf95e974782b36/packages/renderless/src/fluent-editor/index.ts#L68

![image](https://github.com/user-attachments/assets/ef5e1118-fd70-49cc-b3cb-8eff842668c0)

原因是白名单里遗漏了 `<a href>` / `<img src>`

https://github.com/opentiny/tiny-vue/blob/3e24748c27e20ee178c180db58bf95e974782b36/packages/renderless/src/common/xss.ts#L25

https://github.com/opentiny/tiny-vue/blob/3e24748c27e20ee178c180db58bf95e974782b36/packages/renderless/src/common/xss.ts#L77


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2141

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced security configuration to allow `href` attributes for links and `src` attributes for images, improving flexibility in content handling while maintaining XSS protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->