### PR TITLE
fix(date-picker,steps):[date-picker,steps]Fix the width of the datePicker panel and the background of the step bar under the dark theme

### DIFF
--- a/packages/theme/src/date-panel/index.less
+++ b/packages/theme/src/date-panel/index.less
@@ -38,7 +38,8 @@
   }
 
   &.has-sidebar {
-    width: 398px;
+    min-width: 398px;
+    width: min-content;
   }
 
   &.has-time {
@@ -173,6 +174,7 @@
         bottom: 77px;
         max-height: 260px;
         box-shadow: var(--tv-DatePanel-box-shadow);
+        background-color: var(--tv-DatePanel-bg-color);
       }
     }
 

--- a/packages/theme/src/steps/index.less
+++ b/packages/theme/src/steps/index.less
@@ -47,6 +47,28 @@
 
         > div {
           background-color: var(--tv-Steps-advance-node-done-bg-color);
+
+          &:first-child {
+            .@{steps-prefix-cls}-block {
+              &:before {
+                display: none;
+              }
+            }
+          }
+
+          &:last-child {
+            .@{steps-prefix-cls}-block {
+              border-right: solid 1px var(--tv-Steps-advance-border-color);
+
+              &:before {
+                background: inherit;
+              }
+
+              &:after {
+                display: none;
+              }
+            }
+          }
         }
       }
 
@@ -126,19 +148,33 @@
 
   .@{steps-prefix-cls}-block {
     position: relative;
-    height: 32px;
-    display: flex;
-    overflow: hidden;
-    cursor: pointer;
-    color: var(--tv-Steps-text-color);
-    background-color: var(--tv-Steps-advance-node-done-bg-color);
+    border: solid 1px var(--tv-Steps-advance-border-color);
+    border-right: none;
+    text-align: center;
+    text-decoration: none;
+    white-space: nowrap;
+    background-color: var(--tv-Steps-node-done-bg-color);
 
-    .right-arrow.hide {
-      display: none;
+    &:after {
+      content: '';
+      position: absolute;
+      right: 0;
+      top: 0;
+      transform: translateX(100%);
+      border-top: 16px solid transparent;
+      border-bottom: 16px solid transparent;
+      border-left: 9px solid var(--tv-Steps-advance-mark-bg-color);
+      z-index: 1;
     }
 
-    &:hover {
-      background-color: var(--tv-Steps-advance-node-bg-color-hover);
+    &:before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0;
+      border-top: 16px solid transparent;
+      border-bottom: 16px solid transparent;
+      border-left: 9px solid var(--tv-color-border);
     }
 
     &.active {
@@ -156,12 +192,24 @@
     .block-status-mixin(@bgcolor, @hoverBgColor, @activeBgColor) {
       background-color: @bgcolor;
 
+      &:after {
+        border-left: 9px solid @bgcolor;
+      }
+
       &:hover {
         background-color: @hoverBgColor;
+
+        &:after {
+          border-left: 9px solid @hoverBgColor;
+        }
       }
 
       &.active {
         background-color: @activeBgColor;
+
+        &:after {
+          border-left: 9px solid @activeBgColor;
+        }
 
         &:hover {
           background-color: @activeBgColor;
@@ -187,40 +235,13 @@
     }
 
     &.disabled {
-      color: var(--tv-Steps-disabled-icon-color);
+      cursor: not-allowed;
+      color: var(--tv-color-icon-inverse-disabled);
       .block-status-mixin(var(--tv-Steps-advance-node-disable-bg-color), var(--tv-Steps-advance-node-disable-bg-color-hover), var(--tv-Steps-advance-node-disable-bg-color-active));
 
       .@{steps-prefix-cls}-icon {
-        border: 1px solid var(--tv-Steps-disabled-icon-color);
+        border: 1px solid var(--tv-color-icon-inverse-disabled);
       }
-    }
-
-    .arrow {
-      position: absolute;
-      height: 0;
-      width: 0;
-      box-sizing: border-box;
-      border-top-width: 16px;
-      border-bottom-width: 16px;
-      border-left-width: 6px;
-      border-right-width: 0;
-      border-style: solid;
-      border-color: #fff;
-    }
-
-    .left-arrow {
-      left: 0;
-      border-top-color: transparent;
-      border-bottom-color: transparent;
-    }
-
-    .left-arrow.hide {
-      display: none;
-    }
-
-    .right-arrow {
-      right: 0;
-      border-left-color: transparent;
     }
   }
 
@@ -254,7 +275,6 @@
       &.done,
       &.doing {
         background-color: var(--tv-Steps-node-done-bg-color);
-        color: var(--tv-Steps-advance-text-color);
         border: 1px solid var(--tv-Steps-node-done-border-color);
       }
 
@@ -340,10 +360,14 @@
     .@{steps-prefix-cls}-block {
       height: 48px;
 
-      .arrow {
+      &:after {
         border-top-width: 24px;
         border-bottom-width: 24px;
-        box-sizing: border-box;
+      }
+
+      &:before {
+        border-top-width: 24px;
+        border-bottom-width: 24px;
       }
 
       .@{steps-prefix-cls}-content {
@@ -916,7 +940,7 @@
           top: 0;
           border-top: calc(var(--tv-Steps-advance-line-height) / 2) solid transparent;
           border-bottom: calc(var(--tv-Steps-advance-line-height) / 2) solid transparent;
-          border-left: 9px solid #d7d8da;
+          border-left: 9px solid var(--tv-color-border);
         }
 
         &:hover {
@@ -967,7 +991,7 @@
         svg {
           width: 100%;
           height: 100%;
-          fill: var(--tv-Steps-advance-text-color);
+          fill: var(--tv-Steps-done-icon-color);
         }
       }
 
@@ -977,7 +1001,7 @@
       }
 
       &:hover .dot svg {
-        fill: var(--tv-Steps-advance-text-color);
+        fill: var(--tv-Steps-done-icon-color);
       }
     }
 
@@ -1441,7 +1465,7 @@
       padding-bottom: calc(var(--tv-Steps-bottom-divider-margin-top) + var(--tv-Steps-bottom-divider-height));
 
       &.process-current {
-        &::after {
+        &:after {
           content: '';
           position: absolute;
           bottom: 0;
@@ -1454,7 +1478,7 @@
       }
 
       &:first-child {
-        &.process-current::after {
+        &.process-current:after {
           content: '';
           position: absolute;
           bottom: 0;

--- a/packages/theme/src/steps/vars.less
+++ b/packages/theme/src/steps/vars.less
@@ -26,7 +26,7 @@
   // 已完成节点边框色
   --tv-Steps-node-done-border-color: var(--tv-color-border-active, #191919);
   // 已完成节点背景色
-  --tv-Steps-node-done-bg-color: var(--tv-color-bg-dark, #191919);
+  --tv-Steps-node-done-bg-color: var(--tv-color-bg-active-dark, #191919);
   // 高级向导当前项和计数标记点的文本色
   --tv-Steps-advance-li-text-color: var(--tv-color-text-inverse, #fff);
 
@@ -50,11 +50,11 @@
   // 已完成节点线条色
   --tv-Steps-line-active-bg-color: var(--tv-color-bg-active-primary, #191919);
   // 已完成节点图标色
-  --tv-Steps-done-icon-color: var(--tv-color-icon-inverse, #191919);
+  --tv-Steps-done-icon-color: var(--tv-color-icon-active, #191919);
   // 未完成的线条色
   --tv-Steps-line-bg-color: var(--tv-color-border-divider, #f0f0f0);
   // 未完成节点的背景色
-  --tv-Steps-node-icon-bg-color: var(--tv-color-bg-secondary, #ffffff);
+  --tv-Steps-node-icon-bg-color: var(--tv-color-bg-dark, #ffffff);
   // 未完成节点序号图标色
   --tv-Steps-unselected-icon-color: var(--tv-color-icon, #808080);
   // 未完成节点边框色
@@ -92,7 +92,7 @@
   // 高级向导选中节点悬浮背景色
   --tv-Steps-advance-node-active-bg-color-hover: var(--tv-color-bg-hover-primary, #595959);
   // 高级向导已完成节点背景色
-  --tv-Steps-advance-node-done-bg-color: var(--tv-color-bg-header, #f0f0f0);
+  --tv-Steps-advance-node-done-bg-color: var(--tv-color-bg-active-dark, #f0f0f0);
   // 高级向导已完成节点悬浮背景色
   --tv-Steps-advance-node-done-bg-color-hover: var(--tv-color-bg-disabled, #f0f0f0);
   // 高级向导进行中节点背景色
@@ -107,12 +107,15 @@
   --tv-Steps-advance-node-error-bg-color-active: #de504e;
   // 高级向导异常节点图标色
   --tv-Steps-advance-error-icon-color: var(--tv-color-error-icon, #f23030);
+  // 高级向导禁用节点文本以及图标色
+  --tv-Steps-advance-node-disable-text-color: var(--tv-color-icon-inverse-disabled, #fff);
+  --tv-Steps-advance-node-disable-icon-color: var(--tv-color-icon-inverse-disabled, #fff);
   // 高级向导禁用节点背景色
-  --tv-Steps-advance-node-disable-bg-color: var(--tv-color-bg-disabled, #f0f0f0);
+  --tv-Steps-advance-node-disable-bg-color: var(--tv-color-bg-disabled-control-unactive, #dbdbdb);
   // 高级向导禁用节点悬浮背景色
-  --tv-Steps-advance-node-disable-bg-color-hover: var(--tv-color-bg-disabled, #f0f0f0);
+  --tv-Steps-advance-node-disable-bg-color-hover: var(--tv-color-bg-disabled-control-unactive, #dbdbdb);
   // 高级向导禁用节点点击背景色
-  --tv-Steps-advance-node-disable-bg-color-active: var(--tv-color-bg-disabled, #f0f0f0);
+  --tv-Steps-advance-node-disable-bg-color-active: var(--tv-color-bg-disabled-control-unactive, #dbdbdb);
 
   /** 单链型场景 */
   // 单链型序号悬浮边框色


### PR DESCRIPTION
# PR
修复暗色主题下datePicker面板宽度以及步骤条背景

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced the date panel layout for improved responsiveness, including a new adaptive width and background update for popup elements.
  - Refined the steps component visuals with updated borders, alignment, and hover/active indicators to better highlight progress states.
  - Adjusted the color scheme for various step statuses—including completed, uncompleted, and disabled elements—to offer clearer visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->