### PR TITLE
fix(tree): [tree] fix tree node slot radio cannot be displayed

### DIFF
--- a/packages/theme/src/tree/index.less
+++ b/packages/theme/src/tree/index.less
@@ -460,7 +460,7 @@
     }
   }
 
-  .@{radio-prefix-cls} {
+  &__content-left__radio.@{radio-prefix-cls} {
     .@{radio-prefix-cls}__label {
       display: none;
     }

--- a/packages/vue/src/tree/src/tree-node.vue
+++ b/packages/vue/src/tree/src/tree-node.vue
@@ -114,7 +114,8 @@
             :validate-event="false"
             :label="node.id"
             :disabled="!!node.disabled"
-          ></tiny-radio>
+            class="tiny-tree-node__content-left__radio"
+          />
           <icon-loading v-if="node.loading" class="tiny-tree-node__loading" />
           <slot name="prefix" :node="node"></slot>
           <template v-if="action.type === 'edit' && action.node && action.node === node">


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3116 

## What is the new behavior?

radio slots can be displayed, and radio mode still work normally

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced the visual presentation of radio button elements within tree views, resulting in a cleaner and more integrated design.
  - Refined styling and layout details to ensure consistent alignment and improved visual clarity across nested components, delivering a more cohesive user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->