### PR TITLE
fix(select): [select] fix component error caused by vue2 deep cleanup memory leak

### DIFF
--- a/packages/renderless/src/option/vue.ts
+++ b/packages/renderless/src/option/vue.ts
@@ -36,7 +36,7 @@ const initState = ({ reactive, computed, props, api, markRaw, select, parent }) 
     disabled: computed(() => props.disabled || state.groupDisabled),
     isObject: computed(() => Object.prototype.toString.call(props.value).toLowerCase() === '[object object]'),
     currentLabel: computed(() => props.label || (state.isObject ? '' : props.value)),
-    currentValue: computed(() => props.value || props.label || ''),
+    currentValue: props.value || props.label || '',
 
     itemSelected: computed(() => {
       if (!select.multiple) {
@@ -90,7 +90,7 @@ const initWatch = ({ watch, props, state, select, constants }) => {
     () => props.value,
     (value, oldVal) => {
       const { remote, valueKey } = select
-
+      state.currentValue = value || props.label || ''
       if (!props.created && !remote) {
         if (
           valueKey &&


### PR DESCRIPTION
# PR
修复因为vue2深度清理内存泄漏导致的组件报错问题

Vue2.mixin({
  destroyed(){
   delete xxx
  }
})

在深度清理时会删除vue实例的_watcher，导致computed建立的_watcher为undefined的报错

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the handling of `currentValue` property
	- Streamlined value assignment logic for option components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->