### PR TITLE
feat(progress): [progress] add slot support for custom status icons

### DIFF
--- a/examples/sites/demos/apis/progress.js
+++ b/examples/sites/demos/apis/progress.js
@@ -140,7 +140,17 @@ export default {
       ],
       events: [],
       methods: [],
-      slots: []
+      slots: [
+        {
+          name: 'statusIcon',
+          desc: {
+            'zh-CN': '状态插槽，successIcon / exceptionIcon / warningIcon',
+            'en-US': 'Status slot, successIcon / exceptionIcon / warningIcon'
+          },
+          mode: ['pc', 'mobile-first'],
+          pcDemo: 'slot-icon-status'
+        }
+      ]
     }
   ],
   types: [

--- a/examples/sites/demos/apis/progress.js
+++ b/examples/sites/demos/apis/progress.js
@@ -148,7 +148,10 @@ export default {
             'en-US': 'Status slot, successIcon / exceptionIcon / warningIcon'
           },
           mode: ['pc', 'mobile-first'],
-          pcDemo: 'slot-icon-status'
+          pcDemo: 'slot-icon-status',
+          meta: {
+            stable: '3.22.0'
+          }
         }
       ]
     }

--- a/examples/sites/demos/mobile-first/app/progress/slot-icon-status.vue
+++ b/examples/sites/demos/mobile-first/app/progress/slot-icon-status.vue
@@ -1,0 +1,35 @@
+<template>
+  <div>
+    <tiny-progress class="progress" :stroke-width="12" :percentage="100" status="success">
+      <template #successIcon>
+        <TinyIconSmile />
+      </template>
+    </tiny-progress>
+    <br />
+    <tiny-progress class="progress" :stroke-width="12" :percentage="80" status="warning">
+      <template #warningIcon>
+        <TinyIconMeh />
+      </template>
+    </tiny-progress>
+    <br />
+    <tiny-progress class="progress" :stroke-width="12" :percentage="50" status="exception">
+      <template #exceptionIcon>
+        <TinyIconFrown />
+      </template>
+    </tiny-progress>
+  </div>
+</template>
+
+<script lang="jsx">
+import { TinyProgress } from '@opentiny/vue'
+import { IconFrown, IconMeh, IconSmile } from '@opentiny/vue-icon'
+
+export default {
+  components: {
+    TinyProgress,
+    TinyIconSmile: IconSmile(),
+    TinyIconMeh: IconMeh(),
+    TinyIconFrown: IconFrown()
+  }
+}
+</script>

--- a/examples/sites/demos/pc/app/progress/slot-icon-status-composition-api.vue
+++ b/examples/sites/demos/pc/app/progress/slot-icon-status-composition-api.vue
@@ -1,0 +1,30 @@
+<template>
+  <div>
+    <tiny-progress class="progress" :stroke-width="12" :percentage="100" status="success">
+      <template #successIcon>
+        <TinyIconSmile />
+      </template>
+    </tiny-progress>
+    <br />
+    <tiny-progress class="progress" :stroke-width="12" :percentage="80" status="warning">
+      <template #warningIcon>
+        <TinyIconMeh />
+      </template>
+    </tiny-progress>
+    <br />
+    <tiny-progress class="progress" :stroke-width="12" :percentage="50" status="exception">
+      <template #exceptionIcon>
+        <TinyIconFrown />
+      </template>
+    </tiny-progress>
+  </div>
+</template>
+
+<script setup>
+import { TinyProgress } from '@opentiny/vue'
+import { IconFrown, IconMeh, IconSmile } from '@opentiny/vue-icon'
+
+const TinyIconSmile = IconSmile()
+const TinyIconMeh = IconMeh()
+const TinyIconFrown = IconFrown()
+</script>

--- a/examples/sites/demos/pc/app/progress/slot-icon-status.spec.ts
+++ b/examples/sites/demos/pc/app/progress/slot-icon-status.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Icon Status Slots', () => {
+  test('should display correct icon for success status', async ({ page }) => {
+    page.on('pageerror', (exception) => expect(exception).not.toBeNull())
+    await page.goto('progress#slot-icon-status')
+
+    const successProgress = page.locator('.progress').nth(0)
+    const successIcon = successProgress.locator('svg')
+
+    await expect(successProgress).toHaveAttribute('status', 'success')
+    await expect(successIcon).toBeVisible()
+    await expect(successIcon).toHaveClass(/tiny-icon-smile/)
+  })
+
+  test('should display correct icon for warning status', async ({ page }) => {
+    page.on('pageerror', (exception) => expect(exception).not.toBeNull())
+    await page.goto('progress#slot-icon-status')
+
+    const warningProgress = page.locator('.progress').nth(1)
+    const warningIcon = warningProgress.locator('svg')
+
+    await expect(warningProgress).toHaveAttribute('status', 'warning')
+    await expect(warningIcon).toBeVisible()
+    await expect(warningIcon).toHaveClass(/tiny-icon-meh/)
+  })
+
+  test('should display correct icon for exception status', async ({ page }) => {
+    page.on('pageerror', (exception) => expect(exception).not.toBeNull())
+    await page.goto('progress#slot-icon-status')
+
+    const exceptionProgress = page.locator('.progress').nth(2)
+    const exceptionIcon = exceptionProgress.locator('svg')
+
+    await expect(exceptionProgress).toHaveAttribute('status', 'exception')
+    await expect(exceptionIcon).toBeVisible()
+    await expect(exceptionIcon).toHaveClass(/tiny-icon-frown/)
+  })
+})

--- a/examples/sites/demos/pc/app/progress/slot-icon-status.spec.ts
+++ b/examples/sites/demos/pc/app/progress/slot-icon-status.spec.ts
@@ -5,35 +5,34 @@ test.describe('Icon Status Slots', () => {
     page.on('pageerror', (exception) => expect(exception).not.toBeNull())
     await page.goto('progress#slot-icon-status')
 
-    const successProgress = page.locator('.progress').nth(0)
-    const successIcon = successProgress.locator('svg')
-
-    await expect(successProgress).toHaveAttribute('status', 'success')
-    await expect(successIcon).toBeVisible()
-    await expect(successIcon).toHaveClass(/tiny-icon-smile/)
+    const progressLocator = page.getByRole('progressbar').nth(0)
+    const iconLocator = progressLocator.locator('svg')
+    await expect(progressLocator).toHaveClass(/is-success/)
+    await expect(iconLocator).toBeVisible()
+    await expect(iconLocator.locator('.smile_svg__st0').first()).toBeVisible()
   })
 
   test('should display correct icon for warning status', async ({ page }) => {
     page.on('pageerror', (exception) => expect(exception).not.toBeNull())
     await page.goto('progress#slot-icon-status')
 
-    const warningProgress = page.locator('.progress').nth(1)
-    const warningIcon = warningProgress.locator('svg')
+    const progressLocator = page.getByRole('progressbar').nth(1)
+    const iconLocator = progressLocator.locator('svg')
 
-    await expect(warningProgress).toHaveAttribute('status', 'warning')
-    await expect(warningIcon).toBeVisible()
-    await expect(warningIcon).toHaveClass(/tiny-icon-meh/)
+    await expect(progressLocator).toHaveClass(/is-warning/)
+    await expect(iconLocator).toBeVisible()
+    await expect(iconLocator.locator('.meh_svg__st0').first()).toBeVisible()
   })
 
   test('should display correct icon for exception status', async ({ page }) => {
     page.on('pageerror', (exception) => expect(exception).not.toBeNull())
     await page.goto('progress#slot-icon-status')
 
-    const exceptionProgress = page.locator('.progress').nth(2)
-    const exceptionIcon = exceptionProgress.locator('svg')
+    const progressLocator = page.getByRole('progressbar').nth(2)
+    const iconLocator = progressLocator.locator('svg')
 
-    await expect(exceptionProgress).toHaveAttribute('status', 'exception')
-    await expect(exceptionIcon).toBeVisible()
-    await expect(exceptionIcon).toHaveClass(/tiny-icon-frown/)
+    await expect(progressLocator).toHaveClass(/is-exception/)
+    await expect(iconLocator).toBeVisible()
+    await expect(iconLocator.locator('.frown_svg__st0').first()).toBeVisible()
   })
 })

--- a/examples/sites/demos/pc/app/progress/slot-icon-status.vue
+++ b/examples/sites/demos/pc/app/progress/slot-icon-status.vue
@@ -1,0 +1,35 @@
+<template>
+  <div>
+    <tiny-progress class="progress" :stroke-width="12" :percentage="100" status="success">
+      <template #successIcon>
+        <TinyIconSmile />
+      </template>
+    </tiny-progress>
+    <br />
+    <tiny-progress class="progress" :stroke-width="12" :percentage="80" status="warning">
+      <template #warningIcon>
+        <TinyIconMeh />
+      </template>
+    </tiny-progress>
+    <br />
+    <tiny-progress class="progress" :stroke-width="12" :percentage="50" status="exception">
+      <template #exceptionIcon>
+        <TinyIconFrown />
+      </template>
+    </tiny-progress>
+  </div>
+</template>
+
+<script lang="jsx">
+import { TinyProgress } from '@opentiny/vue'
+import { IconFrown, IconMeh, IconSmile } from '@opentiny/vue-icon'
+
+export default {
+  components: {
+    TinyProgress,
+    TinyIconSmile: IconSmile(),
+    TinyIconMeh: IconMeh(),
+    TinyIconFrown: IconFrown()
+  }
+}
+</script>

--- a/examples/sites/demos/pc/app/progress/webdoc/progress.js
+++ b/examples/sites/demos/pc/app/progress/webdoc/progress.js
@@ -56,6 +56,18 @@ export default {
       codeFiles: ['progress-status.vue']
     },
     {
+      demoId: 'slot-icon-status',
+      name: {
+        'zh-CN': '图标状态插槽',
+        'en-US': 'Icon Status Slot'
+      },
+      desc: {
+        'zh-CN': '通过插槽自定义状态图标。',
+        'en-US': 'Customize the status icon through a slot.'
+      },
+      codeFiles: ['slot-icon-status.vue']
+    },
+    {
       demoId: 'custom-status',
       name: {
         'zh-CN': '自定义状态场景',

--- a/packages/vue/src/progress/src/mobile-first.vue
+++ b/packages/vue/src/progress/src/mobile-first.vue
@@ -108,19 +108,21 @@
             <span v-if="typeof format !== 'function'" :style="{ fontSize: state.percentTextSize + 'px' }">%</span>
           </div>
         </template>
-        <component
-          v-else
-          :is="state.iconClass"
-          :class="[
-            status === 'success' && 'fill-color-success',
-            status === 'warning' && 'fill-color-warning',
-            status === 'exception' && 'fill-color-error',
-            size === 'small' ? (type === 'line' ? 'w-3 h-3' : 'w-6 h-6') : '',
-            size === 'medium' ? (type === 'line' ? 'w-4 h-4' : 'w-10 h-10') : '',
-            size === 'large' ? (type === 'line' ? 'w-6 h-6' : 'w-20 h-20') : ''
-          ]"
-          :style="state.iconStyle"
-        />
+
+        <slot v-else :name="status + 'Icon'">
+          <component
+            :is="state.iconClass"
+            :class="[
+              status === 'success' && 'fill-color-success',
+              status === 'warning' && 'fill-color-warning',
+              status === 'exception' && 'fill-color-error',
+              size === 'small' ? (type === 'line' ? 'w-3 h-3' : 'w-6 h-6') : '',
+              size === 'medium' ? (type === 'line' ? 'w-4 h-4' : 'w-10 h-10') : '',
+              size === 'large' ? (type === 'line' ? 'w-6 h-6' : 'w-20 h-20') : ''
+            ]"
+            :style="state.iconStyle"
+          />
+        </slot>
       </div>
     </div>
     <div

--- a/packages/vue/src/progress/src/pc.vue
+++ b/packages/vue/src/progress/src/pc.vue
@@ -85,7 +85,10 @@
       <template v-if="!status">
         {{ state.content }}
       </template>
-      <component v-else :is="state.iconClass" class="tiny-svg-size" />
+
+      <slot v-else :name="status + 'Icon'">
+        <component :is="state.iconClass" class="tiny-svg-size" />
+      </slot>
     </div>
   </div>
 </template>


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

add slot support for custom status icons

Issue Number: #2973

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a customizable `statusIcon` slot in the progress component, allowing users to display different icons for success, warning, and exception statuses.
  - Added new demo components showcasing the `statusIcon` feature for both PC and mobile-first interfaces.

- **Tests**
  - Added a test suite to verify the correct display and behavior of the status icons for various progress conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->