### PR TITLE
Release319 fix(transfer): fix drag 2 item to right when set filterable=true

### DIFF
--- a/packages/renderless/package.json
+++ b/packages/renderless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/vue-renderless",
-  "version": "3.19.4",
+  "version": "3.19.5",
   "private": true,
   "description": "An enterprise-class UI component library, support both Vue.js 2 and Vue.js 3, as well as PC and mobile.",
   "author": "OpenTiny Team",

--- a/packages/renderless/src/transfer/index.ts
+++ b/packages/renderless/src/transfer/index.ts
@@ -217,7 +217,7 @@ export const clearQuery = (refs: ITransferRenderlessParams['refs']) => (which: '
 
 /** SortableJs 插件的回调逻辑， 添加，删除，更新事件后，触发本函数 */
 export const logicFun =
-  ({ props, emit, state }: Pick<ITransferRenderlessParams, 'emit' | 'props' | 'state'>) =>
+  ({ props, emit, state, vm }: Pick<ITransferRenderlessParams, 'emit' | 'props' | 'state'>) =>
   ({ event, isAdd, pullMode }: { event: any; isAdd?: boolean; pullMode?: 'sort' }) => {
     let currentValue = props.modelValue.slice()
     let movedKeys = []
@@ -225,9 +225,12 @@ export const logicFun =
     if (pullMode) {
       currentValue.splice(event.newIndex, 0, currentValue.splice(event.oldIndex, 1)[0])
     } else {
+      const rightPanel = vm.$refs.rightPanel
+      const leftPanel = vm.$refs.leftPanel
+
       const key = isAdd
-        ? state.targetData[event.oldIndex][props.props.key]
-        : state.sourceData[event.oldIndex][props.props.key]
+        ? rightPanel.state.filteredData[event.oldIndex][props.props.key]
+        : leftPanel.state.filteredData[event.oldIndex][props.props.key]
       const index = isAdd ? state.rightChecked.indexOf(key) : state.leftChecked.indexOf(key)
       const valueIndex = currentValue.indexOf(key)
 

--- a/packages/renderless/src/transfer/vue.ts
+++ b/packages/renderless/src/transfer/vue.ts
@@ -61,7 +61,7 @@ const initState = ({ reactive, computed, api, props, h, slots }): ITransferState
 export const renderless = (
   props: ITransferProps,
   { computed, onMounted, reactive, h }: ISharedRenderlessParamHooks,
-  { $prefix, emit, refs, parent, slots }: ITransferRenderlessParamUtils
+  { $prefix, emit, refs, parent, slots, vm }: ITransferRenderlessParamUtils
 ) => {
   const api = {} as ITransferApi
   const Tree = $prefix + 'Tree'
@@ -80,7 +80,7 @@ export const renderless = (
     addToRight: addToRight({ emit, refs, props, state, Tree }),
     onTargetCheckedChange: onTargetCheckedChange({ emit, state }),
     onSourceCheckedChange: onSourceCheckedChange({ emit, state }),
-    logicFun: logicFun({ props, emit, state }),
+    logicFun: logicFun({ props, emit, state, vm }),
     getTargetData: getTargetData({ props, state, Tree, Table }),
     sortableEvent: sortableEvent({ api, droppanel: DROPPANEL, props, queryDom: TRANSFERPANEL, refs })
   })


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the version of the `@opentiny/vue-renderless` package to 3.19.5.
	- Enhanced item movement logic between panels, improving data manipulation accuracy.
	- Introduced a new parameter to key functions for better access to Vue instance properties.

- **Bug Fixes**
	- Adjusted logic for determining keys during item addition/removal to utilize filtered data correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->