### PR TITLE
fix(renderless): restore the removed InfiniteScroll variable

### DIFF
--- a/packages/renderless/package.json
+++ b/packages/renderless/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "@opentiny/utils": "workspace:~",
-    "@opentiny/vue-directive": "workspace:~",
     "@opentiny/vue-hooks": "workspace:~",
     "color": "4.2.3"
   },

--- a/packages/renderless/package.json
+++ b/packages/renderless/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@opentiny/utils": "workspace:~",
+    "@opentiny/vue-directive": "workspace:~",
     "@opentiny/vue-hooks": "workspace:~",
     "color": "4.2.3"
   },

--- a/packages/renderless/src/common/deps/dom.ts
+++ b/packages/renderless/src/common/deps/dom.ts
@@ -1,0 +1,20 @@
+export {
+  on,
+  off,
+  once,
+  hasClass,
+  addClass,
+  removeClass,
+  getStyle,
+  setStyle,
+  isScroll,
+  getScrollContainer,
+  isInContainer,
+  getDomNode,
+  getScrollTop,
+  stopPropagation,
+  preventDefault,
+  getScrollParent,
+  useScrollParent,
+  isDisplayNone
+} from '@opentiny/utils'

--- a/packages/renderless/src/common/deps/infinite-scroll.ts
+++ b/packages/renderless/src/common/deps/infinite-scroll.ts
@@ -1,3 +1,172 @@
-import { InfiniteScroll } from '@opentiny/vue-directive'
+import { throttle } from '@opentiny/utils'
+import { getScrollContainer } from '@opentiny/utils'
 
-export default InfiniteScroll
+const CONTEXT_KEY = '@@infinitescrollContext'
+const OBSERVER_CHECK_INTERVAL = 50
+const ATTR_DEFAULT_DELAY = 200
+const ATTR_DEFAULT_DISTANCE = 0
+
+const attrs = {
+  delay: { type: Number, default: ATTR_DEFAULT_DELAY },
+  disabled: { type: Boolean, default: false },
+  distance: { type: Number, default: ATTR_DEFAULT_DISTANCE },
+  immediate: { type: Boolean, default: true }
+}
+
+const isNull = (val) => val === null
+
+const parseAttrValue = (attrVal, type, defaultVal) => {
+  if (isNull(attrVal)) return defaultVal
+
+  if (type === Boolean) {
+    return attrVal !== 'false'
+  } else if (type === Number) {
+    return Number(attrVal)
+  }
+}
+
+const computeScrollOptions = (el, instance) =>
+  Object.entries(attrs).reduce((accumulator, [name, option]) => {
+    const { type, default: defaultValue } = option
+    const attrKey = `infinite-scroll-${name}`
+    const $attrValue = instance.$el.getAttribute(attrKey)
+    const attrValue = el.getAttribute(attrKey)
+    let value
+
+    if ((isNull(attrValue) && isNull($attrValue)) || !isNull(attrValue)) {
+      value = parseAttrValue(attrValue, type, defaultValue)
+    }
+
+    if (isNull(attrValue) && !isNull($attrValue)) {
+      value = parseAttrValue($attrValue, type, defaultValue)
+    }
+
+    accumulator[name] = Number.isNaN(value) ? defaultValue : value
+
+    return accumulator
+  }, {})
+
+const stopObserver = (el) => {
+  const { observer } = el[CONTEXT_KEY]
+
+  if (observer) {
+    observer.disconnect()
+    delete el[CONTEXT_KEY].observer
+  }
+}
+
+const accumOffsetTop = (el) => {
+  let totalOffset = 0
+  let parent = el
+
+  while (parent) {
+    totalOffset += parent.offsetTop
+    parent = parent.offsetParent
+  }
+
+  return totalOffset
+}
+
+const distanceOffsetTop = (el, containerEl) => Math.abs(accumOffsetTop(el) - accumOffsetTop(containerEl))
+
+const scroller = (el, cb) => {
+  const { container, containerEl, instance, observer, lastScrollTop } = el[CONTEXT_KEY]
+  const { disabled, distance } = computeScrollOptions(el, instance)
+  const { clientHeight, scrollHeight, scrollTop } = containerEl
+  const deltaTop = scrollTop - lastScrollTop
+
+  el[CONTEXT_KEY].lastScrollTop = scrollTop
+
+  if (observer || disabled || deltaTop < 0) return
+
+  let isTrigger = false
+
+  if (container === el) {
+    isTrigger = scrollHeight - (clientHeight + scrollTop) <= distance
+  } else {
+    const { clientTop, scrollHeight: height } = el
+    const offsetTop = distanceOffsetTop(el, containerEl)
+
+    isTrigger = scrollTop + clientHeight >= offsetTop + clientTop + height - distance
+  }
+
+  if (isTrigger) {
+    cb.call(instance)
+  }
+}
+
+function observerChecker(el, cb) {
+  const { containerEl, instance } = el[CONTEXT_KEY]
+  const { disabled } = computeScrollOptions(el, instance)
+
+  if (disabled || containerEl.clientHeight === 0) return
+
+  if (containerEl.scrollHeight <= containerEl.clientHeight) {
+    cb.call(instance)
+  } else {
+    stopObserver(el)
+  }
+}
+
+const bind = (el, binding, vnode) => {
+  const instance = binding.instance || vnode.context
+  const { value: cb } = binding
+
+  if (typeof cb !== 'function') {
+    throw new TypeError('[TINY Error][InfiniteScroll] "v-infinite-scroll" binding value must be a function')
+  }
+
+  instance.$nextTick(() => {
+    const { delay, immediate } = computeScrollOptions(el, instance)
+    const container = getScrollContainer(el, true)
+    const containerEl = container === window ? document.documentElement : container
+    const onScroll = throttle(delay, scroller.bind(null, el, cb))
+
+    if (!container) return
+
+    el[CONTEXT_KEY] = { instance, container, containerEl, delay, cb, onScroll, lastScrollTop: containerEl.scrollTop }
+
+    if (immediate) {
+      const observer = new MutationObserver(throttle(OBSERVER_CHECK_INTERVAL, observerChecker.bind(null, el, cb)))
+
+      el[CONTEXT_KEY].observer = observer
+
+      observer.observe(el, { childList: true, subtree: true })
+
+      observerChecker(el, cb)
+    }
+
+    container.addEventListener('scroll', onScroll)
+  })
+}
+
+const update = (el, binding, vnode) => {
+  if (!el[CONTEXT_KEY]) {
+    const instance = binding.instance || vnode.context
+
+    return instance.$nextTick()
+  } else {
+    const { containerEl, cb, observer } = el[CONTEXT_KEY]
+
+    if (containerEl.clientHeight && observer) {
+      observerChecker(el, cb)
+    }
+  }
+}
+
+const unbind = (el) => {
+  const { container, onScroll } = el[CONTEXT_KEY]
+
+  if (container) container.removeEventListener('scroll', onScroll)
+
+  stopObserver(el)
+}
+
+export default {
+  bind,
+  update,
+  unbind,
+  beforeMount: bind,
+  updated: update,
+  unmounted: unbind
+}

--- a/packages/renderless/src/common/deps/infinite-scroll.ts
+++ b/packages/renderless/src/common/deps/infinite-scroll.ts
@@ -1,0 +1,3 @@
+import { InfiniteScroll } from '@opentiny/vue-directive'
+
+export default InfiniteScroll


### PR DESCRIPTION
# PR
还原 InfiniteScroll 指令变量到renderless/common中去
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic infinite scroll functionality, allowing content to load more seamlessly as you navigate.
  - Added utility functions for DOM manipulation and event handling, enhancing the module's capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->