### PR TITLE
fix(popeditor): the default width of the label in popeditor is added

### DIFF
--- a/packages/theme-saas/src/popeditor/index.less
+++ b/packages/theme-saas/src/popeditor/index.less
@@ -115,6 +115,7 @@
           @apply text-right;
           @apply pr-2;
           @apply text-xs;
+          width: 160px;
         }
       }
 


### PR DESCRIPTION
# PR
theme-saas 中增加popeditor中label的默认宽度


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated popeditor search label width to 160px for improved layout consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->