### PR TITLE
fix(drawer): [drawer] modify the problem that the before-close method is triggered upon page loading is solved

### DIFF
--- a/examples/sites/demos/pc/app/drawer/before-close.spec.ts
+++ b/examples/sites/demos/pc/app/drawer/before-close.spec.ts
@@ -5,14 +5,14 @@ test('拦截弹窗关闭', async ({ page }) => {
   await page.goto('drawer#before-close')
 
   const drawer = page.locator('.tiny-drawer__main')
-  const message = page.locator('.tiny-modal.type__message')
+  const message = page.locator('.tiny-modal__text')
 
   await page.getByRole('button', { name: '点击展开 Drawer' }).click()
   await expect(drawer).toBeVisible()
 
   // 点击关闭按钮
   await page.getByRole('button', { name: 'Close' }).click()
-  await expect(message.nth(1)).toContainText('close')
+  await expect(message).toContainText('close')
   await expect(drawer).toBeVisible()
 
   // 点击遮罩层

--- a/packages/renderless/src/drawer/index.ts
+++ b/packages/renderless/src/drawer/index.ts
@@ -33,7 +33,7 @@ export const computedHeight =
 
 export const close =
   ({ api }: { api: IDrawerApi }) =>
-  (force = false) => {
+  (force = true) => {
     api.handleClose('close', typeof force === 'boolean' ? force : false)
   }
 


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The drawer will now close by default when the `close` method is invoked, enhancing usability.

- **Improvements**
	- Enhanced drag interactions with a debounce mechanism for smoother performance.
	- Added functions for managing scrollbar visibility, improving the user interface during drawer interactions.

- **Tests**
	- Updated test script for the drawer component to simplify message element identification and assertion checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->