### PR TITLE
refactor(utils): [grid,tree] rename log to logger

### DIFF
--- a/packages/renderless/src/common/validate/util.ts
+++ b/packages/renderless/src/common/validate/util.ts
@@ -11,7 +11,7 @@
  */
 
 import { hasOwn, isNull } from '../type'
-import { log } from '@opentiny/utils'
+import { logger } from '@opentiny/utils'
 
 const formatRegExp = /%[sdj%]/g
 
@@ -208,7 +208,7 @@ export function asyncMap(objArray, option, func, callback) {
     })
 
     // 校验器会报告中，errors fields 同时存在，属于正常，不打印；  代码真异常才打印。
-    pending.catch((error) => (error.errors && error.fields) || log.logger.error(error))
+    pending.catch((error) => (error.errors && error.fields) || logger.error(error))
     return pending
   }
 
@@ -244,7 +244,7 @@ export function asyncMap(objArray, option, func, callback) {
   })
 
   // 校验器会报告中，errors fields 同时存在，属于正常，不打印；  代码真异常才打印。
-  pending.catch((error) => (error.errors && error.fields) || log.logger.error(error))
+  pending.catch((error) => (error.errors && error.fields) || logger.error(error))
 
   return pending
 }

--- a/packages/renderless/src/currency/index.ts
+++ b/packages/renderless/src/currency/index.ts
@@ -11,7 +11,7 @@
  */
 
 import { isUndefined, isNull } from '../grid/static'
-import { log } from '@opentiny/utils'
+import { logger } from '@opentiny/utils'
 
 export const init =
   ({ state, service, api }) =>
@@ -76,7 +76,7 @@ export const fixServiceData =
           if (text) {
             option[valueField] = text
           } else {
-            log('data error. set it to the default value.', 'warn')
+            logger.warn('data error. set it to the default value.', 'warn')
             option[textField] = option[valueField] = props.currency
           }
         }

--- a/packages/renderless/src/currency/index.ts
+++ b/packages/renderless/src/currency/index.ts
@@ -76,7 +76,7 @@ export const fixServiceData =
           if (text) {
             option[valueField] = text
           } else {
-            logger.warn('data error. set it to the default value.', 'warn')
+            logger.warn('data error. set it to the default value.')
             option[textField] = option[valueField] = props.currency
           }
         }

--- a/packages/renderless/src/file-upload/index.ts
+++ b/packages/renderless/src/file-upload/index.ts
@@ -30,7 +30,7 @@ import type {
 } from '@/types'
 
 import { extend } from '../common/object'
-import { xss, log, crypt } from '@opentiny/utils'
+import { xss, logger, crypt } from '@opentiny/utils'
 import uploadAjax from '../common/deps/upload-ajax'
 import { isObject } from '../common/type'
 import { isEmptyObject } from '../common/type'
@@ -555,7 +555,7 @@ export const handleStart =
     state,
     vm
   }: Pick<IFileUploadRenderlessParams, 'api' | 'constants' | 'props' | 'state' | 'vm'>) =>
-  (rawFiles: IFileUploadFile[], updateId: string, reUpload: boolean = false) => {
+  (rawFiles: IFileUploadFile[], updateId: string, reUpload = false) => {
     if (state.isHwh5) {
       rawFiles = handleHwh5Files(rawFiles, props.hwh5)
     }
@@ -900,7 +900,7 @@ export const abort =
 
 export const abortDownload =
   ({ state }: Pick<IFileUploadRenderlessParams, 'state'>) =>
-  (file: IFileUploadFile, batch: boolean = false) => {
+  (file: IFileUploadFile, batch = false) => {
     const cancel = (docId) => {
       if (!docId) return
       const cancels = state.downloadCancelToken[docId]
@@ -1685,7 +1685,7 @@ export const afterDownload =
           ']'
         ]
 
-        log.logger.warn(msgArray.join(''))
+        logger.warn(msgArray.join(''))
         delete state.downloadReplayAtoms[key]
       } else {
         if (state.downloadReplayAtoms[key] === undefined) {
@@ -1694,7 +1694,7 @@ export const afterDownload =
 
         const msgArray = ['replay ', countDownloadReplay, '! [docId:', file.docId, ', chunk:', range.index, ']']
 
-        log.logger.warn(msgArray.join(''))
+        logger.warn(msgArray.join(''))
 
         state.downloadReplayAtoms[key] += 1
 
@@ -1932,7 +1932,7 @@ const afterUpload = ({
         file.chunk,
         ']'
       ]
-      log.logger.warn(msgArray.join(''))
+      logger.warn(msgArray.join(''))
 
       delete state.replayAtoms[key]
     } else {
@@ -1942,7 +1942,7 @@ const afterUpload = ({
 
       const msgArray = ['replay ', countReplay, '! [docId:', file.docId, ', chunk:', file.chunk, ']']
 
-      log.logger.warn(msgArray.join(''))
+      logger.warn(msgArray.join(''))
 
       state.replayAtoms[key] += 1
 
@@ -2263,7 +2263,7 @@ export const getToken =
 
 export const previewFile =
   ({ api, props }: Pick<IFileUploadRenderlessParams, 'api' | 'props'>) =>
-  (file: IFileUploadFile, open: boolean = false) => {
+  (file: IFileUploadFile, open = false) => {
     return new Promise((resolve, reject) => {
       try {
         const tokenParams = { isOnlinePreview: true, file, type: 'preview', token: props.edm.preview.token }

--- a/packages/renderless/src/tree/index.ts
+++ b/packages/renderless/src/tree/index.ts
@@ -18,7 +18,7 @@ import { on, off } from '../common/deps/dom'
 import { getDataset } from '../common/dataset'
 import { copyArray } from '../common/object'
 
-import { log } from '@opentiny/utils'
+import { logger } from '@opentiny/utils'
 
 export const setChildren = (props) => (data) => (props.data = data)
 
@@ -823,7 +823,7 @@ export const addNode =
     }
 
     if (state.allNodeKeys.includes(nodeId) && !props.editConfig.noWarning) {
-      log.logger.warn(`the ${props.nodeKey || 'id'} ${nodeId} is already exists. Please check.`)
+      logger.warn(`the ${props.nodeKey || 'id'} ${nodeId} is already exists. Please check.`)
     }
 
     state.allNodeKeys.push(nodeId)

--- a/packages/renderless/src/user/index.ts
+++ b/packages/renderless/src/user/index.ts
@@ -14,7 +14,7 @@ import debounce from '../common/deps/debounce'
 import { toDateStr } from '../common/date'
 import { toJsonStr } from '../common/object'
 import { toJson } from '../common/string'
-import { log } from '@opentiny/utils'
+import { logger } from '@opentiny/utils'
 
 const toLowerCase = (val) => {
   return typeof val === 'string' ? val.toLowerCase() : val
@@ -87,7 +87,6 @@ const request = {
   },
 
   setCache(data, valueField) {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const me = this
 
     if (valueField && !this.group[valueField]) {
@@ -116,7 +115,6 @@ const request = {
       })
   },
   batchRequest(api) {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const me = this
     const reqParamsSeq = me.getParams()
     let reqLen = reqParamsSeq.length
@@ -141,7 +139,7 @@ const request = {
               }
             })
           })
-          errors.length && log.logger.warn(`user [${errors.join(',')}] not found`)
+          errors.length && logger.warn(`user [${errors.join(',')}] not found`)
           this.clearRequest()
         }
       }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,11 +1,11 @@
 import xss from './xss'
-import log from './log'
+import logger from './logger'
 import crypt from './crypt'
 
-export { xss, log, crypt }
+export { xss, logger, crypt }
 
 export default {
   xss,
-  log,
+  logger,
   crypt
 }

--- a/packages/utils/src/log/index.ts
+++ b/packages/utils/src/log/index.ts
@@ -1,7 +1,0 @@
-import { getWindow } from '../window'
-
-const _win: any = getWindow()
-/** 使用 log.logger.xxx 代替 window.console.xxx, 避免语法警告 */
-export const log = { logger: _win.console as Console }
-
-export default log

--- a/packages/utils/src/logger/index.ts
+++ b/packages/utils/src/logger/index.ts
@@ -1,0 +1,7 @@
+import { getWindow } from '../window'
+
+const _win: any = getWindow()
+/** 使用 logger.xxx 代替 window.console.xxx, 避免语法警告 */
+export const logger = _win.console as Console
+
+export default logger

--- a/packages/vue-common/package.json
+++ b/packages/vue-common/package.json
@@ -31,6 +31,7 @@
     "@opentiny/vue-locale": "workspace:~",
     "@opentiny/vue-renderless": "workspace:~",
     "@opentiny/vue-theme": "workspace:~",
+    "@opentiny/utils": "workspace:~",
     "tailwind-merge": "^1.8.0"
   },
   "scripts": {

--- a/packages/vue-common/src/breakpoint.ts
+++ b/packages/vue-common/src/breakpoint.ts
@@ -7,7 +7,7 @@ import debounce from '@opentiny/vue-renderless/common/deps/debounce'
  *
  * @example
  * const breakpoint = useBreakpoint()
- * watch(breakpoint.current, (current) => { console.log(current) })
+ * watch(breakpoint.current, (current) => { ...... })
  */
 export const useBreakpoint = () => {
   const activeBreakpoint = hooks.ref('')

--- a/packages/vue/src/grid/src/tools/logger.ts
+++ b/packages/vue/src/grid/src/tools/logger.ts
@@ -1,4 +1,4 @@
-import { log } from '@opentiny/utils'
+import { logger } from '@opentiny/utils'
 import GlobalConfig from '../config'
 
 const outLog = (type) => (message, detail) => {
@@ -8,7 +8,7 @@ const outLog = (type) => (message, detail) => {
     msg += `: ${detail}`
   }
 
-  log.logger.log(msg, type)
+  logger[type](msg)
 
   return msg
 }


### PR DESCRIPTION
# PR
重新指定utils的导出名称， 从log改为logger
确保所有logger只使用 warn ,error的方法
packages/mobile内的没有修改。
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated logging utility across multiple packages from `log` to `logger`
	- Simplified logging method calls in various components

- **Dependency Updates**
	- Added `@opentiny/utils` as a workspace dependency in `vue-common` package

- **Chores**
	- Removed old logging module
	- Created new logger implementation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->