### PR TITLE
fix(date-picker):[date-picker] In the disabled state, can click the icon to activate the panel.

### DIFF
--- a/packages/renderless/src/picker/index.ts
+++ b/packages/renderless/src/picker/index.ts
@@ -943,6 +943,9 @@ export const handleFocus =
   ({ emit, vm, state, api }) =>
   () => {
     const type = state.type
+    if (state.pickerDisabled) {
+      return
+    }
 
     if (DATEPICKER.TriggerTypes.includes(type)) {
       if (state.isMobileScreen && state.isDateMobileComponent) {


### PR DESCRIPTION
# PR
datePicker禁用状态下仍可以点击图标激活面板

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the picker component to prevent focus events when it is disabled, ensuring it remains inactive during unintended interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->