### PR TITLE
fix(popper): [tooltip,popover] fix popper doms in custom element, cant get zindex

### DIFF
--- a/packages/renderless/src/grid/utils/dom.ts
+++ b/packages/renderless/src/grid/utils/dom.ts
@@ -188,9 +188,13 @@ export const colToVisible = ($table, column, move) => {
 }
 
 export const hasDataTag = (el, value) => {
-  // el可能为shadow-root，shadow-root没有getAttribute方法
-  if (!el || !value || !el.getAttribute) {
+  if (!el || !value) {
     return false
+  }
+
+  // 处理遇到 shadowRoot的情况
+  if (el.host) {
+    el = el.host
   }
 
   return (' ' + el.getAttribute('data-tag') + ' ').includes(' ' + value + ' ')

--- a/packages/utils/src/popper/index.ts
+++ b/packages/utils/src/popper/index.ts
@@ -76,6 +76,10 @@ const isFixed = (el: HTMLElement) => {
     return true
   }
 
+  // 处理遇到 shadowRoot的情况
+  if (el.host) {
+    el = el.host
+  }
   return el.parentNode ? isFixed(el.parentNode as HTMLElement) : false
 }
 

--- a/packages/vue-hooks/src/vue-popper.ts
+++ b/packages/vue-hooks/src/vue-popper.ts
@@ -58,6 +58,11 @@ const getReferMaxZIndex = (reference) => {
   do {
     reference = reference.parentNode
 
+    // 处理遇到shadowRoot的情况
+    if (reference && reference instanceof ShadowRoot && reference.host) {
+      reference = reference.host
+    }
+
     if (reference) {
       z = getZIndex(reference)
     } else {


### PR DESCRIPTION
# PR

## PR Checklist
修复popper用在自定义元素内部时，向上找父节点报错的问题。  ---- 同步代码


Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced handling of shadow DOM elements to ensure consistent element recognition, accurate positioning, and smoother layout behavior across key components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->