### PR TITLE
fix(loading):  [loading] v-loading's lifecycle name replace by inserted

### DIFF
--- a/packages/vue-common/src/adapter/vue2/index.ts
+++ b/packages/vue-common/src/adapter/vue2/index.ts
@@ -301,6 +301,7 @@ export const directive = (directives) => {
   for (const name in directives) {
     const content = directives[name]
 
+    mapping(content, 'mounted', 'inserted')
     mapping(content, 'beforeMount', 'bind')
     mapping(content, 'updated', 'update')
     mapping(content, 'unmounted', 'unbind')

--- a/packages/vue-common/src/adapter/vue3/index.ts
+++ b/packages/vue-common/src/adapter/vue3/index.ts
@@ -381,6 +381,7 @@ export const directive = (directives) => {
   for (const name in directives) {
     const content = directives[name]
 
+    mapping(content, 'inserted', 'mounted')
     mapping(content, 'bind', 'beforeMount')
     mapping(content, 'update', 'updated')
     mapping(content, 'unbind', 'unmounted')

--- a/packages/vue/src/loading/src/directive.ts
+++ b/packages/vue/src/loading/src/directive.ts
@@ -121,7 +121,7 @@ const toggleLoading = (el, binding, maskInstance) => {
 }
 
 const vLoading = {
-  bind(el, binding, vnode) {
+  inserted(el, binding, vnode) {
     const vm = vnode.context
     const textExr = el.getAttribute(constants.TEXT_ATTR)
     const spinnerExr = el.getAttribute(constants.TEXT_SPINNER)
@@ -132,7 +132,7 @@ const vLoading = {
       component: Loading,
       propsData: {
         _constants: constants,
-        tiny_mode: vm.tiny_mode?.value || appProperties().tiny_mode?.value
+        tiny_mode: vm?.tiny_mode?.value || appProperties().tiny_mode?.value
       },
       el: document.createElement('div')
     })


### PR DESCRIPTION
# PR
将v-loading的周期， 从bind改为inserted 周期

其它使用createComponent的组件，都是函数式调用，应该不会触发bug.




## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2528 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated lifecycle hook mappings for Vue 2 and Vue 3 directives to improve compatibility
	- Modified loading directive to use `inserted` hook for more precise DOM manipulation

- **Bug Fixes**
	- Improved handling of directive lifecycle hooks across Vue versions
	- Enhanced safety of property access in loading directive

<!-- end of auto-generated comment: release notes by coderabbit.ai -->