### PR TITLE
chore(fluent-editor): remove meta experimental

### DIFF
--- a/examples/sites/demos/pc/app/fluent-editor/webdoc/fluent-editor.cn.md
+++ b/examples/sites/demos/pc/app/fluent-editor/webdoc/fluent-editor.cn.md
@@ -4,4 +4,4 @@ title: FluentEditor 富文本
 
 # FluentEditor 富文本
 
-<div>用于创建和编辑富文本内容。</div>
+<div>基于框架无关的 <a href="https://opentiny.github.io/fluent-editor/" target="_blank">@opentiny/fluent-editor</a> 富文本，用于创建和编辑富文本内容。</div>

--- a/examples/sites/demos/pc/app/fluent-editor/webdoc/fluent-editor.js
+++ b/examples/sites/demos/pc/app/fluent-editor/webdoc/fluent-editor.js
@@ -1,9 +1,6 @@
 export default {
   column: '2',
   owner: '',
-  meta: {
-    experimental: '3.17.0'
-  },
   demos: [
     {
       demoId: 'basic-usage',

--- a/examples/sites/demos/pc/menus.js
+++ b/examples/sites/demos/pc/menus.js
@@ -134,14 +134,7 @@ export const cmpMenus = [
       { 'nameCn': '日期选择器', 'name': 'DatePicker', 'key': 'date-picker' },
       { 'nameCn': '下拉时间', 'name': 'DropTimes', 'key': 'drop-times' },
       { 'nameCn': '文件上传', 'name': 'FileUpload', 'key': 'file-upload' },
-      {
-        'nameCn': '富文本',
-        'name': 'FluentEditor',
-        'key': 'fluent-editor',
-        'meta': {
-          'experimental': '3.17.0'
-        }
-      },
+      { 'nameCn': '富文本', 'name': 'FluentEditor', 'key': 'fluent-editor' },
       { 'nameCn': '表单', 'name': 'Form', 'key': 'form' },
       { 'nameCn': '输入框', 'name': 'Input', 'key': 'input' },
       { 'nameCn': ' IP地址输入框', 'name': 'IpAddress', 'key': 'ip-address' },


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the FluentEditor description to highlight its framework-agnostic nature and added a link to the official documentation.
	- Introduced a new menu category labeled '业务组件' (Business Components) with various business-related components.

- **Bug Fixes**
	- Removed the experimental `meta` property from the FluentEditor entry and the menus, simplifying the component metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->