### PR TITLE
feat(grid): [grid] add mobile first empty slot

### DIFF
--- a/packages/vue/src/grid/src/mobile-first/empty.vue
+++ b/packages/vue/src/grid/src/mobile-first/empty.vue
@@ -1,0 +1,32 @@
+<script lang="ts">
+import { defineComponent, $props, h } from '@opentiny/vue-common'
+
+export default defineComponent({
+  inject: ['$mftable'],
+  props: { ...$props },
+  render() {
+    const { $mftable } = this as any
+    const slotEmpty = $mftable.slotEmpty
+    const renderEmpty = $mftable.renderEmpty
+    const $table = $mftable.config.tableVm
+
+    let content = null
+    if (typeof slotEmpty === 'function') {
+      content = slotEmpty({ $table })
+    } else if (typeof renderEmpty === 'function') {
+      content = renderEmpty(h, $table)
+    }
+
+    return h(
+      'div',
+      {
+        attrs: {
+          'data-tag': 'tiny-grid-empty-wrapper'
+        },
+        class: 'flex t-0 justify-center items-center w-full h-full bg-transparent sm:bg-color-bg-1 text-center'
+      },
+      [content]
+    )
+  }
+})
+</script>

--- a/packages/vue/src/grid/src/mobile-first/index.vue
+++ b/packages/vue/src/grid/src/mobile-first/index.vue
@@ -7,15 +7,18 @@
     :style="wrapperStyle"
     @scroll="scrollEvent"
   >
+    <template v-if="slotEmpty || renderEmpty">
+      <custom-empty />
+    </template>
     <exception
       tiny_mode="mobile-first"
       tiny_mode_root
-      v-if="exceptionVisible"
+      v-else-if="exceptionVisible"
       class="min-h-[theme(spacing.72)]"
       component-page
       type="nodata"
     ></exception>
-    <div data-tag="tiny-table" :class="[tableClass, cardClass]" ref="table">
+    <div v-else data-tag="tiny-table" :class="[tableClass, cardClass]" ref="table">
       <template v-if="listView">
         <list-view />
       </template>
@@ -52,9 +55,10 @@ import GlobalConfig from '../config'
 import ListView from './list-view.vue'
 import GanttView from './gantt-view.vue'
 import CustomView from './custom-view.vue'
+import CustomEmpty from './empty.vue'
 
 export default defineComponent({
-  components: { TableRow, Tooltip, Exception, ListView, GanttView, CustomView },
+  components: { TableRow, Tooltip, Exception, ListView, GanttView, CustomView, CustomEmpty },
   provide() {
     return { $mftable: this }
   },
@@ -165,12 +169,9 @@ export default defineComponent({
       return `${displayStyle}${heightStyle}${maxHeightStyle}`
     },
     exceptionVisible() {
-      const { config, tableData } = this as any
-      const { viewType } = config?.tableVm?.$grid
-      const { CARD, LIST, MF } = GlobalConfig.viewConfig
+      const { tableData } = this as any
       const isException = tableData.length === 0
-
-      return isException && (viewType === CARD || viewType === LIST || viewType === MF)
+      return isException
     }
   },
   watch: {
@@ -218,7 +219,7 @@ export default defineComponent({
       const { renderList } = listConfig
       const { renderGantt } = ganttConfig
       const { renderCustom } = customConfig
-      let fieldName: string = ''
+      let fieldName = ''
       let fieldNames: Array<string> = []
       let propCols: Array<Column> = firstFewPropertyColumn(tableColumn, few)
 
@@ -230,6 +231,7 @@ export default defineComponent({
       let slotList: Function
       let slotGantt: Function
       let slotCustom: Function
+      let slotEmpty: Function
 
       if (primaryField) {
         fieldName = fnField(primaryField)
@@ -263,9 +265,11 @@ export default defineComponent({
       slotList = config?.tableVm?.$grid?.slots?.list || renderList
       slotGantt = config?.tableVm?.$grid?.slots?.gantt || renderGantt
       slotCustom = config?.tableVm?.$grid?.slots?.custom || renderCustom
+      slotEmpty = config?.tableVm?.$grid?.slots?.empty
+      const renderEmpty = config?.tableVm?.$grid?.renderEmpty
 
       Object.assign(this, { primaryColumn, contentColumns, operationColumn, selectionColumn })
-      Object.assign(this, { slotLink, slotList, slotGantt, slotCustom })
+      Object.assign(this, { slotLink, slotList, slotGantt, slotCustom, slotEmpty, renderEmpty })
     },
     typeColumns(columns: Array<Column>, types: Array<String>, field?: string) {
       const cols = types.map((type) => columns.find((column) => column.visible && column[field || 'property'] === type))


### PR DESCRIPTION
# PR
表格多端模板支持空数据插槽
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configurable empty state that displays customized content when no data is available. The display adapts based on provided custom content, enhancing user flexibility.

- **Refactor**
	- Streamlined the conditional rendering logic to clearly differentiate between normal, empty, and exception states, ensuring a more consistent and intuitive grid display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->