### PR TITLE
fix(fluent-editor): [fluent-editor]  Fixed the bug where the cursor was out of focus when entering line breaks after modifying the font style of the rich text box

### DIFF
--- a/packages/renderless/src/fluent-editor/index.ts
+++ b/packages/renderless/src/fluent-editor/index.ts
@@ -200,10 +200,8 @@ export const handleCompositionend =
       let range = state.quill.getSelection(true)
       const [mentionItem, offset] = state.quill.getLeaf(range.index)
 
-      if (mentionItem.statics.blotName === 'break' || (mentionItem.statics.blotName === 'text' && offset === 0)) {
-        state.quill.clipboard.dangerouslyPasteHTML(data)
-      }
       if (mentionItem.statics.blotName === 'break') {
+        state.quill.clipboard.dangerouslyPasteHTML(data)
         state.quill.setSelection(range.index + event.data.length)
       } else {
         let pattern = /[\u4E00-\u9FA5\uF900-\uFA2D]/


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the editor’s behavior to paste HTML content more consistently, ensuring a smoother editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->