### PR TITLE
fix(image): [image] fix 'appendToBody' definition placement error

### DIFF
--- a/examples/sites/demos/apis/image.js
+++ b/examples/sites/demos/apis/image.js
@@ -146,6 +146,22 @@ export default {
           mode: ['pc', 'mobile-first'],
           pcDemo: 'keep-style',
           mfDemo: ''
+        },
+        {
+          name: 'appendToBody',
+          type: 'boolean',
+          defaultValue: 'true',
+          meta: {
+            stable: '3.19.0'
+          },
+          desc: {
+            'zh-CN': '预览弹框是否显示在 body 下面。\n为 <code>false</code> 时显示在当前节点下面',
+            'en-US':
+              'Indicates whether the preview dialog box is displayed under the body.\nWhen <code>false</code>, it is displayed under the current node.'
+          },
+          mode: ['pc', 'mobile-first'],
+          pcDemo: 'preview',
+          mfDemo: ''
         }
       ],
       events: [
@@ -221,21 +237,6 @@ export default {
           },
           mode: ['pc', 'mobile-first'],
           pcDemo: 'count-slot',
-          mfDemo: ''
-        },
-        {
-          name: 'appendToBody',
-          type: 'boolean',
-          defaultValue: 'true',
-          meta: {
-            stable: '3.19.0'
-          },
-          desc: {
-            'zh-CN': '预览弹框是否显示在当前节点下面',
-            'en-US': 'Indicates whether the preview dialog box is displayed under the current node.'
-          },
-          mode: ['pc', 'mobile-first'],
-          pcDemo: 'preview',
           mfDemo: ''
         }
       ]


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3057 

## What is the new behavior?

`appendToBody` is placed at props.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a configuration option to control the placement of the preview dialog box. By default, the dialog appears under the main page body, offering clearer control over its display location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->