### PR TITLE
fix(tree):  default-expanded-keys description is wrong

### DIFF
--- a/examples/sites/demos/apis/tree.js
+++ b/examples/sites/demos/apis/tree.js
@@ -132,11 +132,12 @@ export default {
         },
         {
           name: 'default-expanded-keys',
-          type: 'boolean',
-          defaultValue: 'false',
+          type: 'string[]',
+          defaultValue: '[]',
           desc: {
-            'zh-CN': '默认展开节点的keys',
-            'en-US': 'The keys of the node are expanded by default'
+            'zh-CN': '默认展开节点的keys。当属性变化时，会自动收起全部并重新展开指定的数据项。 ',
+            'en-US':
+              'The keys of the node are expanded by default.When the property changes, it automatically collapses all and reexpands the specified data item.'
           },
           mode: ['pc'],
           pcDemo: 'expand-control'


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `default-expanded-keys` property in the tree component to accept an array of strings, enhancing flexibility in node expansion.
	- Improved the description of the `default-expanded-keys` property for better clarity on its functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->