### PR TITLE
fix(autocomplete): [autocomplete] fix form validate error when select…

### DIFF
--- a/packages/renderless/package.json
+++ b/packages/renderless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/vue-renderless",
-  "version": "3.18.4",
+  "version": "3.18.5",
   "private": true,
   "description": "An enterprise-class UI component library, support both Vue.js 2 and Vue.js 3, as well as PC and mobile.",
   "author": "OpenTiny Team",

--- a/packages/renderless/src/autocomplete/index.ts
+++ b/packages/renderless/src/autocomplete/index.ts
@@ -109,9 +109,9 @@ export const handleFocus =
 
 export const handleBlur =
   ({ emit, state, dispatch, props }: Pick<IAutoCompleteRenderlessParams, 'emit' | 'state' | 'dispatch' | 'props'>) =>
-  (event) => {
+  () => {
     state.suggestionDisabled = true
-    emit('blur', event)
+    emit('blur')
     if (state.validateEvent) {
       dispatch(FORM_ITEM, FORM_EVENT.blur, [props.modelValue])
     }
@@ -165,7 +165,8 @@ export const select =
     emit,
     nextTick,
     props,
-    state
+    state,
+    dispatch
   }: {
     emit: IAutoCompleteRenderlessParamUtils['emit']
     nextTick: IAutoCompleteRenderlessParamUtils['nextTick']
@@ -173,9 +174,13 @@ export const select =
     state: IAutoCompleteState
   }) =>
   (item) => {
-    emit('update:modelValue', item[props.valueKey])
+    const value = item[props.valueKey]
+    emit('update:modelValue', value)
     emit('select', item)
 
+    if (state.validateEvent) {
+      dispatch(FORM_ITEM, FORM_EVENT.change, [value])
+    }
     nextTick(() => {
       state.activated = false
       state.suggestions = []

--- a/packages/renderless/src/autocomplete/vue.ts
+++ b/packages/renderless/src/autocomplete/vue.ts
@@ -39,7 +39,6 @@ import type {
 
 export const api = [
   'state',
-  'select',
   'suggestionState',
   'getInput',
   'handleChange',
@@ -125,7 +124,7 @@ const initApi = ({
     mounted: mounted({ vm, state, suggestionState }),
     highlight: highlight({ constants, vm, state }),
     handleClear: handleClear({ emit, state }),
-    select: select({ emit, nextTick, props, state }),
+    select: select({ emit, nextTick, props, state, dispatch }),
     watchVisible: watchVisible({ suggestionState, vm }),
     handleChange: handleChange({ api, emit, state, props, dispatch }),
     handleFocus: handleFocus({ api, emit, props, state }),

--- a/packages/vue/src/autocomplete/package.json
+++ b/packages/vue/src/autocomplete/package.json
@@ -1,26 +1,26 @@
 {
   "name": "@opentiny/vue-autocomplete",
-  "version": "3.18.0",
+  "type": "module",
+  "version": "3.18.1",
   "description": "",
+  "license": "MIT",
+  "sideEffects": false,
   "main": "lib/index.js",
   "module": "index.ts",
-  "sideEffects": false,
-  "type": "module",
-  "devDependencies": {
-    "@opentiny-internal/vue-test-utils": "workspace:*",
-    "vitest": "^0.31.0"
-  },
   "scripts": {
     "build": "pnpm -w build:ui $npm_package_name",
     "//postversion": "pnpm build"
   },
   "dependencies": {
-    "@opentiny/vue-renderless": "workspace:~",
-    "@opentiny/vue-input": "workspace:~",
-    "@opentiny/vue-scrollbar": "workspace:~",
-    "@opentiny/vue-icon": "workspace:~",
     "@opentiny/vue-common": "workspace:~",
+    "@opentiny/vue-icon": "workspace:~",
+    "@opentiny/vue-input": "workspace:~",
+    "@opentiny/vue-renderless": "workspace:~",
+    "@opentiny/vue-scrollbar": "workspace:~",
     "@opentiny/vue-theme": "workspace:~"
   },
-  "license": "MIT"
+  "devDependencies": {
+    "@opentiny-internal/vue-test-utils": "workspace:*",
+    "vitest": "^0.31.0"
+  }
 }

--- a/packages/vue/src/autocomplete/src/pc.vue
+++ b/packages/vue/src/autocomplete/src/pc.vue
@@ -24,10 +24,10 @@
       ref="input"
       v-bind="f($props, $attrs)"
       front-clear-icon
+      v-clickoutside="handleBlur"
       @update:modelValue="handleChange"
       :validate-event="false"
       @focus="handleFocus"
-      @blur="handleBlur"
       @clear="handleClear"
       @keydown.up.prevent="highlight(state.highlightedIndex - 1)"
       @keydown.down.prevent="highlight(state.highlightedIndex + 1)"


### PR DESCRIPTION
… suggestion option

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

由于@blur是当鼠标点击时就触发，而选项面板中，是点击事件触发选中，点击事件是需要松开鼠标才会触发。
所以导致失焦先校验 -> 弹出校验框。 选中对应选项，弹窗消失。

修改方案：
将失焦事件触发改为click-outside，使得松开鼠标后才触发校验事件。
