### PR TITLE
fix(datetime-picker): fix datetime-picker's display to flex in mobilefirst

### DIFF
--- a/packages/vue/src/picker/src/token.ts
+++ b/packages/vue/src/picker/src/token.ts
@@ -1,7 +1,7 @@
 export const classes = {
   'input-label': 'text-color-text-placeholder text-xs sm:text-sm mr-2 inline-block text-left max-w-[100px] truncate',
   'range-editor':
-    'bg-color-bg-1 relative inline-flex items-center py-1 sm:px-3 border-0 sm:border border-color-border hover:border-color-border-hover rounded mt-0.5',
+    'bg-color-bg-1 relative flex items-center py-1 sm:px-3 border-0 sm:border border-color-border hover:border-color-border-hover rounded mt-0.5',
   'range-input':
     'appearance-none border-none outline-0 p-0 w-[35%] text-color-text-primary focus:border-color-brand-focus disabled:border-color-border placeholder:text-color-text-placeholder disabled:cursor-not-allowed text-sm sm:placeholder:text-sm sm:text-sm h-full m-0 truncate disabled:text-color-icon-placeholder disabled:bg-transparent sm:disabled:bg-color-border-disabled',
   'datetimerange': 'w-full sm:w-96 sm:max-w-full',


### PR DESCRIPTION
 
# PR
datetime-picker的多端模板中，宽度自适应容器
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the visual styling of the range editor component. The layout adjustment improves the arrangement and alignment of its child elements for a cleaner, more responsive interface. This enhancement addresses consistency issues, ensuring smoother interactions and providing users with a more polished, intuitive experience when using the range editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->