### PR TITLE
fix(datePicker):[date-picker]Fix the display of datePicker deletion icon in dark themes.

### DIFF
--- a/packages/theme/src/picker/index.less
+++ b/packages/theme/src/picker/index.less
@@ -30,7 +30,7 @@
     display: inline-block;
     text-align: left;
 
-    .tiny-svg {
+    .@{css-prefix}svg {
       font-size: var(--tv-Picker-icon-size);
       fill: var(--tv-Picker-icon-color);
 
@@ -51,7 +51,6 @@
     }
 
     &.show-auto-width {
-
       &.@{input-prefix-cls},
       &.@{input-prefix-cls}__inner {
         width: 100%;
@@ -76,7 +75,10 @@
 
       .baseClearicon {
         position: absolute;
-        background-color: var(--tv-Picker-input-clear-icon-bg);
+
+        & + .@{css-prefix}svg-size {
+          visibility: hidden;
+        }
 
         &:hover {
           fill: var(--tv-Picker-icon-color-hover);
@@ -130,7 +132,7 @@
       }
     }
 
-    .@{range-prefix-cls}__close-icon:has(> svg)+.@{range-prefix-cls}__icon {
+    .@{range-prefix-cls}__close-icon:has(> svg) + .@{range-prefix-cls}__icon {
       display: none;
     }
   }

--- a/packages/vue/src/picker/src/pc.vue
+++ b/packages/vue/src/picker/src/pc.vue
@@ -60,7 +60,11 @@
               class="baseClearicon"
             />
           </transition>
-          <component :is="state.triggerClass" @click="handleFocus" class="tiny-svg-size" />
+          <component
+            :is="state.triggerClass"
+            @click="handleFocus"
+            class="tiny-svg-size"
+          />
         </i>
       </template>
     </tiny-input>


### PR DESCRIPTION
# PR
修复暗色主题下datePicker删除图标显示

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Enhanced interactive visual feedback with refined hover and focus effects for the picker component.
  - Introduced conditional styling that dynamically adjusts the trigger icon's appearance based on current state.
  - Improved layout spacing for clearer visual alignment of icons.
  - Removed an unnecessary background style for a cleaner icon presentation.
  - Updated CSS class naming for SVG elements in the picker component.
  - Introduced visibility control for icons following the clear icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->