### PR TITLE
fix(tag): update tag's size when only icon, update one place of button's size

### DIFF
--- a/examples/sites/demos/pc/app/tag/size-composition-api.vue
+++ b/examples/sites/demos/pc/app/tag/size-composition-api.vue
@@ -4,11 +4,19 @@
     <tiny-tag type="success"> 默认标签 </tiny-tag>
     <tiny-tag size="small" type="success"> 小型标签 </tiny-tag>
     <tiny-tag size="mini" type="success"> 超小标签 </tiny-tag>
+    <br /><br />
+    <tiny-tag size="medium" type="success" only-icon> <tiny-icon-heartempty /> </tiny-tag>
+    <tiny-tag type="success" only-icon> <tiny-icon-heartempty /> </tiny-tag>
+    <tiny-tag size="small" type="success" only-icon> <tiny-icon-heartempty /> </tiny-tag>
+    <tiny-tag size="mini" type="success" only-icon> <tiny-icon-heartempty /> </tiny-tag>
   </div>
 </template>
 
 <script setup lang="jsx">
 import { TinyTag } from '@opentiny/vue'
+import { IconHeartempty } from '@opentiny/vue-icon'
+
+const TinyIconHeartempty = IconHeartempty()
 </script>
 
 <style>

--- a/examples/sites/demos/pc/app/tag/size.vue
+++ b/examples/sites/demos/pc/app/tag/size.vue
@@ -4,15 +4,22 @@
     <tiny-tag type="success"> 默认标签 </tiny-tag>
     <tiny-tag size="small" type="success"> 小型标签 </tiny-tag>
     <tiny-tag size="mini" type="success"> 超小标签 </tiny-tag>
+    <br /><br />
+    <tiny-tag size="medium" type="success" only-icon> <tiny-icon-heartempty /> </tiny-tag>
+    <tiny-tag type="success" only-icon> <tiny-icon-heartempty /> </tiny-tag>
+    <tiny-tag size="small" type="success" only-icon> <tiny-icon-heartempty /> </tiny-tag>
+    <tiny-tag size="mini" type="success" only-icon> <tiny-icon-heartempty /> </tiny-tag>
   </div>
 </template>
 
 <script lang="jsx">
 import { TinyTag } from '@opentiny/vue'
+import { IconHeartempty } from '@opentiny/vue-icon'
 
 export default {
   components: {
-    TinyTag
+    TinyTag,
+    TinyIconHeartempty: IconHeartempty()
   }
 }
 </script>

--- a/examples/sites/demos/pc/app/tag/webdoc/tag.js
+++ b/examples/sites/demos/pc/app/tag/webdoc/tag.js
@@ -11,11 +11,13 @@ export default {
       desc: {
         'zh-CN': `
           通过默认插槽，可以将文字和图标显示为一个标签。 <br>
-          通过 <code>value</code> 属性，也可以设置标签值。
+          通过 <code>value</code> 属性，也可以设置标签值。 <br>
+          通过 <code>only-icon</code> 属性，设置标签只有图标。
         `,
         'en-US': `
           Through the default slot, text and ICONS can be displayed as a label. <br>
-          Tag values can also be set using the <code>value</code> property.
+          Tag values can also be set using the <code>value</code> property. <br>
+          Use the <code>only-icon</code> property to set the label to only ICONS.
         `
       },
       codeFiles: ['basic-usage.vue']

--- a/packages/design/aurora/index.ts
+++ b/packages/design/aurora/index.ts
@@ -27,7 +27,6 @@ import Pager from './src/pager'
 import Wizard from './src/wizard'
 import DialogBox from './src/dialog-box'
 import Popeditor from './src/popeditor'
-import DialogSelect from './src/dialog-select'
 import { version } from './package.json'
 
 export default {
@@ -62,7 +61,6 @@ export default {
     Pager,
     Wizard,
     DialogBox,
-    Popeditor,
-    DialogSelect
+    Popeditor
   }
 }

--- a/packages/modules.json
+++ b/packages/modules.json
@@ -3,7 +3,9 @@
     "path": "vue/src/action-menu/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "ActionMenuPc": {
     "path": "vue/src/action-menu/src/pc.vue",
@@ -14,7 +16,10 @@
     "path": "vue/src/action-sheet/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile"]
+    "mode": [
+      "mobile-first",
+      "mobile"
+    ]
   },
   "ActionSheetMobile": {
     "path": "vue/src/action-sheet/src/mobile.vue",
@@ -30,7 +35,11 @@
     "path": "vue/src/alert/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "AlertMobile": {
     "path": "vue/src/alert/src/mobile.vue",
@@ -51,7 +60,10 @@
     "path": "vue/src/amount/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "AmountMobileFirst": {
     "path": "vue/src/amount/src/mobile-first.vue",
@@ -67,7 +79,10 @@
     "path": "vue/src/anchor/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "AnchorMobileFirst": {
     "path": "vue/src/anchor/src/mobile-first.vue",
@@ -83,7 +98,9 @@
     "path": "vue/src/area/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "AreaPc": {
     "path": "vue/src/area/src/pc.vue",
@@ -94,7 +111,9 @@
     "path": "vue/src/async-flowchart/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "AsyncFlowchartMobileFirst": {
     "path": "vue/src/async-flowchart/src/mobile-first.vue",
@@ -105,7 +124,9 @@
     "path": "vue/src/autocomplete/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "AutocompletePc": {
     "path": "vue/src/autocomplete/src/pc.vue",
@@ -116,13 +137,19 @@
     "path": "vue/src/avatar/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile"]
+    "mode": [
+      "mobile"
+    ]
   },
   "Badge": {
     "path": "vue/src/badge/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "BadgeMobile": {
     "path": "vue/src/badge/src/mobile.vue",
@@ -143,7 +170,10 @@
     "path": "vue/src/base-select/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "BaseSelectMobileFirst": {
     "path": "vue/src/base-select/src/mobile-first.vue",
@@ -159,13 +189,17 @@
     "path": "vue/src/breadcrumb/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "BreadcrumbItem": {
     "path": "vue/src/breadcrumb-item/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "BreadcrumbItemPc": {
     "path": "vue/src/breadcrumb-item/src/pc.vue",
@@ -181,7 +215,9 @@
     "path": "vue/src/bulletin-board/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "BulletinBoardPc": {
     "path": "vue/src/bulletin-board/src/pc.vue",
@@ -192,13 +228,19 @@
     "path": "vue/src/button/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "ButtonGroup": {
     "path": "vue/src/button-group/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "ButtonGroupPc": {
     "path": "vue/src/button-group/src/pc.vue",
@@ -224,13 +266,17 @@
     "path": "vue/src/calendar/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "CalendarBar": {
     "path": "vue/src/calendar-bar/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "CalendarBarMobileFirst": {
     "path": "vue/src/calendar-bar/src/mobile-first.vue",
@@ -246,7 +292,10 @@
     "path": "vue/src/calendar-view/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "CalendarViewMobileFirst": {
     "path": "vue/src/calendar-view/src/mobile-first.vue",
@@ -262,13 +311,19 @@
     "path": "vue/src/card/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "CardGroup": {
     "path": "vue/src/card-group/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "CardGroupMobileFirst": {
     "path": "vue/src/card-group/src/mobile-first.vue",
@@ -294,7 +349,9 @@
     "path": "vue/src/card-template/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "CardTemplatePc": {
     "path": "vue/src/card-template/src/pc.vue",
@@ -305,13 +362,19 @@
     "path": "vue/src/carousel/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "CarouselItem": {
     "path": "vue/src/carousel-item/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "CarouselItemMobileFirst": {
     "path": "vue/src/carousel-item/src/mobile-first.vue",
@@ -337,13 +400,19 @@
     "path": "vue/src/cascader/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "CascaderMenu": {
     "path": "vue/src/cascader-menu/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "CascaderMenuMobileFirst": {
     "path": "vue/src/cascader-menu/src/mobile-first.vue",
@@ -359,7 +428,9 @@
     "path": "vue/src/cascader-mobile/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "CascaderMobileFirst": {
     "path": "vue/src/cascader/src/mobile-first.vue",
@@ -370,7 +441,10 @@
     "path": "vue/src/cascader-node/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "CascaderNodeMobileFirst": {
     "path": "vue/src/cascader-node/src/mobile-first.vue",
@@ -386,7 +460,10 @@
     "path": "vue/src/cascader-panel/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "CascaderPanelMobileFirst": {
     "path": "vue/src/cascader-panel/src/mobile-first.vue",
@@ -407,7 +484,9 @@
     "path": "vue/src/cascader-select/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "CascaderSelectMobileFirst": {
     "path": "vue/src/cascader-select/src/mobile-first.vue",
@@ -418,25 +497,35 @@
     "path": "vue/src/cascader-view/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "Cell": {
     "path": "vue/src/cell/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "Checkbox": {
     "path": "vue/src/checkbox/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "CheckboxButton": {
     "path": "vue/src/checkbox-button/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "CheckboxButtonPc": {
     "path": "vue/src/checkbox-button/src/pc.vue",
@@ -447,7 +536,11 @@
     "path": "vue/src/checkbox-group/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "CheckboxGroupMobile": {
     "path": "vue/src/checkbox-group/src/mobile.vue",
@@ -483,7 +576,9 @@
     "path": "vue/src/col/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "ColPc": {
     "path": "vue/src/col/src/pc.vue",
@@ -494,13 +589,19 @@
     "path": "vue/src/collapse/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "CollapseItem": {
     "path": "vue/src/collapse-item/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "CollapseItemMobileFirst": {
     "path": "vue/src/collapse-item/src/mobile-first.vue",
@@ -526,13 +627,18 @@
     "path": "vue/src/collapse-transition/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "ColorPicker": {
     "path": "vue/src/color-picker/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile", "pc"]
+    "mode": [
+      "mobile",
+      "pc"
+    ]
   },
   "ColorPickerMobile": {
     "path": "vue/src/color-picker/src/mobile.vue",
@@ -548,7 +654,9 @@
     "path": "vue/src/color-select-panel/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "ColorSelectPanelPc": {
     "path": "vue/src/color-select-panel/src/pc.vue",
@@ -559,13 +667,17 @@
     "path": "vue/src/column-list-group/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "ColumnListItem": {
     "path": "vue/src/column-list-item/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "Common": {
     "path": "vue-common/src/index.ts",
@@ -576,7 +688,9 @@
     "path": "vue/src/company/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "CompanyPc": {
     "path": "vue/src/company/src/pc.vue",
@@ -592,7 +706,10 @@
     "path": "vue/src/container/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile", "pc"]
+    "mode": [
+      "mobile",
+      "pc"
+    ]
   },
   "ContainerMobile": {
     "path": "vue/src/container/src/mobile.vue",
@@ -608,7 +725,9 @@
     "path": "vue/src/country/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "CountryPc": {
     "path": "vue/src/country/src/pc.vue",
@@ -619,13 +738,18 @@
     "path": "vue/src/crop/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "Currency": {
     "path": "vue/src/currency/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "CurrencyMobileFirst": {
     "path": "vue/src/currency/src/mobile-first.vue",
@@ -641,7 +765,10 @@
     "path": "vue/src/date-panel/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "DatePanelMobileFirst": {
     "path": "vue/src/date-panel/src/mobile-first.vue",
@@ -657,7 +784,10 @@
     "path": "vue/src/date-picker/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile", "pc"]
+    "mode": [
+      "mobile",
+      "pc"
+    ]
   },
   "DatePickerMobile": {
     "path": "vue/src/date-picker/src/mobile.vue",
@@ -678,7 +808,10 @@
     "path": "vue/src/date-range/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "DateRangeMobileFirst": {
     "path": "vue/src/date-range/src/mobile-first.vue",
@@ -694,7 +827,10 @@
     "path": "vue/src/date-table/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "DateTableMobileFirst": {
     "path": "vue/src/date-table/src/mobile-first.vue",
@@ -710,7 +846,9 @@
     "path": "vue/src/dept/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "DeptPc": {
     "path": "vue/src/dept/src/pc.vue",
@@ -727,16 +865,15 @@
     "type": "module",
     "exclude": false
   },
-  "DesignSmb": {
-    "path": "design/smb/index.ts",
-    "type": "module",
-    "exclude": false
-  },
   "DialogBox": {
     "path": "vue/src/dialog-box/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "DialogBoxMobile": {
     "path": "vue/src/dialog-box/src/mobile.vue",
@@ -757,7 +894,9 @@
     "path": "vue/src/dialog-select/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "DialogSelectPc": {
     "path": "vue/src/dialog-select/src/pc.vue",
@@ -773,7 +912,9 @@
     "path": "vue/src/divider/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "DividerPc": {
     "path": "vue/src/divider/src/pc.vue",
@@ -784,7 +925,10 @@
     "path": "vue/src/drawer/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "DrawerMobileFirst": {
     "path": "vue/src/drawer/src/mobile-first.vue",
@@ -800,7 +944,9 @@
     "path": "vue/src/drop-roles/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "DropRolesPc": {
     "path": "vue/src/drop-roles/src/pc.vue",
@@ -811,7 +957,9 @@
     "path": "vue/src/drop-times/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "DropTimesPc": {
     "path": "vue/src/drop-times/src/pc.vue",
@@ -822,13 +970,20 @@
     "path": "vue/src/dropdown/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "DropdownItem": {
     "path": "vue/src/dropdown-item/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "DropdownItemMobile": {
     "path": "vue/src/dropdown-item/src/mobile.vue",
@@ -849,7 +1004,11 @@
     "path": "vue/src/dropdown-menu/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "DropdownMenuMobile": {
     "path": "vue/src/dropdown-menu/src/mobile.vue",
@@ -880,13 +1039,17 @@
     "path": "vue/src/dynamic-scroller/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "DynamicScrollerItem": {
     "path": "vue/src/dynamic-scroller-item/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "DynamicScrollerItemPc": {
     "path": "vue/src/dynamic-scroller-item/src/pc.vue",
@@ -902,7 +1065,9 @@
     "path": "vue/src/espace/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "EspacePc": {
     "path": "vue/src/espace/src/pc.vue",
@@ -913,7 +1078,10 @@
     "path": "vue/src/exception/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile"]
+    "mode": [
+      "mobile-first",
+      "mobile"
+    ]
   },
   "ExceptionMobile": {
     "path": "vue/src/exception/src/mobile.vue",
@@ -929,7 +1097,9 @@
     "path": "vue/src/fall-menu/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "FallMenuPc": {
     "path": "vue/src/fall-menu/src/pc.vue",
@@ -940,7 +1110,11 @@
     "path": "vue/src/file-upload/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "FileUploadMobile": {
     "path": "vue/src/file-upload/src/mobile.vue",
@@ -961,13 +1135,17 @@
     "path": "vue/src/filter/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "FilterBar": {
     "path": "vue/src/filter-bar/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "FilterBarMobileFirst": {
     "path": "vue/src/filter-bar/src/mobile-first.vue",
@@ -978,7 +1156,9 @@
     "path": "vue/src/filter-box/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "FilterMobileFirst": {
     "path": "vue/src/filter/src/mobile-first.vue",
@@ -989,13 +1169,17 @@
     "path": "vue/src/filter-panel/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "FloatButton": {
     "path": "vue/src/float-button/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "FloatButtonPc": {
     "path": "vue/src/float-button/src/pc.vue",
@@ -1006,7 +1190,9 @@
     "path": "vue/src/floatbar/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "FloatbarPc": {
     "path": "vue/src/floatbar/src/pc.vue",
@@ -1017,7 +1203,9 @@
     "path": "vue/src/floating-button/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "FloatingButtonMobileFirst": {
     "path": "vue/src/floating-button/src/mobile-first.vue",
@@ -1028,7 +1216,10 @@
     "path": "vue/src/flowchart/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "FlowchartMobileFirst": {
     "path": "vue/src/flowchart/src/mobile-first.vue",
@@ -1044,7 +1235,10 @@
     "path": "vue/src/fluent-editor/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "FluentEditorMobileFirst": {
     "path": "vue/src/fluent-editor/src/mobile-first.vue",
@@ -1060,13 +1254,20 @@
     "path": "vue/src/form/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "FormItem": {
     "path": "vue/src/form-item/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "FormItemLabelWrap": {
     "path": "vue/src/form-item/src/label-wrap.ts",
@@ -1102,7 +1303,9 @@
     "path": "vue/src/fullscreen/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "Grid": {
     "path": "vue/src/grid/index.ts",
@@ -1128,7 +1331,9 @@
     "path": "vue/src/guide/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "GuidePc": {
     "path": "vue/src/guide/src/pc.vue",
@@ -1144,7 +1349,9 @@
     "path": "vue/src/hrapprover/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "HrapproverPc": {
     "path": "vue/src/hrapprover/src/pc.vue",
@@ -1281,13 +1488,13 @@
     "type": "module",
     "exclude": false
   },
-  "IconSaas": {
-    "path": "vue-icon-saas/index.ts",
+  "IconMulticolor": {
+    "path": "vue-icon-multicolor/index.ts",
     "type": "module",
     "exclude": false
   },
-  "IconMulticolor": {
-    "path": "vue-icon-multicolor/index.ts",
+  "IconSaas": {
+    "path": "vue-icon-saas/index.ts",
     "type": "module",
     "exclude": false
   },
@@ -1295,7 +1502,10 @@
     "path": "vue/src/image/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "ImageMobileFirst": {
     "path": "vue/src/image/src/mobile-first.vue",
@@ -1311,7 +1521,11 @@
     "path": "vue/src/image-viewer/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "ImageViewerMobile": {
     "path": "vue/src/image-viewer/src/mobile.vue",
@@ -1332,7 +1546,9 @@
     "path": "vue/src/index-bar/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile"]
+    "mode": [
+      "mobile"
+    ]
   },
   "IndexBarAnchor": {
     "path": "vue/src/index-bar-anchor/index.ts",
@@ -1348,7 +1564,11 @@
     "path": "vue/src/input/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "InputMobile": {
     "path": "vue/src/input/src/mobile.vue",
@@ -1374,7 +1594,9 @@
     "path": "vue/src/ip-address/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "IpAddressPc": {
     "path": "vue/src/ip-address/src/pc.vue",
@@ -1385,7 +1607,9 @@
     "path": "vue/src/label/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile"]
+    "mode": [
+      "mobile"
+    ]
   },
   "LabelMobile": {
     "path": "vue/src/label/src/mobile.vue",
@@ -1396,7 +1620,9 @@
     "path": "vue/src/layout/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "LayoutPc": {
     "path": "vue/src/layout/src/pc.vue",
@@ -1407,13 +1633,17 @@
     "path": "vue/src/link/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "LinkMenu": {
     "path": "vue/src/link-menu/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "LinkMenuPc": {
     "path": "vue/src/link-menu/src/pc.vue",
@@ -1429,13 +1659,17 @@
     "path": "vue/src/list/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile"]
+    "mode": [
+      "mobile"
+    ]
   },
   "LoadList": {
     "path": "vue/src/load-list/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "LoadListMobileFirst": {
     "path": "vue/src/load-list/src/mobile-first.vue",
@@ -1446,7 +1680,11 @@
     "path": "vue/src/loading/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "LoadingMobile": {
     "path": "vue/src/loading/src/mobile.vue",
@@ -1472,19 +1710,25 @@
     "path": "vue/src/locales/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "LogonUser": {
     "path": "vue/src/logon-user/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "Logout": {
     "path": "vue/src/logout/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "LogoutPc": {
     "path": "vue/src/logout/src/pc.vue",
@@ -1495,13 +1739,17 @@
     "path": "vue/src/mask/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile"]
+    "mode": [
+      "mobile"
+    ]
   },
   "Menu": {
     "path": "vue/src/menu/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "Message": {
     "path": "vue/src/message/index.ts",
@@ -1512,7 +1760,9 @@
     "path": "vue/src/milestone/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "MilestonePc": {
     "path": "vue/src/milestone/src/pc.vue",
@@ -1523,7 +1773,9 @@
     "path": "vue/src/mind-map/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "MindMapPc": {
     "path": "vue/src/mind-map/src/pc.vue",
@@ -1534,13 +1786,19 @@
     "path": "vue/src/mini-picker/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile"]
+    "mode": [
+      "mobile"
+    ]
   },
   "Modal": {
     "path": "vue/src/modal/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "ModalMobile": {
     "path": "vue/src/modal/src/mobile.vue",
@@ -1561,25 +1819,33 @@
     "path": "vue/src/month-range/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "MonthTable": {
     "path": "vue/src/month-table/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "MultiSelect": {
     "path": "vue/src/multi-select/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile"]
+    "mode": [
+      "mobile"
+    ]
   },
   "MultiSelectItem": {
     "path": "vue/src/multi-select-item/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile"]
+    "mode": [
+      "mobile"
+    ]
   },
   "MultiSelectItemMobile": {
     "path": "vue/src/multi-select-item/src/mobile.vue",
@@ -1595,13 +1861,17 @@
     "path": "vue/src/nav-bar/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile"]
+    "mode": [
+      "mobile"
+    ]
   },
   "NavMenu": {
     "path": "vue/src/nav-menu/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "NavMenuPc": {
     "path": "vue/src/nav-menu/src/pc.vue",
@@ -1612,13 +1882,19 @@
     "path": "vue/src/notify/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "Numeric": {
     "path": "vue/src/numeric/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "NumericMobile": {
     "path": "vue/src/numeric/src/mobile.vue",
@@ -1639,13 +1915,19 @@
     "path": "vue/src/option/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "OptionGroup": {
     "path": "vue/src/option-group/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "OptionGroupMobileFirst": {
     "path": "vue/src/option-group/src/mobile-first.vue",
@@ -1671,13 +1953,19 @@
     "path": "vue/src/pager/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "PagerItem": {
     "path": "vue/src/pager-item/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "PagerItemMobileFirst": {
     "path": "vue/src/pager-item/src/mobile-first.vue",
@@ -1703,7 +1991,9 @@
     "path": "vue/src/panel/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "PanelPc": {
     "path": "vue/src/panel/src/pc.vue",
@@ -1714,13 +2004,18 @@
     "path": "vue/src/picker/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "PickerColumn": {
     "path": "vue/src/picker-column/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile"]
+    "mode": [
+      "mobile"
+    ]
   },
   "PickerMobileFirst": {
     "path": "vue/src/picker/src/mobile-first.vue",
@@ -1736,7 +2031,9 @@
     "path": "vue/src/pop-upload/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "PopUploadPc": {
     "path": "vue/src/pop-upload/src/pc.vue",
@@ -1747,7 +2044,10 @@
     "path": "vue/src/popconfirm/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "PopconfirmMobileFirst": {
     "path": "vue/src/popconfirm/src/mobile-first.vue",
@@ -1763,7 +2063,9 @@
     "path": "vue/src/popeditor/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "PopeditorPc": {
     "path": "vue/src/popeditor/src/pc.vue",
@@ -1774,7 +2076,11 @@
     "path": "vue/src/popover/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "PopoverMobile": {
     "path": "vue/src/popover/src/mobile.vue",
@@ -1795,13 +2101,19 @@
     "path": "vue/src/popup/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "Progress": {
     "path": "vue/src/progress/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "ProgressMobile": {
     "path": "vue/src/progress/src/mobile.vue",
@@ -1822,7 +2134,10 @@
     "path": "vue/src/pull-refresh/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile"]
+    "mode": [
+      "mobile-first",
+      "mobile"
+    ]
   },
   "PullRefreshMobile": {
     "path": "vue/src/pull-refresh/src/mobile.vue",
@@ -1838,31 +2153,44 @@
     "path": "vue/src/qr-code/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "QuarterPanel": {
     "path": "vue/src/quarter-panel/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "QueryBuilder": {
     "path": "vue/src/query-builder/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "Radio": {
     "path": "vue/src/radio/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "RadioButton": {
     "path": "vue/src/radio-button/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "RadioButtonMobileFirst": {
     "path": "vue/src/radio-button/src/mobile-first.vue",
@@ -1878,7 +2206,10 @@
     "path": "vue/src/radio-group/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "RadioGroupMobileFirst": {
     "path": "vue/src/radio-group/src/mobile-first.vue",
@@ -1909,7 +2240,10 @@
     "path": "vue/src/rate/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "RateMobileFirst": {
     "path": "vue/src/rate/src/mobile-first.vue",
@@ -1925,7 +2259,9 @@
     "path": "vue/src/record/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "RecordMobileFirst": {
     "path": "vue/src/record/src/mobile-first.vue",
@@ -1936,7 +2272,9 @@
     "path": "vue/src/recycle-scroller/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "RecycleScrollerPc": {
     "path": "vue/src/recycle-scroller/src/pc.vue",
@@ -1947,19 +2285,25 @@
     "path": "vue/src/rich-text/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "RichTextEditor": {
     "path": "vue/src/rich-text-editor/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "River": {
     "path": "vue/src/river/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "RiverPc": {
     "path": "vue/src/river/src/pc.vue",
@@ -1970,7 +2314,9 @@
     "path": "vue/src/roles/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "RolesPc": {
     "path": "vue/src/roles/src/pc.vue",
@@ -1981,7 +2327,9 @@
     "path": "vue/src/row/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "RowPc": {
     "path": "vue/src/row/src/pc.vue",
@@ -1997,7 +2345,9 @@
     "path": "vue/src/scroll-text/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "ScrollTextPc": {
     "path": "vue/src/scroll-text/src/pc.vue",
@@ -2008,13 +2358,19 @@
     "path": "vue/src/scrollbar/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "Search": {
     "path": "vue/src/search/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "SearchMobile": {
     "path": "vue/src/search/src/mobile.vue",
@@ -2035,13 +2391,19 @@
     "path": "vue/src/select/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "SelectDropdown": {
     "path": "vue/src/select-dropdown/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "SelectDropdownMobileFirst": {
     "path": "vue/src/select-dropdown/src/mobile-first.vue",
@@ -2057,7 +2419,9 @@
     "path": "vue/src/select-mobile/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "SelectMobileFirst": {
     "path": "vue/src/select/src/mobile-first.vue",
@@ -2073,13 +2437,18 @@
     "path": "vue/src/select-view/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "SelectedBox": {
     "path": "vue/src/selected-box/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "SelectedBoxMobileFirst": {
     "path": "vue/src/selected-box/src/mobile-first.vue",
@@ -2095,7 +2464,9 @@
     "path": "vue/src/signature/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "SignatureMobileFirst": {
     "path": "vue/src/signature/src/mobile-first.vue",
@@ -2106,13 +2477,17 @@
     "path": "vue/src/skeleton/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "SkeletonItem": {
     "path": "vue/src/skeleton-item/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "SkeletonItemPc": {
     "path": "vue/src/skeleton-item/src/pc.vue",
@@ -2128,19 +2503,27 @@
     "path": "vue/src/slider/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "SliderButton": {
     "path": "vue/src/slider-button/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "SliderButtonGroup": {
     "path": "vue/src/slider-button-group/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "SliderButtonGroupMobileFirst": {
     "path": "vue/src/slider-button-group/src/mobile-first.vue",
@@ -2171,7 +2554,9 @@
     "path": "vue/src/split/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "SplitPc": {
     "path": "vue/src/split/src/pc.vue",
@@ -2182,13 +2567,17 @@
     "path": "vue/src/standard-list-item/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "Statistic": {
     "path": "vue/src/statistic/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "StatisticPc": {
     "path": "vue/src/statistic/src/pc.vue",
@@ -2199,7 +2588,10 @@
     "path": "vue/src/steps/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "StepsMobileFirst": {
     "path": "vue/src/steps/src/mobile-first.vue",
@@ -2215,7 +2607,10 @@
     "path": "vue/src/sticky/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "StickyMobileFirst": {
     "path": "vue/src/sticky/src/mobile-first.vue",
@@ -2231,7 +2626,11 @@
     "path": "vue/src/switch/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "SwitchMobile": {
     "path": "vue/src/switch/src/mobile.vue",
@@ -2252,7 +2651,10 @@
     "path": "vue/src/tab-item/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "TabItemMobileFirst": {
     "path": "vue/src/tab-item/src/mobile-first.vue",
@@ -2268,13 +2670,19 @@
     "path": "vue/src/tabbar/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile"]
+    "mode": [
+      "mobile-first",
+      "mobile"
+    ]
   },
   "TabbarItem": {
     "path": "vue/src/tabbar-item/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile"]
+    "mode": [
+      "mobile-first",
+      "mobile"
+    ]
   },
   "TabbarItemMobile": {
     "path": "vue/src/tabbar-item/src/mobile.vue",
@@ -2300,7 +2708,10 @@
     "path": "vue/src/table/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile", "pc"]
+    "mode": [
+      "mobile",
+      "pc"
+    ]
   },
   "TableMobile": {
     "path": "vue/src/table/src/mobile.vue",
@@ -2316,7 +2727,11 @@
     "path": "vue/src/tabs/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "TabsMobile": {
     "path": "vue/src/tabs/src/mobile.vue",
@@ -2337,13 +2752,20 @@
     "path": "vue/src/tag/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "TagGroup": {
     "path": "vue/src/tag-group/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "TagGroupMobileFirst": {
     "path": "vue/src/tag-group/src/mobile-first.vue",
@@ -2374,7 +2796,9 @@
     "path": "vue/src/text-popup/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "TextPopupPc": {
     "path": "vue/src/text-popup/src/pc.vue",
@@ -2385,13 +2809,20 @@
     "path": "vue/src/time/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "TimeLine": {
     "path": "vue/src/time-line/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "TimeLineMobile": {
     "path": "vue/src/time-line/src/mobile.vue",
@@ -2407,7 +2838,11 @@
     "path": "vue/src/time-line-new/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "TimeLineNewMobile": {
     "path": "vue/src/time-line-new/src/mobile.vue",
@@ -2438,7 +2873,10 @@
     "path": "vue/src/time-panel/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "TimePanelMobileFirst": {
     "path": "vue/src/time-panel/src/mobile-first.vue",
@@ -2459,31 +2897,42 @@
     "path": "vue/src/time-picker/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "TimePickerMobile": {
     "path": "vue/src/time-picker-mobile/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "TimeRange": {
     "path": "vue/src/time-range/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "TimeSelect": {
     "path": "vue/src/time-select/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "TimeSpinner": {
     "path": "vue/src/time-spinner/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "TimeSpinnerMobileFirst": {
     "path": "vue/src/time-spinner/src/mobile-first.vue",
@@ -2499,7 +2948,9 @@
     "path": "vue/src/timeline-item/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "TimelineItemPc": {
     "path": "vue/src/timeline-item/src/pc.vue",
@@ -2510,7 +2961,9 @@
     "path": "vue/src/toast/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile"]
+    "mode": [
+      "mobile"
+    ]
   },
   "ToastMobile": {
     "path": "vue/src/toast/src/mobile.vue",
@@ -2521,7 +2974,9 @@
     "path": "vue/src/toggle-menu/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "ToggleMenuPc": {
     "path": "vue/src/toggle-menu/src/pc.vue",
@@ -2532,7 +2987,10 @@
     "path": "vue/src/tooltip/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "TooltipMobileFirst": {
     "path": "vue/src/tooltip/src/mobile-first.vue",
@@ -2548,7 +3006,9 @@
     "path": "vue/src/top-box/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "TopBoxPc": {
     "path": "vue/src/top-box/src/pc.vue",
@@ -2559,13 +3019,17 @@
     "path": "vue/src/transfer/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "TransferPanel": {
     "path": "vue/src/transfer-panel/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "TransferPc": {
     "path": "vue/src/transfer/src/pc.vue",
@@ -2576,13 +3040,17 @@
     "path": "vue/src/tree/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "TreeMenu": {
     "path": "vue/src/tree-menu/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "TreeMenuPc": {
     "path": "vue/src/tree-menu/src/pc.vue",
@@ -2598,19 +3066,27 @@
     "path": "vue/src/tree-select/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "Upload": {
     "path": "vue/src/upload/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "UploadDragger": {
     "path": "vue/src/upload-dragger/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "UploadDraggerMobileFirst": {
     "path": "vue/src/upload-dragger/src/mobile-first.vue",
@@ -2626,7 +3102,11 @@
     "path": "vue/src/upload-list/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "UploadListMobile": {
     "path": "vue/src/upload-list/src/mobile.vue",
@@ -2657,13 +3137,17 @@
     "path": "vue/src/user/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "UserAccount": {
     "path": "vue/src/user-account/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "UserAccountPc": {
     "path": "vue/src/user-account/src/pc.vue",
@@ -2674,7 +3158,9 @@
     "path": "vue/src/user-contact/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "UserContactPc": {
     "path": "vue/src/user-contact/src/pc.vue",
@@ -2685,13 +3171,19 @@
     "path": "vue/src/user-head/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "mobile", "pc"]
+    "mode": [
+      "mobile-first",
+      "mobile",
+      "pc"
+    ]
   },
   "UserHeadGroup": {
     "path": "vue/src/user-head-group/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first"]
+    "mode": [
+      "mobile-first"
+    ]
   },
   "UserHeadGroupMobileFirst": {
     "path": "vue/src/user-head-group/src/mobile-first.vue",
@@ -2717,7 +3209,9 @@
     "path": "vue/src/user-link/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "UserLinkPc": {
     "path": "vue/src/user-link/src/pc.vue",
@@ -2733,7 +3227,9 @@
     "path": "vue/src/virtual-scroll-box/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "VirtualScrollBoxPc": {
     "path": "vue/src/virtual-scroll-box/src/pc.vue",
@@ -2744,7 +3240,9 @@
     "path": "vue/src/virtual-tree/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "VirtualTreePc": {
     "path": "vue/src/virtual-tree/src/pc.vue",
@@ -2755,19 +3253,25 @@
     "path": "vue/src/watermark/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "Wheel": {
     "path": "vue/src/wheel/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile"]
+    "mode": [
+      "mobile"
+    ]
   },
   "Wizard": {
     "path": "vue/src/wizard/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["pc"]
+    "mode": [
+      "pc"
+    ]
   },
   "WizardPc": {
     "path": "vue/src/wizard/src/pc.vue",
@@ -2778,7 +3282,10 @@
     "path": "vue/src/year-range/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "YearRangeMobileFirst": {
     "path": "vue/src/year-range/src/mobile-first.vue",
@@ -2794,7 +3301,10 @@
     "path": "vue/src/year-table/index.ts",
     "type": "component",
     "exclude": false,
-    "mode": ["mobile-first", "pc"]
+    "mode": [
+      "mobile-first",
+      "pc"
+    ]
   },
   "YearTableMobileFirst": {
     "path": "vue/src/year-table/src/mobile-first.vue",

--- a/packages/theme/src/button/vars.less
+++ b/packages/theme/src/button/vars.less
@@ -66,7 +66,7 @@
   // 小型按钮最小宽度
   --tv-Button-min-width-small: 72px;
   // 小型按钮内图标的大小
-  --tv-Button-size-icon-font-size-small: 14px;
+  --tv-Button-size-icon-font-size-small: 16px;
   // 超小按钮字号
   --tv-Button-font-size-mini: var(--tv-font-size-sm);
   // 超小按钮高度

--- a/packages/theme/src/index.less
+++ b/packages/theme/src/index.less
@@ -6,6 +6,7 @@
 @import './autocomplete/index.less';
 @import './badge/index.less';
 @import './base/index.less';
+@import './base-select/index.less';
 @import './breadcrumb/index.less';
 @import './breadcrumb-item/index.less';
 @import './bulletin-board/index.less';

--- a/packages/theme/src/tag/index.less
+++ b/packages/theme/src/tag/index.less
@@ -29,16 +29,36 @@
   text-overflow: ellipsis;
   overflow: hidden;
 
+  &.@{tag-prefix-cls}--only-icon.@{tag-prefix-cls}--only-icon.@{tag-prefix-cls}--only-icon {
+    padding: var(--tv-Tag-only-icon-padding);
+
+    svg {
+      font-size: var(--tv-Tag-only-icon-font-size);
+      margin-right: 0; // 此时不需要右边距了
+    }
+  }
+
   /** size 场景 */
   .size-mixin(@size) {
     @fs: %('var(--tv-Tag-font-size%a)', @size);
     @px: %('var(--tv-Tag-padding-x%a)', @size);
     @py: %('var(--tv-Tag-padding-y%a)', @size);
     @br: %('var(--tv-Tag-border-radius%a)', @size);
+    @icon-fs: %('var(--tv-Tag-only-icon-font-size%a)', @size);
+    @icon-py: %('var(--tv-Tag-only-icon-padding%a)', @size);
 
     font-size: e(@fs);
     padding: e(@py) e(@px);
     border-radius: e(@br);
+
+    &.@{tag-prefix-cls}--only-icon.@{tag-prefix-cls}--only-icon {
+      padding: e(@icon-py);
+
+      svg {
+        font-size: e(@icon-fs);
+        margin-right: 0; // 此时不需要右边距了
+      }
+    }
   }
 
   .size-mixin(e(''));
@@ -148,14 +168,5 @@
   & svg:not(.@{tag-prefix-cls}__close) {
     margin-right: var(--tv-Tag-slot-icon-margin-right);
     fill: currentColor;
-  }
-
-  &.@{tag-prefix-cls}--only-icon.@{tag-prefix-cls}--only-icon.@{tag-prefix-cls}--only-icon {
-    padding: var(--tv-Tag-only-icon-padding);
-
-    svg {
-      font-size: var(--tv-Tag-only-icon-font-size);
-      margin-right: 0; // 此时不需要右边距了
-    }
   }
 }

--- a/packages/theme/src/tag/vars.less
+++ b/packages/theme/src/tag/vars.less
@@ -24,6 +24,11 @@
   --tv-Tag-padding-y-mini: 0.5px;
   // 超小标签圆角
   --tv-Tag-border-radius-mini: var(--tv-border-radius-xs);
+  // 标签在仅图标模式时，图标的大小
+  --tv-Tag-only-icon-font-size-mini: 12px;
+  // 标签在仅图标模式时，标签的内边距
+  --tv-Tag-only-icon-padding-mini: 2px;
+
   // 小型标签字号
   --tv-Tag-font-size-small: var(--tv-font-size-sm);
   // 小型标签水平间距
@@ -32,6 +37,11 @@
   --tv-Tag-padding-y-small: 0;
   // 小型标签圆角
   --tv-Tag-border-radius-small: var(--tv-border-radius-xs);
+  // 标签在仅图标模式时，图标的大小
+  --tv-Tag-only-icon-font-size-small: 14px;
+  // 标签在仅图标模式时，标签的内边距
+  --tv-Tag-only-icon-padding-small: 2px;
+
   // 默认标签字号
   --tv-Tag-font-size: var(--tv-font-size-md);
   // 默认标签水平间距
@@ -40,6 +50,11 @@
   --tv-Tag-padding-y: 0.5px;
   // 默认标签圆角
   --tv-Tag-border-radius: var(--tv-border-radius-sm);
+  // 标签在仅图标模式时，图标的大小
+  --tv-Tag-only-icon-font-size: 16px;
+  // 标签在仅图标模式时，标签的内边距
+  --tv-Tag-only-icon-padding: 3px;
+
   // 中等标签字号
   --tv-Tag-font-size-medium: var(--tv-font-size-md);
   // 中等标签水平间距
@@ -48,6 +63,10 @@
   --tv-Tag-padding-y-medium: 4.5px;
   // 中等标签圆角
   --tv-Tag-border-radius-medium: var(--tv-border-radius-md);
+  // 标签在仅图标模式时，图标的大小
+  --tv-Tag-only-icon-font-size-medium: 20px;
+  // 标签在仅图标模式时，标签的内边距
+  --tv-Tag-only-icon-padding-medium: 5px;
 
   //------------------------------------------------------- 颜色 场景：（1、考虑border，虽然cloud design没有，但适配其它肯定有border的) ----
 
@@ -201,8 +220,4 @@
   //------------------------------------------------------- 其它 场景：-----------------------------------
   // 标签插槽有前置图标时，图标的右间距
   --tv-Tag-slot-icon-margin-right: var(--tv-space-sm);
-  // 标签在仅图标模式时，图标的大小
-  --tv-Tag-only-icon-font-size: var(--tv-font-size-sm);
-  // 标签在仅图标模式时，标签的内边距
-  --tv-Tag-only-icon-padding: 3px;
 }

--- a/packages/vue-icon-saas/index.ts
+++ b/packages/vue-icon-saas/index.ts
@@ -127,6 +127,7 @@ import IconExport from './src/export'
 import IconExpressSearch from './src/express-search'
 import IconEyeclose from './src/eyeclose'
 import IconEyeopen from './src/eyeopen'
+import IconFeedback from './src/feedback'
 import IconEditorAlignCenter from './src/editor-align-center'
 import IconEditorAlignLeft from './src/editor-align-left'
 import IconEditorAlignRight from './src/editor-align-right'
@@ -180,6 +181,7 @@ import IconFrownO from './src/frown-o'
 import IconFrown from './src/frown'
 import IconFullscreen from './src/fullscreen'
 import IconFullscreenLeft from './src/fullscreen-left'
+import IconFullscreenRight from './src/fullscreen-right'
 import IconGoBack from './src/go-back'
 import IconGrade from './src/grade'
 import IconGroupTransfer from './src/group-transfer'
@@ -219,6 +221,7 @@ import IconLineThrought from './src/line-throught'
 import IconLink from './src/link'
 import IconLoading from './src/loading'
 import IconLoadingShadow from './src/loading-shadow'
+import IconLocalePanel from './src/locale-panel'
 import IconLock from './src/lock'
 import IconMailContent from './src/mail-content'
 import IconMail from './src/mail'
@@ -339,6 +342,7 @@ import IconSetting from './src/setting'
 import IconShare from './src/share'
 import IconShareArrow from './src/share-arrow'
 import IconShoppingCard from './src/shopping-card'
+import IconShutdown from './src/shutdown'
 import IconSmileO from './src/smile-o'
 import IconSmile from './src/smile'
 import IconSoldOut from './src/sold-out'
@@ -377,6 +381,7 @@ import IconUnlock from './src/unlock'
 import IconUnsent from './src/unsent'
 import IconUpO from './src/up-o'
 import IconUp from './src/up'
+import IconUpdate from './src/update'
 import IconUpload from './src/upload'
 import IconUser from './src/user'
 import IconVersiontree from './src/versiontree'
@@ -431,6 +436,7 @@ import IconAddPicture from './src/add-picture'
 
 // sync aui icons
 import IconAdministratorO from './src/administrator-o'
+import IconAgency from './src/agency'
 import IconAudit from './src/audit'
 import IconBatchFill from './src/batch-fill'
 import IconCardMode from './src/card-mode'
@@ -509,6 +515,7 @@ import IconShipped from './src/shipped'
 import IconSubstituteMaterial from './src/substitute-material'
 import IconSurchargeSettled from './src/surcharge-settled'
 import IconSurchargeToBeSettled from './src/surcharge-to-be-settled'
+import IconSynchronize from './src/synchronize'
 import IconToBeUploaded from './src/to-be-uploaded'
 import IconTotalNolume from './src/total-nolume'
 import IconTotalNumber from './src/total-number'
@@ -593,6 +600,8 @@ export {
   IconSurchargeSettled as iconSurchargeSettled,
   IconSurchargeToBeSettled,
   IconSurchargeToBeSettled as iconSurchargeToBeSettled,
+  IconSynchronize,
+  IconSynchronize as iconSynchronize,
   IconToBeUploaded,
   IconToBeUploaded as iconToBeUploaded,
   IconTotalNolume,
@@ -919,6 +928,8 @@ export {
   IconEyeclose as iconEyeclose,
   IconEyeopen,
   IconEyeopen as iconEyeopen,
+  IconFeedback,
+  IconFeedback as iconFeedback,
   IconEditorAlignCenter,
   IconEditorAlignCenter as iconEditorAlignCenter,
   IconEditorAlignLeft,
@@ -1025,6 +1036,8 @@ export {
   IconFullscreen as iconFullscreen,
   IconFullscreenLeft,
   IconFullscreenLeft as iconFullscreenLeft,
+  IconFullscreenRight,
+  IconFullscreenRight as iconFullscreenRight,
   IconMinscreenLeft,
   IconMinscreenLeft as iconMinscreenLeft,
   IconGoBack,
@@ -1105,6 +1118,8 @@ export {
   IconLoading as iconLoading,
   IconLoadingShadow,
   IconLoadingShadow as iconLoadingShadow,
+  IconLocalePanel,
+  IconLocalePanel as iconLocalePanel,
   IconLock,
   IconLock as iconLock,
   IconLeftWardArrow,
@@ -1345,6 +1360,8 @@ export {
   IconShareArrow as iconShareArrow,
   IconShoppingCard,
   IconShoppingCard as iconShoppingCard,
+  IconShutdown,
+  IconShutdown as iconShutdown,
   IconSmileO,
   IconSmileO as iconSmileO,
   IconSmile,
@@ -1421,6 +1438,8 @@ export {
   IconUpO as iconUpO,
   IconUp,
   IconUp as iconUp,
+  IconUpdate,
+  IconUpdate as iconUpdate,
   IconUpWard,
   IconUpWard as iconUpWard,
   IconUpload,
@@ -1457,6 +1476,8 @@ export {
   // sync aui icons
   IconAdministratorO,
   IconAdministratorO as iconAdministratorO,
+  IconAgency,
+  IconAgency as iconAgency,
   IconAudit,
   IconAudit as iconAudit,
   IconBatchFill,
@@ -1580,6 +1601,7 @@ export default {
   IconSubstituteMaterial,
   IconSurchargeSettled,
   IconSurchargeToBeSettled,
+  IconSynchronize,
   IconToBeUploaded,
   IconTotalNolume,
   IconTotalNumber,
@@ -1741,6 +1763,7 @@ export default {
   IconExpressSearch,
   IconEyeclose,
   IconEyeopen,
+  IconFeedback,
   IconEditorAlignCenter,
   IconEditorAlignLeft,
   IconEditorAlignRight,
@@ -1794,6 +1817,7 @@ export default {
   IconFrown,
   IconFullscreen,
   IconFullscreenLeft,
+  IconFullscreenRight,
   IconMinscreenLeft,
   IconGoBack,
   IconGrade,
@@ -1834,6 +1858,7 @@ export default {
   IconLink,
   IconLoading,
   IconLoadingShadow,
+  IconLocalePanel,
   IconLock,
   IconLeftWardArrow,
   IconMailContent,
@@ -1953,6 +1978,7 @@ export default {
   IconShare,
   IconShareArrow,
   IconShoppingCard,
+  IconShutdown,
   IconSmileO,
   IconSmile,
   IconSoldOut,
@@ -1991,6 +2017,7 @@ export default {
   IconUnsent,
   IconUpO,
   IconUp,
+  IconUpdate,
   IconUpWard,
   IconUpload,
   IconUser,
@@ -2009,6 +2036,7 @@ export default {
   IconAddPicture,
   // sync aui icons
   IconAdministratorO,
+  IconAgency,
   IconAudit,
   IconBatchFill,
   IconCardMode,


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
增加tag的only icon时， 不同尺寸时的大小

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced new `<tiny-tag>` components with icon-only variations for different sizes, enhancing visual representation.
	- Added new icons to the application, expanding the available icon set.

- **Bug Fixes**
	- Improved clarity in documentation regarding the `only-icon` property for tags.

- **Style**
	- Updated styles for tags containing only icons to enhance their appearance.
	- Adjusted icon size for small buttons to improve visual consistency.

- **Chores**
	- Reformatted JSON files for better readability and organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->