### PR TITLE
fix(calendar-view): [calendar-view] change month type from string to number

### DIFF
--- a/examples/sites/demos/apis/calendar-view.js
+++ b/examples/sites/demos/apis/calendar-view.js
@@ -91,7 +91,7 @@ export default {
         },
         {
           name: 'month',
-          type: 'string',
+          type: 'number',
           defaultValue: '',
           desc: {
             'zh-CN': '日历当前显示月份',


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3025 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the calendar view so that the current month is now represented numerically, enhancing consistency in display and interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->