### PR TITLE
fix(dialog-box): [dialog-box] right pop-up window height style issue

### DIFF
--- a/packages/theme/src/dialog-box/index.less
+++ b/packages/theme/src/dialog-box/index.less
@@ -182,7 +182,8 @@
       overflow: auto;
       color: var(--tv-DialogBox-drawer-body-color);
       border-bottom: 1px solid var(--tv-DialogBox-drawer-divider-border-color);
-      padding: 0 var(--tv-DialogBox-padding);
+      padding: var(--tv-DialogBox-vertical-padding) var(--tv-DialogBox-padding);
+      max-height: 100vh;
     }
 
     .@{dialog-box-prefix-cls}__footer {


### PR DESCRIPTION
# PR
修改前：
![image](https://github.com/user-attachments/assets/c99cd7a4-ae5d-499e-8747-581fedc83fa3)
修改后：
![image](https://github.com/user-attachments/assets/e736a987-dbb5-4b57-b9e0-302e7d860eb9)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated dialog box styling for right-slide drawer state
	- Improved layout flexibility with dynamic padding
	- Set dialog body maximum height to full viewport height

<!-- end of auto-generated comment: release notes by coderabbit.ai -->