### PR TITLE
fix: fixed the background color of the official website API table expansion

### DIFF
--- a/examples/sites/src/views/components-doc/components/api-docs.vue
+++ b/examples/sites/src/views/components-doc/components/api-docs.vue
@@ -220,10 +220,6 @@ defineExpose({ jumpToApi })
     padding-left: 16px;
   }
 
-  :deep(.tiny-grid-body__expanded-cell) {
-    background-color: #fafafa;
-  }
-
   :deep(code) {
     color: #476582;
     padding: 4px 8px;

--- a/packages/theme/src/grid/table.less
+++ b/packages/theme/src/grid/table.less
@@ -26,7 +26,7 @@
   overflow: hidden;
   font-size: var(--tv-Grid-font-size);
   color: var(--tv-Grid-text-color);
-  background-color: #fff;
+  background-color: var(--tv-Grid-bg-color);
 
   // 展开行背景颜色
   .@{grid-prefix-cls}-body__expanded-row {


### PR DESCRIPTION
修复官网api表格展开背景色
![image](https://github.com/user-attachments/assets/acc0e9a0-965b-48e5-9a1e-c8837ac6f72b)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Expanded grid cells no longer use a fixed background color, allowing them to inherit default styling.
  - The grid table’s background color has been updated to use a themable variable, enabling more flexible customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->