### PR TITLE
fix(grid): [grid] fix can not select first option when value is empty

### DIFF
--- a/packages/vue/src/grid/src/adapter/src/renderer.ts
+++ b/packages/vue/src/grid/src/adapter/src/renderer.ts
@@ -100,24 +100,32 @@ function getEvents(renderOpts, params, context) {
 }
 
 function renderOptions(h, options, renderOpts, params, context) {
-  let { optionProps = {} } = renderOpts
-  let labelProp = optionProps.label || 'label'
-  let valueProp = optionProps.value || 'value'
-  let { column, row } = params
-  let { formatConfig } = column.own
-  let cellValue = isSyncCell(renderOpts, params, context) ? getCellValue(row, column) : column.model.value
+  const { optionProps = {} } = renderOpts
+  const labelProp = optionProps.label || 'label'
+  const valueProp = optionProps.value || 'value'
+  const { column, row } = params
+  const { formatConfig } = column.own
+  const cellValue = isSyncCell(renderOpts, params, context) ? getCellValue(row, column) : column.model.value
 
   if (!options && formatConfig && formatConfig.data) {
     options = formatConfig.data
   }
-
-  return options.map((item, index) => {
-    let attrs = {
-      domProps: { value: item[valueProp], selected: item.value === cellValue },
+  let hasSelected = false
+  const optionsList = options.map((item, index) => {
+    const selected = item.value === cellValue
+    if (selected) {
+      hasSelected = true
+    }
+    const attrs = {
+      domProps: { value: item[valueProp], selected },
       key: index
     }
     return h('option', attrs, item[labelProp])
   })
+  if (options.length && !hasSelected) {
+    optionsList.unshift(h('option', { style: 'display:none', selected: true }, ''))
+  }
+  return optionsList
 }
 
 function renderOptgroups(h, options, params, context) {


### PR DESCRIPTION
# PR
修复原生select当默认值为空第一项无法选中
当原生select没有指定选中值时，默认会选中第一项，因此再次选择第一项时，不会触发change事件。导致实际的值无法更新
![image](https://github.com/user-attachments/assets/83a082c9-1c17-4a69-a558-35527171798d)

修复方案：
当默认值为空值，给原生select标签添加一个隐藏的空选项


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

close #2649
