### PR TITLE
fix(site): document search box adapts to the dark theme.

### DIFF
--- a/examples/sites/src/assets/custom-block.less
+++ b/examples/sites/src/assets/custom-block.less
@@ -84,7 +84,7 @@ body {
     --color-danger-title: #900;
   }
 }
-.dark {
+html.dark {
   .markdown-body {
     --color-tip-fg: #d3d5d6;
     --color-tip-bg: #24292f;

--- a/examples/sites/src/assets/custom-markdown.css
+++ b/examples/sites/src/assets/custom-markdown.css
@@ -4,7 +4,7 @@
 }
 
 /* 以下为 github-markdown-css 包的预制颜色，根据暗色主题再修改 */
-.dark .markdown-body {
+html.dark .markdown-body {
   color-scheme: dark;
   --color-prettylights-syntax-comment: #8b949e;
   --color-prettylights-syntax-constant: #79c0ff;
@@ -99,22 +99,22 @@ body .markdown-body {
   text-shadow: none !important;
 }
 
-.dark.dark .markdown-body {
+html.dark.dark .markdown-body {
   background-color: #000;
 }
 
-.dark.dark .markdown-body pre {
+html.dark.dark .markdown-body pre {
   background-color: #1a1a1a;
 }
 
-.dark.dark .markdown-body code {
+html.dark.dark .markdown-body code {
   color: var(--tv-color-text);
 }
 
-.dark.dark .markdown-body code .token.operator {
+html.dark.dark .markdown-body code .token.operator {
   background-color: transparent;
 }
 
-.dark.dark .markdown-body code .hljs-string {
+html.dark.dark .markdown-body code .hljs-string {
   color: #6f42c1;
 }

--- a/examples/sites/src/style.css
+++ b/examples/sites/src/style.css
@@ -74,6 +74,26 @@ strong {
   color: #969faf;
 }
 
+/** docsearch 的暗黑模式 */
+html.dark {
+  --docsearch-text-color: #f5f6f7;
+  --docsearch-container-background: rgba(9, 10, 17, 0.8);
+  --docsearch-modal-background: #15172a;
+  --docsearch-modal-shadow: inset 1px 1px 0 0 #2c2e40, 0 3px 8px 0 #000309;
+  --docsearch-searchbox-background: #090a11;
+  --docsearch-searchbox-focus-background: #000;
+  --docsearch-hit-color: #bec3c9;
+  --docsearch-hit-shadow: none;
+  --docsearch-hit-background: #090a11;
+  --docsearch-key-gradient: linear-gradient(-26.5deg, #565872, #31355b);
+  --docsearch-key-shadow: inset 0 -2px 0 0 #282d55, inset 0 0 1px 1px #51577d, 0 2px 2px 0 rgba(3, 4, 9, 0.3);
+  --docsearch-key-pressed-shadow: inset 0 -2px 0 0 #282d55, inset 0 0 1px 1px #51577d, 0 1px 1px 0 #0304094d;
+  --docsearch-footer-background: #1e2136;
+  --docsearch-footer-shadow: inset 0 1px 0 0 rgba(73, 76, 106, 0.5), 0 -4px 8px 0 rgba(0, 0, 0, 0.2);
+  --docsearch-logo-color: #fff;
+  --docsearch-muted-color: #7f8497;
+}
+
 :root {
   --docsearch-primary-color: #1476ff;
   --docsearch-searchbox-background: #f5f5f5;

--- a/examples/sites/src/views/components-doc/common.vue
+++ b/examples/sites/src/views/components-doc/common.vue
@@ -513,6 +513,7 @@ defineExpose({ loadPage })
   justify-content: space-between;
   align-items: flex-start;
   column-gap: 16px;
+  overflow: auto;
 }
 
 .cmp-container {

--- a/examples/sites/src/views/components-doc/components/api-docs.vue
+++ b/examples/sites/src/views/components-doc/components/api-docs.vue
@@ -184,11 +184,7 @@ defineExpose({ jumpToApi })
   color: var(--primary);
   border: 1px solid var(--primary);
 }
-.dark .api-groupname-tag {
-  color: var(--tv-color-text-secondary);
-  background-color: var(--tv-color-bg-header);
-  border: none;
-}
+
 .api-table-box {
   overflow-x: auto;
   width: 100%;
@@ -229,5 +225,13 @@ defineExpose({ jumpToApi })
     background-color: var(--tv-color-bg-header);
     border-radius: 3px;
   }
+}
+</style>
+
+<style lang="less">
+html.dark .api-groupname-tag {
+  color: var(--tv-color-text-secondary);
+  background-color: var(--tv-color-bg-header);
+  border: none;
 }
 </style>

--- a/examples/sites/src/views/components-doc/components/demo.vue
+++ b/examples/sites/src/views/components-doc/components/demo.vue
@@ -398,12 +398,12 @@ onBeforeUnmount(() => {
 </style>
 
 <style lang="less">
-.dark .pc-demo-container.pc-demo-container {
+html.dark .pc-demo-container.pc-demo-container {
   background-color: #1a1a1a;
   border: none;
 }
 
-.dark .demo-content.demo-content .demo-desc {
+html.dark .demo-content.demo-content .demo-desc {
   color: #b3b3b3;
 }
 </style>

--- a/examples/sites/src/views/components-doc/components/float-settings.vue
+++ b/examples/sites/src/views/components-doc/components/float-settings.vue
@@ -275,7 +275,7 @@ export default defineComponent({
     margin-right: 0;
   }
 }
-.dark .settings-btn {
+html.dark .settings-btn {
   background-color: var(--tv-color-bg-dark);
 }
 
@@ -363,7 +363,7 @@ export default defineComponent({
   border-radius: 12px;
   background-color: var(--tv-color-bg);
 }
-.dark .tiny-popover.tiny-popper.theme-settings-popover {
+html.dark .tiny-popover.tiny-popper.theme-settings-popover {
   background-color: var(--tv-color-bg-dark);
 }
 

--- a/examples/sites/src/views/components-doc/components/header.vue
+++ b/examples/sites/src/views/components-doc/components/header.vue
@@ -70,7 +70,7 @@ const mdContent = computed(() =>
 </style>
 
 <style lang="less">
-.dark .docs-header {
+html.dark .docs-header {
   background-color: #1a1a1a;
 
   .markdown-top-body {

--- a/examples/sites/src/views/layout/layout.vue
+++ b/examples/sites/src/views/layout/layout.vue
@@ -394,7 +394,7 @@ export default defineComponent({
   }
 }
 
-.dark #layoutSider {
+html.dark #layoutSider {
   border-right: 1px solid #1a1a1a; // 没有常用变量
 }
 

--- a/examples/sites/src/views/overview.vue
+++ b/examples/sites/src/views/overview.vue
@@ -214,7 +214,7 @@ export default defineComponent({
   }
 }
 
-.dark .component-card {
+html.dark .component-card {
   &:hover {
     box-shadow: 1px 1px 6px 6px rgba(255, 255, 255, 0.08);
   }
@@ -229,7 +229,7 @@ export default defineComponent({
   width: 24.25%;
 }
 
-.dark .overview-card-container {
+html.dark .overview-card-container {
   background-color: var(--tv-color-bg-dark);
 }
 

--- a/packages/theme/src/checkbox/vars.less
+++ b/packages/theme/src/checkbox/vars.less
@@ -46,5 +46,5 @@
   // 复选框选中禁用背景色
   --tv-Checkbox-checked-disabled-bg-color: var(--tv-color-icon-checked-disabled);
   // 复选框选中禁用边框色
-  --tv-Checkbox-checked-disabled-border-color: var(--tv-color-bg-disabled-control-unactive)
+  --tv-Checkbox-checked-disabled-border-color: var(--tv-color-bg-disabled-control-unactive);
 }


### PR DESCRIPTION
# PR
1、 文档搜索框适配暗色主题
2、去掉charts-doc 的基本文档页面滚动时，出现的颜色转换
3、所有的.dark选择器改为：  html.dark，  避免dark类的无意识污染

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced dark mode appearance across various pages and components for a more consistent and refined look.
  - Updated styles for search, layout, and content cards to ensure improved readability and visual alignment.
  - Enabled automatic scrolling for horizontal content containers to improve usability.
  
- **Chores**
  - Fixed minor syntax issues to ensure smoother CSS behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->