### PR TITLE
fix(statistic): [statistic] when precision is not set, the current value is displayed by default

### DIFF
--- a/examples/sites/demos/apis/statistic.js
+++ b/examples/sites/demos/apis/statistic.js
@@ -7,7 +7,7 @@ export default {
       props: [
         {
           name: 'value',
-          type: 'number',
+          type: 'number | string',
           defaultValue: '0',
           desc: {
             'zh-CN': '数字显示内容',
@@ -20,7 +20,7 @@ export default {
         {
           name: 'precision',
           type: 'number',
-          defaultValue: '0',
+          defaultValue: '',
           desc: {
             'zh-CN': '精度值',
             'en-US': 'Take precision value'

--- a/examples/sites/demos/pc/app/statistic/basic-usage-composition-api.vue
+++ b/examples/sites/demos/pc/app/statistic/basic-usage-composition-api.vue
@@ -8,6 +8,9 @@
         <tiny-col :span="8">
           <tiny-statistic :value="num" :precision="2"></tiny-statistic>
         </tiny-col>
+        <tiny-col :span="8">
+          <tiny-statistic :value="num"></tiny-statistic>
+        </tiny-col>
       </tiny-row>
     </tiny-layout>
   </div>

--- a/examples/sites/demos/pc/app/statistic/basic-usage.vue
+++ b/examples/sites/demos/pc/app/statistic/basic-usage.vue
@@ -8,6 +8,9 @@
         <tiny-col :span="8">
           <tiny-statistic :value="num" :precision="2"></tiny-statistic>
         </tiny-col>
+        <tiny-col :span="8">
+          <tiny-statistic :value="num"></tiny-statistic>
+        </tiny-col>
       </tiny-row>
     </tiny-layout>
   </div>

--- a/examples/sites/demos/pc/app/statistic/statistic-slot.spec.ts
+++ b/examples/sites/demos/pc/app/statistic/statistic-slot.spec.ts
@@ -3,9 +3,10 @@ import { test, expect } from '@playwright/test'
 test('插槽用法', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
   await page.goto('statistic#statistic-slot')
+  const desc = page.locator('.tiny-statistic__description')
   await page
     .locator('div')
     .filter({ hasText: /^存储总量已使用容量\(GB\)10,010,258GB$/ })
     .first()
-  await page.getByText('306,526存储平均值').click()
+  await expect(desc.first()).toHaveCSS('font-weight', '500')
 })

--- a/examples/sites/demos/pc/app/statistic/statistic-style.spec.ts
+++ b/examples/sites/demos/pc/app/statistic/statistic-style.spec.ts
@@ -7,6 +7,5 @@ test('样式用法', async ({ page }) => {
     .locator('div')
     .filter({ hasText: /^进行中306,526$/ })
     .first()
-  await page.getByText('306,526失败').click()
   await expect(page.getByText(/^进行中306,526$/).first()).toHaveClass(/tiny-statistic/)
 })

--- a/packages/renderless/src/statistic/index.ts
+++ b/packages/renderless/src/statistic/index.ts
@@ -15,10 +15,15 @@ export const getIntegerAndDecimal =
     if (!isNumber(props.value)) {
       return props.value
     }
-    let displayValue = props.value ? String(props.value).split('.') : ''
+    let displayValue = String(props.value).split('.')
     let integer = displayValue[0]?.replace(/\B(?=(\d{3})+(?!\d))/g, props.groupSeparator)
-    let decimal = displayValue[1]?.padEnd(props.precision, '0').slice(0, props.precision > 0 ? props.precision : 0)
-    // 处理当数字为0的情况
+    let decimal = displayValue[1]?.padEnd(props.precision, '0')
+
+    // 当精度为0且大于0，进行精度截取
+    if (props.precision >= 0) {
+      decimal = decimal?.slice(0, props.precision > 0 ? props.precision : 0)
+    }
+    // 处理当没有显示值，数字默认为0
     if (!displayValue) {
       integer = '0'
     }

--- a/packages/vue/src/statistic/package.json
+++ b/packages/vue/src/statistic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/vue-statistic",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "",
   "main": "lib/index.js",
   "module": "index.ts",

--- a/packages/vue/src/statistic/src/index.ts
+++ b/packages/vue/src/statistic/src/index.ts
@@ -11,13 +11,10 @@ export const statisticProps = {
     type: Object,
     default: () => $constants
   },
-  precision: {
-    type: Number,
-    default: 0
-  },
+  precision: Number,
   formatter: Function,
   value: {
-    type: Number,
+    type: Number || String,
     default: 0
   },
   prefix: String,

--- a/packages/vue/src/statistic/src/index.ts
+++ b/packages/vue/src/statistic/src/index.ts
@@ -14,7 +14,7 @@ export const statisticProps = {
   precision: Number,
   formatter: Function,
   value: {
-    type: Number || String,
+    type: [Number, String],
     default: 0
   },
   prefix: String,


### PR DESCRIPTION
…lue is displayed by default

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced flexibility for the `value` property in the statistic component to accept both numbers and strings.
  - Added new `<tiny-statistic>` components in multiple locations to improve statistical data display.

- **Bug Fixes**
  - Improved handling of precision and display values in the statistic component, ensuring robustness in formatting.

- **Chores**
  - Updated version number for the `@opentiny/vue-statistic` package from `3.18.0` to `3.18.1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->