### PR TITLE
docs: added Vitepress packaging to FAQ section

### DIFF
--- a/examples/sites/demos/pc/webdoc/faq-en.md
+++ b/examples/sites/demos/pc/webdoc/faq-en.md
@@ -2,10 +2,10 @@
 
 ## 1, Popup element misaligned and flipped in wujie micro front-end
 
-_Reason:_ The popup element has a boundary detection logic, and in sub applications, the width and height of 'window' may be much smaller than that of the viewport,
+**Reason:** The popup element has a boundary detection logic, and in sub applications, the width and height of 'window' may be much smaller than that of the viewport,
 therefore, it can misjudge boundaries, leading to issues such as flipping and misalignment.
 
-_Solution:_ Introducing popup global configuration, assigning the 'window' of the main application to the 'viewportWindow' of the global configuration for boundary judgment
+**Solution:** Introducing 'popup global' configuration, assigning the 'window' of the main application to the 'viewportWindow' of the global configuration for boundary judgment
 
 ```js
 import globalConfig from '@opentiny/vue-renderless/common/global'
@@ -17,15 +17,16 @@ if (window.__POWERED_BY_WUJIE__) {
 }
 ```
 
-## 2、In Vitepress, reference the Opentiny component package and use Vitepress to package the command: pnpm docs:build， report errors: ERR_UNSUPPORTED_DIR_IMPORT
+## 2、In the 'Vitepress' project, reference the 'opentiny' component package and use the 'Vitepress' packaging command: 'pnpm docs:build' ， Causing error: 'ERR_UNSUPPORTED_DIR_IMPORT'
 
-_Reason：_ Using Vitepress packaging, the suffix paths such as js/css related to file references in the component package cannot be found. Causing error: ERR_UNSUPPORTED_DIR_IMPORT
+**Reason:** Unable to find the 'js/css/...' files referenced within the component package waiting for suffix path, error statement: 'Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import "xxx" is not supported resolving ES modules imported from xxx/lib/index.js'
 
-_Solution:_ Resolve the error issue by configuring the 'vitepress/config. js' file:
+**Solution:** In the '. vitepress/config. js' file, add the following code:
 
 ```js
 export default defineConfig({
   vite: {
+    // ...
     ssr: {
       noExternal: [/@opentiny\//]
     }

--- a/examples/sites/demos/pc/webdoc/faq-en.md
+++ b/examples/sites/demos/pc/webdoc/faq-en.md
@@ -17,7 +17,7 @@ if (window.__POWERED_BY_WUJIE__) {
 }
 ```
 
-## 2、In the 'Vitepress' project, reference the 'opentiny' component package and use the 'Vitepress' packaging command: 'pnpm docs:build' ， Causing error: 'ERR_UNSUPPORTED_DIR_IMPORT'
+## 2、In the 'Vitepress' project, reference the 'Opentiny' component package and use the 'Vitepress' packaging command: 'pnpm docs:build' ， Causing error: 'ERR_UNSUPPORTED_DIR_IMPORT'
 
 **Reason:** Unable to find the 'js/css/...' files referenced within the component package waiting for suffix path, error statement: 'Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import "xxx" is not supported resolving ES modules imported from xxx/lib/index.js'
 

--- a/examples/sites/demos/pc/webdoc/faq-en.md
+++ b/examples/sites/demos/pc/webdoc/faq-en.md
@@ -16,3 +16,19 @@ if (window.__POWERED_BY_WUJIE__) {
   globalConfig.viewportWindow = window.parent
 }
 ```
+
+## 2、In Vitepress, reference the Opentiny component package and use Vitepress to package the command: pnpm docs:build， report errors: ERR_UNSUPPORTED_DIR_IMPORT
+
+_Reason：_ Using Vitepress packaging, the suffix paths such as js/css related to file references in the component package cannot be found. Causing error: ERR_UNSUPPORTED_DIR_IMPORT
+
+_Solution:_ Resolve the error issue by configuring the 'vitepress/config. js' file:
+
+```js
+export default defineConfig({
+  vite: {
+    ssr: {
+      noExternal: [/@opentiny\//]
+    }
+  }
+})
+```

--- a/examples/sites/demos/pc/webdoc/faq.md
+++ b/examples/sites/demos/pc/webdoc/faq.md
@@ -17,7 +17,7 @@ if (window.__POWERED_BY_WUJIE__) {
 }
 ```
 
-## 2、在 `Vitepress` 项目中，引用 `opentiny` 组件包，使用 `Vitepress` 打包命令：`pnpm docs:build`，导致报错：`ERR_UNSUPPORTED_DIR_IMPORT`
+## 2、在 `Vitepress` 项目中，引用 `Opentiny` 组件包，使用 `Vitepress` 打包命令：`pnpm docs:build`，导致报错：`ERR_UNSUPPORTED_DIR_IMPORT`
 
 **原因：** 找不到组件包内引用相关文件的 `js/css/...` 等后缀路径，报错语句：`Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import 'xxx' is not supported resolving ES modules imported from xxx/lib/index.js`
 

--- a/examples/sites/demos/pc/webdoc/faq.md
+++ b/examples/sites/demos/pc/webdoc/faq.md
@@ -2,10 +2,10 @@
 
 ## 1、弹出元素在无界微前端中发生错位、翻转
 
-_原因：_ 弹出类的元素，存在一个边界检测逻辑，在子应用中，`window` 的宽高可能会比视口小得多，
+**原因：** 弹出类的元素，存在一个边界检测逻辑，在子应用中，`window` 的宽高可能会比视口小得多，
 因此会错误判断边界，导致翻转和错位等问题。
 
-_解决方案:_ 引入 popup 全局配置，将主应用的 `window` 赋值给全局配置的 `viewportWindow` 用于边界判断
+**解决方案：** 引入 `popup` 全局配置，将主应用的 `window` 赋值给全局配置的 `viewportWindow` 用于边界判断
 
 ```js
 import globalConfig from '@opentiny/vue-renderless/common/global'
@@ -17,15 +17,16 @@ if (window.__POWERED_BY_WUJIE__) {
 }
 ```
 
-## 2、在vitepress中，引用opentiny组件包，使用vitepress打包命令:pnpm docs:build，报错：ERR_UNSUPPORTED_DIR_IMPORT
+## 2、在 `Vitepress` 项目中，引用 `opentiny` 组件包，使用 `Vitepress` 打包命令：`pnpm docs:build`，导致报错：`ERR_UNSUPPORTED_DIR_IMPORT`
 
-_原因：_ 使用vitepress打包，找不到组件包内文件相关引用的js/css等后缀路径。导致报错：ERR_UNSUPPORTED_DIR_IMPORT
+**原因：** 找不到组件包内引用相关文件的 `js/css/...` 等后缀路径，报错语句：`Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import 'xxx' is not supported resolving ES modules imported from xxx/lib/index.js`
 
-_解决方案:_ 通过配置`vitepress/config.js`文件，解决报错问题：
+**解决方案：** 在`.vitepress/config.js`文件中，加入以下代码：
 
 ```js
 export default defineConfig({
   vite: {
+    // ...
     ssr: {
       noExternal: [/@opentiny\//]
     }

--- a/examples/sites/demos/pc/webdoc/faq.md
+++ b/examples/sites/demos/pc/webdoc/faq.md
@@ -16,3 +16,19 @@ if (window.__POWERED_BY_WUJIE__) {
   globalConfig.viewportWindow = window.parent
 }
 ```
+
+## 2、在vitepress中，引用opentiny组件包，使用vitepress打包命令:pnpm docs:build，报错：ERR_UNSUPPORTED_DIR_IMPORT
+
+_原因：_ 使用vitepress打包，找不到组件包内文件相关引用的js/css等后缀路径。导致报错：ERR_UNSUPPORTED_DIR_IMPORT
+
+_解决方案:_ 通过配置`vitepress/config.js`文件，解决报错问题：
+
+```js
+export default defineConfig({
+  vite: {
+    ssr: {
+      noExternal: [/@opentiny\//]
+    }
+  }
+})
+```


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:
 Add solutions to common problems
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
#2684
## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new FAQ section addressing a VitePress build error when using the Opentiny component package
	- Provided a solution for resolving the `ERR_UNSUPPORTED_DIR_IMPORT` error by configuring `noExternal` in VitePress settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->