### PR TITLE
fix(grid): [grid] fix repeated trigger cell active when boardConfig.isEdit is set true

### DIFF
--- a/packages/vue/src/grid/src/table/src/events.ts
+++ b/packages/vue/src/grid/src/table/src/events.ts
@@ -230,7 +230,6 @@ export function handleOtherKeyDown({ event, selected }) {
     (!keyboardConfig.editMethod || !(keyboardConfig.editMethod(selected.args, event) === false))
   ) {
     // 如果是按下非功能键之外允许直接编辑
-    setCellValue(selected.row, selected.column, null)
     this.handleActived(selected.args, event)
   }
 }

--- a/packages/vue/src/grid/src/table/src/utils/handleGlobalKeydownEvent.ts
+++ b/packages/vue/src/grid/src/table/src/utils/handleGlobalKeydownEvent.ts
@@ -100,9 +100,11 @@ function rule9({ keyboardConfig, isKeyWithCtrl, isKeyA, isKeyX, isKeyC, isKeyV, 
   }
 }
 
-function rule10({ keyboardConfig, isKeyWithCtrl, _vm, event, selected }) {
+function rule10({ keyboardConfig, isKeyWithCtrl, _vm, event, selected, actived }) {
+  // 如果同一个单元格已经被激活编辑态，那么就不重复触发
   return {
-    match: () => keyboardConfig.isEdit && !isKeyWithCtrl,
+    match: () =>
+      keyboardConfig.isEdit && !isKeyWithCtrl && !(selected.row === actived.row && selected.column === actived.column),
     action: () => _vm.handleOtherKeyDown({ event, selected })
   }
 }
@@ -147,7 +149,7 @@ export function onGlobalKeydown(event, _vm) {
     rule8({ isKeyDel, treeConfig, highlightCurrentRow, currentRow, isKeyBack, keyboardConfig, _vm, event, selected }),
     rule9({ keyboardConfig, isKeyWithCtrl, isKeyA, isKeyX, isKeyC, isKeyV, _vm, event }),
     // 如果是按下非功能键之外允许直接编辑
-    rule10({ keyboardConfig, isKeyWithCtrl, _vm, event, selected })
+    rule10({ keyboardConfig, isKeyWithCtrl, _vm, event, selected, actived })
   ]
 
   for (let i = 0; i < rules.length; i++) {


### PR DESCRIPTION
# PR
修复当配置了boardConfig.isEdit为true时，激活编辑被一直重复触发
![PixPin_2025-01-09_17-32-36](https://github.com/user-attachments/assets/026fa142-7b77-48d8-ae10-eeae53b361bc)
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
close #2321 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved cell editing behavior in the grid component
	- Enhanced keyboard interaction logic to prevent redundant edit actions
	- Refined cell selection and editing state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->