### PR TITLE
fix(ip-address): [ip-address] fix IPv6 display error when ipValidator not true

### DIFF
--- a/packages/renderless/src/ip-address/index.ts
+++ b/packages/renderless/src/ip-address/index.ts
@@ -89,32 +89,31 @@ export const getValue =
 export const setValue =
   ({ api, props, state }: { api: IIpAddressApi; props: IIpAddressProps; state: IIpAddressState }) =>
   (value: string) => {
-    if (value) {
-      /* istanbul ignore else */
-      if (api?.ipValidator?.(value)) {
-        if (api.isIP6(props.type)) {
-          state.address = value.split(':').map((item) => ({ value: item }))
-          if (state.address.length < 8) {
-            let insertIndex = 0
-            state.address.forEach((item, index) => {
-              if (item.value === '') {
-                item.value = '0000'
-                insertIndex = index
-              }
-            })
-            for (let i = 0; i <= 8 - state.address.length; i++) {
-              state.address.splice(insertIndex, 0, { value: '0000' })
-            }
-          }
-        } else {
-          state.address = value.split('.').map((item) => ({ value: item }))
-        }
-      }
-    } else {
+    if (!value || !api?.ipValidator?.(value)) {
       const createValue = () => ({ value: '' })
       state.address = api.isIP6(props.type)
-        ? new Array(8).fill('').map(createValue)
-        : new Array(4).fill('').map(createValue)
+        ? Array.from({ length: 8 }, createValue)
+        : Array.from({ length: 4 }, createValue)
+
+      return
+    }
+
+    if (api.isIP6(props.type)) {
+      state.address = value.split(':').map((item) => ({ value: item }))
+      if (state.address.length < 8) {
+        const missingCount = 8 - state.address.length
+        const emptyIndex = state.address.findIndex((item) => item.value === '')
+        const insertIndex = emptyIndex >= 0 ? emptyIndex : 0
+
+        if (emptyIndex >= 0) {
+          state.address[emptyIndex].value = '0000'
+        }
+
+        const newItems = Array(missingCount).fill({ value: '0000' })
+        state.address.splice(insertIndex, 0, ...newItems)
+      }
+    } else {
+      state.address = value.split('.').map((item) => ({ value: item }))
     }
   }
 

--- a/packages/vue/src/ip-address/__tests__/ip-address.test.tsx
+++ b/packages/vue/src/ip-address/__tests__/ip-address.test.tsx
@@ -2,6 +2,7 @@ import { mountPcMode } from '@opentiny-internal/vue-test-utils'
 import { describe, expect, test, vi } from 'vitest'
 import IpAddress from '@opentiny/vue-ip-address'
 import { nextTick } from 'vue'
+import { iconBoat } from '@opentiny/vue-icon'
 
 let value = ''
 
@@ -14,15 +15,47 @@ describe('PC Mode', () => {
     expect(wrapper.find('input').attributes()).toHaveProperty('readonly')
   })
 
-  test.todo('delimiter ，设置IP段之间的分隔符，默认为 "." ')
+  describe('delimiter ，设置IP段之间的分隔符', () => {
+    test('默认为 "." ', async () => {
+      const wrapper = mount(() => <IpAddress v-model={value} />)
+      expect(wrapper.findAll('svg')).toHaveLength(3)
+    })
 
-  test.todo('size ,设置组件大小;该属性的可选值为 medium / small / mini')
+    test('设置为 "-" ', async () => {
+      const wrapper = mount(() => (
+        <IpAddress v-model={value}>
+          <span>-</span>
+        </IpAddress>
+      ))
+      expect(wrapper.findAll('span').map((i) => i.text())).toEqual(['-', '-', '-'])
+    })
 
-  test.todo('disabled ,设置文本的禁用属性，默认为 false ')
+    test('设置为 icon', async () => {
+      const IconBoat = iconBoat()
+      const wrapper = mount(() => <IpAddress v-model={value} delimiter={IconBoat} />)
+      expect(wrapper.findAll('svg')).toHaveLength(3)
+    })
+  })
 
-  test.todo('type ，设置IpAddress框的类型，默认是IPv4，当为IPv6时，只有一个IP端输入框，无分隔符')
+  describe('size, 设置组件大小', () => {
+    ;['medium', 'small', 'mini'].forEach((size) => {
+      test(size, async () => {
+        const wrapper = mount(() => <IpAddress v-model={value} size={size} />)
+        expect(wrapper.find('.tiny-ip-address__input').classes()).toContain(size)
+      })
+    })
+  })
 
-  test.todo('value ，设置文本显示的默认值')
+  test('disabled ,设置文本的禁用属性，默认为 false ', async () => {
+    const wrapper = mount(() => <IpAddress v-model={value} disabled={true} />)
+    expect(wrapper.find('input').attributes()).toHaveProperty('disabled')
+  })
+
+  test('value ，设置文本显示的默认值', async () => {
+    value = '127.0.0.1'
+    const wrapper = mount(() => <IpAddress v-model={value} />)
+    expect(wrapper.findAll('input').map((inputEl) => inputEl.element.value)).toEqual(['127', '0', '0', '1'])
+  })
 
   test('invalid value in ipv6', async () => {
     value = '127.0.0.1'
@@ -40,7 +73,6 @@ describe('PC Mode', () => {
     expect(values).toEqual(Array.from({ length: 4 }, () => ''))
   })
 
-  // slots
   test('default slot', async () => {
     const wrapper = mount(() => (
       <IpAddress

--- a/packages/vue/src/ip-address/__tests__/ip-address.test.tsx
+++ b/packages/vue/src/ip-address/__tests__/ip-address.test.tsx
@@ -24,6 +24,22 @@ describe('PC Mode', () => {
 
   test.todo('value ，设置文本显示的默认值')
 
+  test('invalid value in ipv6', async () => {
+    value = '127.0.0.1'
+    const wrapper = mount(() => <IpAddress v-model={value} type={'ipv6'} />)
+    const values = wrapper.findAll('input').map((inputEl) => inputEl.element.value)
+    expect(values).toHaveLength(8)
+    expect(values).toEqual(Array.from({ length: 8 }, () => ''))
+  })
+
+  test('invalid value in ipv4', async () => {
+    value = 'fe80::204:61ff:fe9d:f156'
+    const wrapper = mount(() => <IpAddress v-model={value} />)
+    const values = wrapper.findAll('input').map((inputEl) => inputEl.element.value)
+    expect(values).toHaveLength(4)
+    expect(values).toEqual(Array.from({ length: 4 }, () => ''))
+  })
+
   // slots
   test('default slot', async () => {
     const wrapper = mount(() => (
@@ -32,7 +48,7 @@ describe('PC Mode', () => {
         v-slots={{
           default: () => <i>--</i>
         }}
-      ></IpAddress>
+      />
     ))
     expect(wrapper.find('i').text()).toBe('--')
   })
@@ -40,7 +56,7 @@ describe('PC Mode', () => {
   // events
   test('events', async () => {
     const focus = vi.fn()
-    const wrapper = mount(() => <IpAddress v-model={value} onFocus={focus}></IpAddress>)
+    const wrapper = mount(() => <IpAddress v-model={value} onFocus={focus} />)
     await wrapper.find('input').trigger('focus')
     await nextTick()
     expect(focus).toHaveBeenCalled()


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3055 

## What is the new behavior?

IPv6 input displays normally

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced IP address input handling by streamlining validation and defaulting behavior for both IPv4 and IPv6 formats.
- **Tests**
  - Expanded test coverage for the IP Address component to verify delimiter options, size variants, disabled states, and proper handling of default and invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->