### PR TITLE
fix(popper): [tooltip,popover] fix popper doms in custom element, cant get zindex

### DIFF
--- a/packages/renderless/package.json
+++ b/packages/renderless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/vue-renderless",
-  "version": "3.21.1",
+  "version": "3.21.2",
   "private": true,
   "description": "An enterprise-class UI component library, support both Vue.js 2 and Vue.js 3, as well as PC and mobile.",
   "author": "OpenTiny Team",
@@ -36,8 +36,8 @@
     "release": "esno ./scripts/postbuild.ts && shx cp README.md dist"
   },
   "dependencies": {
-    "color": "4.2.3",
-    "@opentiny/utils": "workspace:~"
+    "@opentiny/utils": "workspace:~",
+    "color": "4.2.3"
   },
   "devDependencies": {
     "esno": "^4.7.0",

--- a/packages/renderless/src/common/deps/popper.ts
+++ b/packages/renderless/src/common/deps/popper.ts
@@ -77,6 +77,10 @@ const isFixed = (el: HTMLElement) => {
     return true
   }
 
+  // 处理遇到 shadowRoot的情况
+  if (el.host) {
+    el = el.host
+  }
   return el.parentNode ? isFixed(el.parentNode as HTMLElement) : false
 }
 

--- a/packages/renderless/src/common/deps/vue-popper.ts
+++ b/packages/renderless/src/common/deps/vue-popper.ts
@@ -59,6 +59,11 @@ const getReferMaxZIndex = (reference) => {
   do {
     reference = reference.parentNode
 
+    // 处理遇到shadowRoot的情况
+    if (reference && reference instanceof ShadowRoot && reference.host) {
+      reference = reference.host
+    }
+
     if (reference) {
       z = getZIndex(reference)
     } else {

--- a/packages/renderless/src/grid/utils/dom.ts
+++ b/packages/renderless/src/grid/utils/dom.ts
@@ -180,9 +180,13 @@ export const colToVisible = ($table, column, move) => {
 }
 
 export const hasDataTag = (el, value) => {
-  // el可能为shadow-root，shadow-root没有getAttribute方法
-  if (!el || !value || !el.getAttribute) {
+  if (!el || !value) {
     return false
+  }
+
+  // 处理遇到 shadowRoot的情况
+  if (el.host) {
+    el = el.host
   }
 
   return (' ' + el.getAttribute('data-tag') + ' ').includes(' ' + value + ' ')


### PR DESCRIPTION
# PR

## PR Checklist
修复popper用在自定义元素内部时，向上找父节点报错的问题。  ---- 同步代码
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced UI element positioning and stacking by improving support for shadow DOM scenarios, ensuring consistent display and behavior.
- **Chores**
	- Updated the package version and adjusted dependency ordering for improved package management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->