### PR TITLE
fix(utils): fixed the issue that the release version of the utils package could not correspond

### DIFF
--- a/packages/renderless/scripts/postbuild.ts
+++ b/packages/renderless/scripts/postbuild.ts
@@ -4,7 +4,7 @@ import { promises as fs } from 'node:fs'
 async function run() {
   const content = await fs.readFile(resolve('package.json'), 'utf8')
   const packageJson = JSON.parse(content)
-  packageJson.dependencies['@opentiny/utils'] = '^1.0.0'
+  packageJson.dependencies['@opentiny/utils'] = `~${packageJson.version.split('.').slice(0, 2).join('.')}.0`
   delete packageJson.exports
   delete packageJson.private
   await fs.writeFile(resolve('dist', 'package.json'), JSON.stringify(packageJson, null, 2))

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opentiny/utils",
   "type": "module",
-  "version": "1.0.0",
+  "version": "3.21.0",
   "description": "nanoid console xss",
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
修复utils包发布版本无法对应的问题

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Update**
	- Updated `@opentiny/utils` package version from `1.0.0` to `3.21.0`
	- Improved dependency versioning mechanism to dynamically align with package version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->