### PR TITLE
fix(docs): Fixed an issue where the document demo disappears in github-markdown-css5.8.0.

### DIFF
--- a/examples/sites/package.json
+++ b/examples/sites/package.json
@@ -38,7 +38,7 @@
     "@unocss/reset": "0.38.2",
     "@vue/repl": "^2.5.5",
     "@vueuse/head": "0.7.13",
-    "github-markdown-css": "^5.1.0",
+    "github-markdown-css": "~5.1.0",
     "highlight.js": "^11.5.1",
     "marked": "^4.3.0",
     "mathlive": "^0.101.1",


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the dependency version for `github-markdown-css` to restrict updates to patch versions only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->