### PR TITLE
fix(input): [input] cancel bacground style of input count in textarea

### DIFF
--- a/packages/theme/src/textarea/index.less
+++ b/packages/theme/src/textarea/index.less
@@ -92,7 +92,6 @@
 
   .@{input-prefix-cls}__count {
     color: var(--tv-Textarea-count-color);
-    background: var(--tv-Textarea-bg-color);
     font-size: var(--tv-Textarea-count-font-size);
     text-align: right;
     position: absolute;


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

![image](https://github.com/user-attachments/assets/e2e9d9da-9140-4387-bfde-82af99c9f5ab)

Issue Number: #2687

## What is the new behavior?

![image](https://github.com/user-attachments/assets/70910a1e-3a70-4263-a3f2-d89ec59e3902)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
 <tiny-input>在'type="textarea"'且使用‘’maxlength‘’,"show-word-limit" 时，计数的样式为“background:#fff”，应该跟随其父元素。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated textarea count styling by removing background color
	- Maintained existing textarea component styling and behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->