### PR TITLE
fix(cascader): [cascader,select] add the changeCompat attribute to the component

### DIFF
--- a/packages/renderless/src/cascader/vue.ts
+++ b/packages/renderless/src/cascader/vue.ts
@@ -133,7 +133,8 @@ const initState = ({
     isHidden: false,
     tooltipVisible: false,
     tooltipContent: '',
-    tagTypeWhenMultiple: designConfig?.tagTypeWhenMultiple || ''
+    tagTypeWhenMultiple: designConfig?.tagTypeWhenMultiple || '',
+    userChangeValue: false
   })
 
   return state as ICascaderState
@@ -188,7 +189,7 @@ const initApi = ({
     watchValue: watchValue({ api, state }),
     computePresentTags: computePresentTags({ api, props, state }),
     computePresentContent: computePresentContent({ api, state }),
-    watchCheckedValue: watchCheckedValue({ constants, dispatch, api, nextTick, emit, state }),
+    watchCheckedValue: watchCheckedValue({ constants, dispatch, api, nextTick, emit, state, props }),
     toggleDropDownVisible: toggleDropDownVisible({ emit, vm, state, updatePopper }),
     selfMounted: selfMounted({ api, parent, props, vm, state }),
     handleBeforeUpdate: handleBeforeUpdate({ props, api, state }),
@@ -217,7 +218,7 @@ const initWatch = ({
 }) => {
   watch(() => state.disabled, api.computePresentContent)
 
-  watch(() => props.modelValue, api.watchValue)
+  watch(() => props.modelValue, api.watchValue) // 用户在修改值，不必触发change
 
   watch(() => state.checkedValue, api.watchCheckedValue)
 

--- a/packages/vue/src/cascader/src/index.ts
+++ b/packages/vue/src/cascader/src/index.ts
@@ -100,6 +100,10 @@ export const cascaderProps = {
   blank: {
     type: Boolean,
     default: false
+  },
+  changeCompat: {
+    type: Boolean,
+    default: false
   }
 }
 

--- a/packages/vue/src/cascader/src/mobile-first.vue
+++ b/packages/vue/src/cascader/src/mobile-first.vue
@@ -40,6 +40,7 @@ import { IconChevronRight } from '@opentiny/vue-icon'
 
 import CascaderMobile from '@opentiny/vue-cascader-mobile'
 import PcFirst from './pc-first.vue'
+
 export default defineComponent({
   props: [
     ...props,
@@ -91,7 +92,8 @@ export default defineComponent({
     'expand-change',
     'active-item-change',
     'remove-tag',
-    'created'
+    'created',
+    'changeCompat'
   ],
   setup(props, ctx) {
     const bp = useBreakpoint().current

--- a/packages/vue/src/cascader/src/pc.vue
+++ b/packages/vue/src/cascader/src/pc.vue
@@ -234,7 +234,8 @@ export default defineComponent({
     'label',
     'tip',
     'hoverExpand',
-    'blank'
+    'blank',
+    'changeCompat'
   ],
   emits: [
     'update:modelValue',

--- a/packages/vue/src/option/src/pc.vue
+++ b/packages/vue/src/option/src/pc.vue
@@ -17,6 +17,7 @@
       },
       highlightClass
     ]"
+    :title="state.currentLabel || ''"
   >
     <span v-if="state.selectMultiple" class="tiny-option__checkbox-wrap tiny-select-dropdown__item-checkbox">
       <component :is="`icon-${state.selectCls}`" :class="`tiny-svg-size ${state.selectCls}`" />


### PR DESCRIPTION
# PR
为cascader组件添加changeCompat属性
为option 组件添加默认的title属性

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced responsiveness as the Cascader now distinguishes user-triggered actions from automated updates.
	- A new compatibility mode option has been added, enabling tailored event handling across mobile and desktop experiences.
	- Improved accessibility with dynamic tooltips providing additional context on selectable options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->