### PR TITLE
fix: [virtual-scroll-box] fixed the  wrong class and horizontal scrol…

### DIFF
--- a/examples/sites/demos/pc/app/virtual-tree/basic-usage-composition-api.vue
+++ b/examples/sites/demos/pc/app/virtual-tree/basic-usage-composition-api.vue
@@ -6,7 +6,7 @@
       width="600"
       height="400"
       row-height="36"
-      scrollbar-size="6"
+      scrollbar-size="8"
       :tree-op="treeOp"
     ></tiny-virtual-tree>
   </div>

--- a/examples/sites/demos/pc/app/virtual-tree/basic-usage.vue
+++ b/examples/sites/demos/pc/app/virtual-tree/basic-usage.vue
@@ -6,7 +6,7 @@
       width="600"
       height="400"
       row-height="36"
-      scrollbar-size="6"
+      scrollbar-size="8"
       :tree-op="treeOp"
     ></tiny-virtual-tree>
   </div>

--- a/packages/vue/src/virtual-scroll-box/src/pc.vue
+++ b/packages/vue/src/virtual-scroll-box/src/pc.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="aui-virtual-scroll-box" :style="state.ctx.boxStyle" @scroll="onScroll">
-    <div class="aui-virtual-scroll-box__x-axis" :style="state.ctx.xAxisStyle"></div>
-    <div class="aui-virtual-scroll-box__y-axis" :style="state.ctx.yAxisStyle"></div>
-    <div class="aui-virtual-scroll-box__view" :style="state.ctx.viewStyle">
+  <div class="tiny-virtual-scroll-box" :style="state.ctx.boxStyle" @scroll="onScroll">
+    <div class="tiny-virtual-scroll-box__x-axis" :style="state.ctx.xAxisStyle"></div>
+    <div class="tiny-virtual-scroll-box__y-axis" :style="state.ctx.yAxisStyle"></div>
+    <div class="tiny-virtual-scroll-box__view" :style="state.ctx.viewStyle">
       <slot :params="state.slotParams"></slot>
     </div>
   </div>

--- a/packages/vue/src/virtual-tree/src/pc.vue
+++ b/packages/vue/src/virtual-tree/src/pc.vue
@@ -1,6 +1,6 @@
 <template>
-  <aui-virtual-scroll-box ref="vsBox" class="aui-virtual-tree" v-bind="state.vsBoxOptions" @change="onVsBoxChange">
-    <aui-tree
+  <tiny-virtual-scroll-box ref="vsBox" class="tiny-virtual-tree" v-bind="state.vsBoxOptions" @change="onVsBoxChange">
+    <tiny-tree
       ref="tree"
       v-bind="state.treeOptions"
       v-on="state.treeEvents"
@@ -32,8 +32,8 @@
       <template v-if="slots.operation" #operation="params">
         <slot name="operation" v-bind="params"></slot>
       </template>
-    </aui-tree>
-  </aui-virtual-scroll-box>
+    </tiny-tree>
+  </tiny-virtual-scroll-box>
 </template>
 
 <script lang="ts">
@@ -46,8 +46,8 @@ export default defineComponent({
   inheritAttrs: false,
   props: [...props, 'width', 'height', 'rowHeight', 'scrollbarSize', 'treeOp'],
   components: {
-    AuiVirtualScrollBox: VirtualScrollBox,
-    AuiTree: Tree
+    TinyVirtualScrollBox: VirtualScrollBox,
+    TinyTree: Tree
   },
   setup(props, context): any {
     return setup({ props, context, renderless, api })


### PR DESCRIPTION
…l bar always showing

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased scrollbar size in the `<tiny-virtual-tree>` component for better visibility.
	- Added functionality to generate a new dataset of 600 items with a button click.

- **Refactor**
	- Updated component names from `aui-virtual-scroll-box` and `aui-tree` to `tiny-virtual-scroll-box` and `tiny-tree` for consistency across the application. 

These changes enhance the user experience while maintaining existing functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->