### PR TITLE
fix(grid): [grid] fix gird header tip error show

### DIFF
--- a/packages/vue/src/grid/src/tooltip/src/methods.ts
+++ b/packages/vue/src/grid/src/tooltip/src/methods.ts
@@ -53,7 +53,8 @@ export default {
     const rangeWidth = range.getBoundingClientRect().width
     const padding =
       (parseInt(getStyle(cell, 'paddingLeft'), 10) || 0) + (parseInt(getStyle(cell, 'paddingRight'), 10) || 0)
-    const isOverflow = rangeWidth + padding > cell.offsetWidth || wrapperElem.scrollWidth > wrapperElem.clientWidth
+    const isOverflow =
+      rangeWidth + padding > cell.getBoundingClientRect().width || wrapperElem.scrollWidth > wrapperElem.clientWidth
 
     // content如果是空字符串，但是用户配置了contentMethod，则同样也可以触发提示
     if ((contentMethod || content) && (showTip || isOverflow)) {


### PR DESCRIPTION
# PR
修复表头溢出提示错误显示问题
问题根因：
offsetWidth获取到的宽度是非精确宽度，会进行四舍五入处理，导致个别场景下计算的宽度比父容器小，错误的判断为溢出状态

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced tooltip behavior in grid cells by refining how content overflow is detected, ensuring tooltips appear more consistently when cell content exceeds its boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->