### PR TITLE
fix(fluent-editor): fix export defaultToolbar error

### DIFF
--- a/packages/vue/src/fluent-editor/index.ts
+++ b/packages/vue/src/fluent-editor/index.ts
@@ -20,4 +20,6 @@ if (process.env.BUILD_TARGET === 'runtime') {
   }
 }
 
+export { defaultToolbar } from '@opentiny/vue-renderless/fluent-editor/options'
+
 export default FluentEditor

--- a/packages/vue/src/fluent-editor/package.json
+++ b/packages/vue/src/fluent-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/vue-fluent-editor",
-  "version": "3.18.3",
+  "version": "3.18.4",
   "description": "",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/vue/src/fluent-editor/src/index.ts
+++ b/packages/vue/src/fluent-editor/src/index.ts
@@ -68,8 +68,6 @@ export const fluentEditorProps = {
   }
 }
 
-export { defaultToolbar } from '@opentiny/vue-renderless/fluent-editor/options'
-
 export default defineComponent({
   name: $prefix + 'FluentEditor',
   props: fluentEditorProps,


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the export of `defaultToolbar` from the `fluent-editor` package, enhancing accessibility for users.
  
- **Version Updates**
	- Updated the package version for `@opentiny/vue-fluent-editor` from 3.18.3 to 3.18.4. 

- **Bug Fixes**
	- Removed the export of `defaultToolbar`, ensuring clarity in available features and maintaining existing functionality of the `FluentEditor` component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->