### PR TITLE
fix(datepicker):[date-picker]year panel disabling does not take effect

### DIFF
--- a/packages/renderless/src/year-table/index.ts
+++ b/packages/renderless/src/year-table/index.ts
@@ -26,7 +26,7 @@ export const getIsDefault =
 export const getIsDisabled =
   ({ props }) =>
   (year) => {
-    return props.selectionMode.startsWith('year') && typeof props.disabledDate === 'function'
+    return typeof props.disabledDate === 'function'
       ? props.disabledDate(new Date(year, 0, 1, 0))
       : false
   }


### PR DESCRIPTION
# PR
datepicker年份面板禁用不生效

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the calendar's date disabling logic. Now, date validation relies exclusively on a provided callback, streamlining the conditions that determine if a date should be disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->