### PR TITLE
fix(tooltip): [tooltip] add a default value for the contentMaxHeight property

### DIFF
--- a/packages/theme-saas/src/tooltip/index.less
+++ b/packages/theme-saas/src/tooltip/index.less
@@ -10,7 +10,6 @@
   }
 
   &__content-wrapper {
-    max-height: 50vh;
     @apply overflow-auto;
   }
 

--- a/packages/theme/src/tooltip/index.less
+++ b/packages/theme/src/tooltip/index.less
@@ -27,7 +27,6 @@
   }
 
   &__content-wrapper {
-    max-height: var(--tv-Tooltip-content-max-height);
     overflow: auto;
   }
 

--- a/packages/theme/src/tooltip/vars.less
+++ b/packages/theme/src/tooltip/vars.less
@@ -63,7 +63,7 @@
   // light主题弹框背景色
   --tv-Tooltip-popper-light-bg-color: var(--tv-color-bg-inverse, #ffffff);
   // light主题|禁用弹框文本色
-  --tv-Tooltip-popper-light-text-color: var(--tv-color-text-inverse-black,  #191919);
+  --tv-Tooltip-popper-light-text-color: var(--tv-color-text-inverse-black, #191919);
   // light主题|禁用时弹框边框色
   --tv-Tooltip-popper-light-border-color: var(--tv-Tooltip-popper-light-bg-color);
 
@@ -75,6 +75,4 @@
   --tv-Tooltip-padding-x: var(--tv-space-xl, 16px);
   // 文字提示错误图标色
   --tv-Tooltip-validate-icon-color: var(--tv-color-error-icon, #f23030);
-  // 文本内容容器最大高度
-  --tv-Tooltip-content-max-height: 50vh;
 }

--- a/packages/vue/src/tooltip/src/index.ts
+++ b/packages/vue/src/tooltip/src/index.ts
@@ -86,7 +86,8 @@ export const tooltipProps = {
     default: () => 'next'
   },
   contentMaxHeight: {
-    type: String
+    type: String,
+    default: () => '80vh'
   }
 }
 export default defineComponent({

--- a/packages/vue/src/tooltip/src/mobile-first.vue
+++ b/packages/vue/src/tooltip/src/mobile-first.vue
@@ -96,6 +96,9 @@ export default defineComponent({
     zIndex: {
       type: String,
       default: () => 'next'
+    },
+    contentMaxHeight: {
+      type: String
     }
   },
   setup(props, context) {
@@ -160,7 +163,7 @@ export default defineComponent({
                         aria-hidden={this.disabled || !this.state.showPopper ? 'true' : 'false'}
                         onMouseenter={() => mouseenter()}
                         onMouseleave={() => mouseleave()}>
-                        {content}
+                        <div style={`overflow:auto; max-height:${this.contentMaxHeight}`}>{content}</div>
                         {this.visibleArrow ? (
                           <div
                             x-arrow


### PR DESCRIPTION
# PR

## PR Checklist
为tooltip组件的contentMaxHeight  属性添加默认值 80vh

 修改了多端 ， theme-saas。  去掉我们原来的默认 最大高度 50vh

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted tooltip styling by removing fixed maximum height restrictions, allowing content to expand dynamically while preserving scrollability.
	- Improved formatting consistency in tooltip style variables.
- **New Features**
	- Introduced a customizable default maximum height for tooltip content, enabling tailored display behavior across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->