### PR TITLE
fix(dialog-select): [dialog-select] fixed an issue where grid data could not be loaded when initially visible was set to true

### DIFF
--- a/packages/renderless/src/dialog-select/vue.ts
+++ b/packages/renderless/src/dialog-select/vue.ts
@@ -130,10 +130,13 @@ export const renderless = (props, { reactive, computed, watch }, { vm, nextTick,
   watch(
     () => props.visible,
     (value) => {
-      if (value && !state.multiGridStore.inited) {
-        api.queryGridData()
-      }
-    }
+      nextTick(() => {
+        if (value && !state.multiGridStore.inited) {
+          api.queryGridData()
+        }
+      })
+    },
+    { immediate: true }
   )
 
   watch(


### PR DESCRIPTION
…d when initially visible was set to true

# PR
修复问题单： dialog-select组件， 初始就将visible设置为true时， 表格数据不加载的问题

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the initialization of grid data in dialogs so that updates now occur seamlessly after the interface renders. This ensures a more consistent and reliable display of data when dialogs open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->