### PR TITLE
fix(cascader): [ cascader] fix active-node 's color and font-weight

### DIFF
--- a/packages/theme/src/cascader-node/vars.less
+++ b/packages/theme/src/cascader-node/vars.less
@@ -20,7 +20,7 @@
   // 下拉列表子项选中后悬浮时的背景色
   --tv-CascaderNode-selectable-hover-bg-color: var(--tv-color-bg, #f5f5f5);
   // 下拉列表子项选中时的文本色
-  --tv-CascaderNode-selectable-text-color: var(--tv-color-text, #191919);
+  --tv-CascaderNode-selectable-text-color: var(--tv-color-text-active, #1476ff);
   // 下拉列表子项禁用状态时的文本色
   --tv-CascaderNode-disabled-text-color: var(--tv-color-text-disabled, #c2c2c2);
   // 下拉列表子项禁用状态时的背景色
@@ -48,5 +48,5 @@
   // 下拉列表子项最大宽度
   --tv-CascaderNode-label-max-width: 107px;
   // 下拉列表子项高亮时字重
-  --tv-CascaderNode-active-font-weight: var(--tv-font-weight-regular, 400);
+  --tv-CascaderNode-active-font-weight: var(--tv-font-weight-bold, 600);
 }


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
修复高亮节点的颜色和字重

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visual styling for the Cascader Node component with updated hover text color and bold font weight for active items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->