### PR TITLE
ci: [button] change ubuntu-latest to ubuntu-22.04 when run e2e test

### DIFF
--- a/.github/workflows/test-e2e-all.yml
+++ b/.github/workflows/test-e2e-all.yml
@@ -10,7 +10,7 @@ jobs:
   dispatch-test-all:
     name: Dispatch All Test
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -63,7 +63,7 @@ jobs:
     if: always()
     needs: [dispatch-test-all]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/test-e2e-dispatch.yml
+++ b/.github/workflows/test-e2e-dispatch.yml
@@ -17,7 +17,7 @@ jobs:
   dispatch-tests:
     name: Dispatch Tests
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Setup pnpm

--- a/.github/workflows/test-e2e-pr-comment.yml
+++ b/.github/workflows/test-e2e-pr-comment.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       pull-requests: write
     name: Comment User Tip
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Download Pr Artifact
         uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/test-e2e-pr.yml
+++ b/.github/workflows/test-e2e-pr.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   parse-components:
     name: Parse Affected Components
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       testComponents: ${{ steps.parseTitle.outputs.testComponents }}
       testclis: ${{ steps.parsetestCli.outputs.testClis }}
@@ -82,7 +82,7 @@ jobs:
 
     name: PR E2E Test
     needs: parse-components
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       TEST_COMPONENTS: ${{ needs.parse-components.outputs.testComponents }}
     steps:

--- a/.github/workflows/test-unit-pr.yml
+++ b/.github/workflows/test-unit-pr.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   parse-components:
     name: Parse Affected Components
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       testComponents: ${{ steps.parseTitle.outputs.testComponents }}
     steps:
@@ -69,7 +69,7 @@ jobs:
   pr-test:
     name: PR Unit Test
     needs: parse-components
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       TEST_COMPONENTS: ${{ needs.parse-components.outputs.testComponents }}
     steps:


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configurations to use Ubuntu 22.04 as the runner environment across multiple test workflows
	- Ensured consistent operating system version for E2E and unit test jobs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->