### PR TITLE
fix(alert): move close icon to center

### DIFF
--- a/packages/theme/src/alert/index.less
+++ b/packages/theme/src/alert/index.less
@@ -32,7 +32,7 @@
   }
 
   /** alert-icon 场景 */
-  .@{alert-prefix-cls}__icon {
+  .@{alert-prefix-cls}__icon:not(.@{alert-prefix-cls}__close) {
     font-size: var(--tv-Alert-icon-size);
     margin-right: var(--tv-Alert-icon-margin-right);
     flex-shrink: 0;


### PR DESCRIPTION
# PR
修复Alert组件的关闭按钮偏下的问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced the visual presentation of the alert component by refining the styling applied to the alert icon, ensuring that the close icon maintains a distinct appearance.
  - Retained design decisions regarding border styling for a consistent look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->