### PR TITLE
fix(tooltip): remove :has selector on popper__arrow

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opentiny/vue-theme",
   "type": "module",
-  "version": "3.21.1",
+  "version": "3.21.2",
   "description": "An enterprise-class UI component library, support both Vue.js 2 and Vue.js 3, as well as PC and mobile.",
   "author": "OpenTiny Team",
   "license": "MIT",

--- a/packages/theme/src/base/reset.less
+++ b/packages/theme/src/base/reset.less
@@ -197,9 +197,9 @@
 }
 
 // 有箭头的场景，统一规范所有样式
-.tiny-popconfirm-popover:has(.popper__arrow),
-.tiny-popper:has(.popper__arrow),
-.tiny-tooltip__popper:has(.popper__arrow) {
+.tiny-popconfirm-popover,
+.tiny-popper,
+.tiny-tooltip__popper {
   .popper__arrow {
     position: absolute;
     display: block;


### PR DESCRIPTION
# PR
:has选择器在低版本浏览器上不支持。此处has并不是必须的，可以移除


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package version for `@opentiny/vue-theme` from `3.21.1` to `3.21.2`

- **Style**
	- Simplified CSS selectors for popover and tooltip components to improve browser compatibility
	- Retained existing styling rules for arrow positioning and appearance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->