### PR TITLE
fix(input): [input] fixed the abnormal display of the input box back icon in read-only mode

### DIFF
--- a/packages/vue/src/input/src/pc.vue
+++ b/packages/vue/src/input/src/pc.vue
@@ -45,7 +45,7 @@
   >
     <template v-if="type !== 'textarea'">
       <!-- 前置元素 -->
-      <div class="tiny-input-group__prepend" ref="prepend" v-if="slots.prepend">
+      <div class="tiny-input-group__prepend" ref="prepend" v-if="slots.prepend && !state.isDisplayOnly">
         <slot name="prepend"></slot>
       </div>
       <span class="tiny-input-display-only">
@@ -158,11 +158,11 @@
         </transition>
       </div>
       <!-- 后置元素 -->
-      <div class="tiny-input-group__append" ref="append" v-if="slots.append">
+      <div class="tiny-input-group__append" ref="append" v-if="slots.append && !state.isDisplayOnly">
         <slot name="append"></slot>
       </div>
       <!-- Panel弹窗（例如时间组件的非范围选择窗口） -->
-      <div class="tiny-input-group__panel" ref="panel" v-if="slots.panel">
+      <div class="tiny-input-group__panel" ref="panel" v-if="slots.panel && !state.isDisplayOnly">
         <slot name="panel"></slot>
       </div>
     </template>


### PR DESCRIPTION
修复input框后置图标在只读模式下显示异常问题

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced input components to better control UI display: when in display-only mode, additional visual elements such as leading/trailing controls and panels will no longer appear, ensuring a cleaner and more streamlined interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->