### PR TITLE
fix(popover): [popover] make popover placement reactive

### DIFF
--- a/packages/utils/src/popper/index.ts
+++ b/packages/utils/src/popper/index.ts
@@ -901,4 +901,9 @@ export class PopperJS {
 
     return boundaries
   }
+
+  // https://popper.js.org/docs/v2/lifecycle/#set-new-options
+  setOptions(options: PopperOptions) {
+    Object.assign(this._options, options)
+  }
 }

--- a/packages/vue-hooks/src/vue-popper.ts
+++ b/packages/vue-hooks/src/vue-popper.ts
@@ -222,7 +222,7 @@ export const userPopper = (options: IPopperInputParams) => {
     }
   }
 
-  // 注意： 一直以来，state.showPopper 为false时，并未调用doDestory. 像popover只是依赖这个值来 给reference元素 v-show一下
+  // 注意： 一直以来，state.showPopper 为false时，并未调用doDestroy. 像popover只是依赖这个值来 给reference元素 v-show一下
   watch(
     () => state.showPopper,
     (val) => {

--- a/packages/vue-hooks/src/vue-popper.ts
+++ b/packages/vue-hooks/src/vue-popper.ts
@@ -236,6 +236,22 @@ export const userPopper = (options: IPopperInputParams) => {
     }
   )
 
+  watch(
+    () => props.placement,
+    (val?: string) => {
+      state.currentPlacement = val
+      state.popperJS?.setOptions({ placement: val })
+
+      if (props.disabled) {
+        return
+      }
+      if (val) {
+        nextTick(updatePopper)
+      }
+      props.trigger === 'manual' && emit('update:modelValue', val)
+    }
+  )
+
   onBeforeUnmount(() => {
     nextTick(() => {
       doDestroy(true)

--- a/packages/vue/src/popover/__tests__/popover.test.tsx
+++ b/packages/vue/src/popover/__tests__/popover.test.tsx
@@ -2,6 +2,7 @@ import { mountPcMode as mount } from '@opentiny-internal/vue-test-utils'
 import { describe, test, expect } from 'vitest'
 import Button from '@opentiny/vue-button'
 import Popover from '@opentiny/vue-popover'
+import { ref } from 'vue'
 
 describe('PC Mode', () => {
   document.body.innerHTML = `
@@ -36,8 +37,35 @@ describe('PC Mode', () => {
 
   test.todo('height 高度')
 
-  test.todo('placement 出现位置')
+  test('placement 出现位置', async () => {
+    const wrapper = mount(() => (
+      <Popover placement="top-start" trigger="hover" content="这是一段内容">
+        {{
+          reference: () => <Button>悬浮我提示</Button>
+        }}
+      </Popover>
+    ))
 
+    await wrapper.find('button').trigger('mouseenter')
+    expect(document.querySelector('.tiny-popover')!.getAttribute('x-placement')).toBe('top-start')
+  })
+
+  test.only('响应式 placement', async () => {
+    const placement = ref('top-start')
+    const wrapper = mount(() => (
+      <Popover placement={placement.value} content="这是一段内容">
+        {{ reference: () => <Button>点击我</Button> }}
+      </Popover>
+    ))
+
+    await wrapper.find('button').trigger('click')
+    expect(document.querySelector('.tiny-popover')!.getAttribute('x-placement')).toBe('top-start')
+    await wrapper.find('button').trigger('click')
+
+    placement.value = 'right'
+    await wrapper.find('button').trigger('click')
+    expect(document.querySelector('.tiny-popover')!.getAttribute('x-placement')).toBe('right')
+  })
   test.todo('disabled  是否可用')
 
   test.todo('modelValue 状态是否可见')

--- a/packages/vue/src/popover/__tests__/popover.test.tsx
+++ b/packages/vue/src/popover/__tests__/popover.test.tsx
@@ -1,5 +1,5 @@
 import { mountPcMode as mount } from '@opentiny-internal/vue-test-utils'
-import { describe, test, expect } from 'vitest'
+import { describe, test, expect, afterEach } from 'vitest'
 import Button from '@opentiny/vue-button'
 import Popover from '@opentiny/vue-popover'
 import { ref } from 'vue'
@@ -10,9 +10,16 @@ describe('PC Mode', () => {
     <div id="app"></div>
   </div>
 `
+
+  let wrapper
+
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
   // attrs
   test('trigger 触发方式', async () => {
-    const wrapper = mount(
+    wrapper = mount(
       () => (
         <Popover placement="top-start" title="标题" width="200" trigger="hover" append-to-body content="这是一段内容">
           {{
@@ -38,7 +45,7 @@ describe('PC Mode', () => {
   test.todo('height 高度')
 
   test('placement 出现位置', async () => {
-    const wrapper = mount(() => (
+    wrapper = mount(() => (
       <Popover placement="top-start" trigger="hover" content="这是一段内容">
         {{
           reference: () => <Button>悬浮我提示</Button>
@@ -50,16 +57,16 @@ describe('PC Mode', () => {
     expect(document.querySelector('.tiny-popover')!.getAttribute('x-placement')).toBe('top-start')
   })
 
-  test.only('响应式 placement', async () => {
-    const placement = ref('top-start')
-    const wrapper = mount(() => (
+  test('响应式 placement', async () => {
+    const placement = ref('bottom')
+    wrapper = mount(() => (
       <Popover placement={placement.value} content="这是一段内容">
         {{ reference: () => <Button>点击我</Button> }}
       </Popover>
     ))
 
     await wrapper.find('button').trigger('click')
-    expect(document.querySelector('.tiny-popover')!.getAttribute('x-placement')).toBe('top-start')
+    expect(document.querySelector('.tiny-popover')!.getAttribute('x-placement')).toBe('bottom')
     await wrapper.find('button').trigger('click')
 
     placement.value = 'right'


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3079 

## What is the new behavior?

reactive when placement change

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a dynamic configuration update that enables real-time modifications of popover options and placements.
  - Enhanced interactivity so that components now adjust their positioning responsively and react to manual triggers.

- **Tests**
  - Expanded automated test coverage to validate responsive placement behavior and ensure proper cleanup during interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->