### PR TITLE
fix(dialog-box): [dialog-box] destoryOnClose transition

### DIFF
--- a/packages/theme/src/dialog-box/index.less
+++ b/packages/theme/src/dialog-box/index.less
@@ -272,6 +272,9 @@
 }
 
 .dialog-fade-leave-active {
+  .tiny-dialog-box {
+      animation: dialog-fade-out 3s;
+    }
   animation: dialog-fade-out 0.3s;
 }
 

--- a/packages/theme/src/dialog-box/index.less
+++ b/packages/theme/src/dialog-box/index.less
@@ -272,7 +272,7 @@
 }
 
 .dialog-fade-leave-active {
-  .tiny-dialog-box {
+  @{dialog-box-prefix-cls} {
       animation: dialog-fade-out 3s;
     }
   animation: dialog-fade-out 0.3s;

--- a/packages/theme/src/dialog-box/index.less
+++ b/packages/theme/src/dialog-box/index.less
@@ -272,7 +272,7 @@
 }
 
 .dialog-fade-leave-active {
-  @{dialog-box-prefix-cls} {
+  .@{dialog-box-prefix-cls} {
       animation: dialog-fade-out 3s;
     }
   animation: dialog-fade-out 0.3s;

--- a/packages/vue/src/dialog-box/src/pc.vue
+++ b/packages/vue/src/dialog-box/src/pc.vue
@@ -18,7 +18,7 @@
       @mouseup="useMouseEventUp"
       @mousedown="useMouseEventDown"
     >
-      <transition :name="dialogTransition">
+      <transition :name="dialogTransition" :duration="3000">
         <div
           ref="dialog"
           v-show="visible"

--- a/packages/vue/src/dialog-box/src/pc.vue
+++ b/packages/vue/src/dialog-box/src/pc.vue
@@ -18,7 +18,7 @@
       @mouseup="useMouseEventUp"
       @mousedown="useMouseEventDown"
     >
-      <transition :name="dialogTransition" :duration="3000">
+      <transition :name="dialogTransition">
         <div
           ref="dialog"
           v-show="visible"


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2045 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

![fix-show](https://github.com/user-attachments/assets/4eada06a-7525-41d5-9e03-e6dcf87dbcab)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new fade-out animation for the dialog box, enhancing visual transitions with a duration of 3 seconds.

- **Improvements**
	- Ensured consistent application of the fade-out effect across different dialog instances.
	- Maintained responsive design for smaller screens without impacting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->