### PR TITLE
fix(tree): [tree] remove  red color from demos

### DIFF
--- a/examples/sites/demos/.eslintrc.js
+++ b/examples/sites/demos/.eslintrc.js
@@ -3,6 +3,7 @@
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
   rules: {
-    'no-console': 'off'
+    'no-console': 'off',
+    'vue/no-unused-vars': 'off'
   }
 }

--- a/examples/sites/demos/pc/app/tree/edit-control-composition-api.vue
+++ b/examples/sites/demos/pc/app/tree/edit-control-composition-api.vue
@@ -4,7 +4,7 @@
     <tiny-button @click="closeEdit">取消编辑</tiny-button>
     <tiny-button @click="saveEdit">保存编辑</tiny-button> <br />
     <br />
-    <div class="red">数据1 禁止添加; &nbsp;数据2 禁止编辑; &nbsp;数据3 禁止删除;</div>
+    <div class="tips">提示：数据1 禁止添加; &nbsp;数据2 禁止编辑; &nbsp;数据3 禁止删除;</div>
     <tiny-tree
       ref="treeRef"
       node-key="id"
@@ -109,7 +109,8 @@ function deleteNodeMethod() {
 </script>
 
 <style scoped>
-.red {
-  color: red;
+.tips {
+  color: #888;
+  margin: 12px 20px;
 }
 </style>

--- a/examples/sites/demos/pc/app/tree/edit-control.vue
+++ b/examples/sites/demos/pc/app/tree/edit-control.vue
@@ -4,7 +4,7 @@
     <tiny-button @click="closeEdit">取消编辑</tiny-button>
     <tiny-button @click="saveEdit">保存编辑</tiny-button> <br />
     <br />
-    <div class="red">数据1 禁止添加; &nbsp;数据2 禁止编辑; &nbsp;数据3 禁止删除;</div>
+    <div class="tips">提示：数据1 禁止添加; &nbsp;数据2 禁止编辑; &nbsp;数据3 禁止删除;</div>
     <tiny-tree
       ref="treeRef"
       node-key="id"
@@ -117,7 +117,8 @@ export default {
 </script>
 
 <style scoped>
-.red {
-  color: red;
+.tips {
+  color: #888;
+  margin: 12px 20px;
 }
 </style>

--- a/examples/sites/demos/pc/app/tree/other-composition-api.vue
+++ b/examples/sites/demos/pc/app/tree/other-composition-api.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
-    <span class="red">手风琴模式，父子严格显示自动勾选</span>
+    <div class="tips">提示：手风琴模式，父子严格显示自动勾选</div>
     <tiny-tree :data="data" accordion show-checkbox check-strictly show-check-easily :icon-trigger-click-node="false">
     </tiny-tree>
     <br />
-    <span class="red">非手风琴模式，自定义自动勾选的内容</span>
+    <div class="tips">提示：非手风琴模式，自定义自动勾选的内容</div>
     <tiny-tree :data="data" accordion show-checkbox check-strictly show-check-easily :icon-trigger-click-node="false">
       <template #switchText>
         <span>自定义开关的内容</span>
@@ -43,7 +43,8 @@ const data = ref([
 </script>
 
 <style scoped>
-.red {
-  color: red;
+.tips {
+  color: #888;
+  margin: 12px 20px;
 }
 </style>

--- a/examples/sites/demos/pc/app/tree/other.vue
+++ b/examples/sites/demos/pc/app/tree/other.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
-    <span class="red">手风琴模式，父子严格显示自动勾选</span>
+    <div class="tips">提示：手风琴模式，父子严格显示自动勾选</div>
     <tiny-tree :data="data" accordion show-checkbox check-strictly show-check-easily :icon-trigger-click-node="false">
     </tiny-tree>
     <br />
-    <span class="red">非手风琴模式，自定义自动勾选的内容</span>
+    <div class="tips">提示：非手风琴模式，自定义自动勾选的内容</div>
     <tiny-tree :data="data" accordion show-checkbox check-strictly show-check-easily :icon-trigger-click-node="false">
       <template #switchText>
         <span>自定义开关的内容</span>
@@ -51,7 +51,8 @@ export default {
 </script>
 
 <style scoped>
-.red {
-  color: red;
+.tips {
+  color: #888;
+  margin: 12px 20px;
 }
 </style>

--- a/examples/sites/demos/pc/app/tree/slot-composition-api.vue
+++ b/examples/sites/demos/pc/app/tree/slot-composition-api.vue
@@ -5,7 +5,7 @@
       <tiny-button @click="clearData">清除数据</tiny-button>
     </div>
     <div>
-      <div class="tip">5个插槽示例</div>
+      <div class="tips">提示：5个插槽示例</div>
       <tiny-tree :data="data" default-expand-all>
         <!-- 前缀插槽 -->
         <template #prefix="{ node }">
@@ -33,7 +33,7 @@
       </tiny-tree>
     </div>
     <div>
-      <div class="tip">render-content + empty-text 示例</div>
+      <div class="tips">提示：render-content + empty-text 示例</div>
       <tiny-tree :data="data" empty-text="组件无数据" :render-content="renderContent" default-expand-all> </tiny-tree>
     </div>
   </div>
@@ -94,8 +94,8 @@ function renderContent(h, { node, data }) {
 .slot-demo > div {
   margin-bottom: 8px;
 }
-.tip {
-  font-weight: bold;
-  margin-bottom: 8px;
+.tips {
+  color: #888;
+  margin: 12px 20px;
 }
 </style>

--- a/examples/sites/demos/pc/app/tree/slot.vue
+++ b/examples/sites/demos/pc/app/tree/slot.vue
@@ -5,7 +5,7 @@
       <tiny-button @click="clearData">清除数据</tiny-button>
     </div>
     <div>
-      <div class="tip">5个插槽示例</div>
+      <div class="tips">提示：5个插槽示例</div>
       <tiny-tree :data="data" default-expand-all>
         <!-- 前缀插槽 -->
         <template #prefix="{ node }">
@@ -33,7 +33,7 @@
       </tiny-tree>
     </div>
     <div>
-      <div class="tip">render-content + empty-text 示例</div>
+      <div class="tips">提示：render-content + empty-text 示例</div>
       <tiny-tree :data="data" empty-text="组件无数据" :render-content="renderContent" default-expand-all> </tiny-tree>
     </div>
   </div>
@@ -105,8 +105,8 @@ export default {
 .slot-demo > div {
   margin-bottom: 8px;
 }
-.tip {
-  font-weight: bold;
-  margin-bottom: 8px;
+.tips {
+  color: #888;
+  margin: 12px 20px;
 }
 </style>


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new class `.tips` for improved visual presentation of messages across various components.
	- Updated message content to include "提示：" for better clarity.

- **Bug Fixes**
	- Removed the `.red` class to eliminate confusion regarding message importance.

- **Style**
	- Updated styles for the `.tips` class, setting color to `#888` and adjusting margins for a cleaner look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->