### PR TITLE
fix(select): [select] fix the issue where the `dropStyle` attribute of the `select` component is not passed through to the internal `scrollBar` component

### DIFF
--- a/packages/vue/src/scrollbar/src/pc.vue
+++ b/packages/vue/src/scrollbar/src/pc.vue
@@ -13,7 +13,7 @@
 import { renderless, api } from '@opentiny/vue-renderless/scrollbar/vue'
 import { $prefix, setup, h, defineComponent } from '@opentiny/vue-common'
 import { calcScrollWidth } from '@opentiny/utils'
-import { toObject } from '@opentiny/utils'
+import { toObject, isObject } from '@opentiny/utils'
 import Bar from './bar.vue'
 
 export default defineComponent({
@@ -68,6 +68,9 @@ export default defineComponent({
 
       if (Array.isArray(wrapStyle)) {
         style = toObject(wrapStyle)
+        style.marginRight = gutterWith
+        style.marginBottom = gutterHeight
+      } else if (isObject(wrapStyle)) {
         style.marginRight = gutterWith
         style.marginBottom = gutterHeight
       } else if (typeof wrapStyle === 'string') {

--- a/packages/vue/src/select/src/pc.vue
+++ b/packages/vue/src/select/src/pc.vue
@@ -470,6 +470,7 @@
             tag="ul"
             :wrap-class="['tiny-select-dropdown__wrap']"
             :view-class="['tiny-select-dropdown__list']"
+            :wrapStyle="dropStyle"
             @mousedown.stop
             :class="{
               'is-empty': !allowCreate && state.query && state.filteredOptionsCount === 0


### PR DESCRIPTION
 
# PR
修复select组件未将dropStyle透传到内部的scrollbar组件上的问题

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the scrollbar component’s styling options, allowing for more flexible margin adjustments when using different style formats.
	- Enabled dynamic styling for the select dropdown’s scrollbar, offering improved customization of its appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->