### PR TITLE
fix(grid): [grid ] fix grid show overflow tip error when navigator scale

### DIFF
--- a/packages/vue/src/grid/src/tooltip/src/methods.ts
+++ b/packages/vue/src/grid/src/tooltip/src/methods.ts
@@ -47,14 +47,16 @@ export default {
     }
     const tooltip = this.$refs.tooltip
     const wrapperElem = cell
-    const content = cell.innerText.trim() || cell.textContent.trim()
+    const content = cell.innerText.trim()
     const { contentMethod } = this.tooltipConfig
     const range = createTooltipRange({ _vm: this, cell, column, isHeader })
     const rangeWidth = range.getBoundingClientRect().width
     const padding =
       (parseInt(getStyle(cell, 'paddingLeft'), 10) || 0) + (parseInt(getStyle(cell, 'paddingRight'), 10) || 0)
     const isOverflow =
-      rangeWidth + padding > cell.getBoundingClientRect().width || wrapperElem.scrollWidth > wrapperElem.clientWidth
+      // 浏览器缩放情况下，会存在细微的像素无法，因此设置0.1像素作为误差量
+      rangeWidth + padding > cell.getBoundingClientRect().width + 0.1 ||
+      wrapperElem.scrollWidth > wrapperElem.clientWidth
 
     // content如果是空字符串，但是用户配置了contentMethod，则同样也可以触发提示
     if ((contentMethod || content) && (showTip || isOverflow)) {


### PR DESCRIPTION
# PR
修复当浏览器缩放时，表格错误地展示了溢出提示。
问题根因：
![image](https://github.com/user-attachments/assets/ac4fbeae-6d15-4a54-bca1-c393f49fd216)
当浏览器缩放的情况下，元素宽度可能会出现小数点的情况。导致计算时，出现误差，导致了错误的判断了溢出。
![image](https://github.com/user-attachments/assets/61e5694f-ec0a-4407-9601-041383c415a6)
解决方案：
增加0.1像素的计算误差，在误差范围内，判断为不溢出。
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined tooltip behavior to prevent unintended fallback text from appearing when no content is provided.
	- Enhanced tooltip overflow detection by incorporating a slight tolerance, ensuring more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->