### PR TITLE
fix(select): [select] fix state.selected.state is empty object, and can't get the right displayText

### DIFF
--- a/packages/renderless/src/select/vue.ts
+++ b/packages/renderless/src/select/vue.ts
@@ -251,11 +251,7 @@ const initState = ({ reactive, computed, props, api, emitter, parent, constants,
             const find = props.options.find((opt) => opt[props.valueField] === state.selected.value)
             return find ? find[props.textField] : ''
           } else {
-            return (
-              (state.selected.state
-                ? state.selected.state.currentLabel
-                : state.selected.currentLabel || state.selected.label) || ''
-            )
+            return state.selected.state?.currentLabel || state.selected.currentLabel || state.selected.label || ''
           }
         } else {
           return ''


### PR DESCRIPTION
…the right displayText

# PR
修复 select 组件单选，只读时， state.selected.state对象是空的object， 造成无法取到正确的label值
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced interactive display elements, including dynamic icons and tag visuals for a more intuitive interface.
	- Improved responsiveness to data changes for smoother, real-time updates.
	- Introduced new options for resetting search inputs and managing display states, streamlining user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->