### PR TITLE
fix: fix warning in cascader component

### DIFF
--- a/packages/vue/src/cascader-menu/src/index.ts
+++ b/packages/vue/src/cascader-menu/src/index.ts
@@ -22,7 +22,7 @@ export default defineComponent({
       required: true
     },
     index: Number,
-    onlyUsePanel: String
+    onlyUsePanel: Boolean
   },
   setup(props, context) {
     return $setup({ props, context, template })

--- a/packages/vue/src/cascader-menu/src/pc.vue
+++ b/packages/vue/src/cascader-menu/src/pc.vue
@@ -50,7 +50,7 @@ const CascaderMenu = defineComponent({
       required: true
     },
     index: Number,
-    onlyUsePanel: String
+    onlyUsePanel: Boolean
   },
   inject: {
     panel: {

--- a/packages/vue/src/cascader-panel/src/pc.vue
+++ b/packages/vue/src/cascader-panel/src/pc.vue
@@ -43,7 +43,7 @@ export default defineComponent({
       default: true
     },
     renderLabel: Function,
-    onlyUsePanel: String
+    onlyUsePanel: Boolean
   },
   provide() {
     return {


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `onlyUsePanel` property in the `CascaderMenu` and `CascaderPanel` components to accept a boolean value instead of a string.
- **Bug Fixes**
	- Corrected the data type for the `onlyUsePanel` prop in the relevant components, enhancing type safety and usage clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->