### PR TITLE
fix(calendar-view): [calendar-view] increase the maximum height and overflow handling of calendar-view tooltip content to optimize display effect

### DIFF
--- a/packages/theme-saas/src/calendar-view/index.less
+++ b/packages/theme-saas/src/calendar-view/index.less
@@ -630,6 +630,8 @@
   @apply ~'max-w-[theme(spacing.80)]';
 
   .tooltip-main{
+    @apply overflow-auto;
+    @apply max-h-[80vh];
     @apply p-2;
 
     .title{

--- a/packages/theme/src/calendar-view/index.less
+++ b/packages/theme/src/calendar-view/index.less
@@ -630,12 +630,17 @@
   .inject-CalendarView-vars();
   position: absolute;
   max-width: 320px;
+
   .tooltip-main {
+    overflow: auto;
+    max-height: 80vh;
     padding: var(--tv-CalendarView-tooltip-title-font-size);
+
     .title {
       font-size: var(--tv-CalendarView-tooltip-title-font-size);
       font-weight: var(--tv-CalendarView-tooltip-title-font-weight);
     }
+
     .date {
       margin: 6px 0;
       color: var(--tv-CalendarView-tooltip-date-text-color);

--- a/packages/vue/src/calendar-view/src/mobile-first.vue
+++ b/packages/vue/src/calendar-view/src/mobile-first.vue
@@ -3,7 +3,7 @@
     <tiny-tooltip
       ref="tooltip"
       v-model="state.eventTipVisible"
-      popper-class="absolute max-w-[theme(spacing.80)]"
+      popper-class="absolute max-w-[theme(spacing.80)] max-h-[80vh] overflow-auto"
       :manual="true"
       effect="light"
       placement="right"

--- a/packages/vue/src/calendar-view/src/mobile-first.vue
+++ b/packages/vue/src/calendar-view/src/mobile-first.vue
@@ -3,13 +3,13 @@
     <tiny-tooltip
       ref="tooltip"
       v-model="state.eventTipVisible"
-      popper-class="absolute max-w-[theme(spacing.80)] max-h-[80vh] overflow-auto"
+      popper-class="absolute max-w-[theme(spacing.80)]"
       :manual="true"
       effect="light"
       placement="right"
     >
       <template #content>
-        <div class="p-2">
+        <div class="p-2 max-h-[80vh] overflow-auto">
           <div class="px-1.5 mb-1.5 border-l-2 border-color-brand">{{ state.eventTipContent.title }}</div>
           <div class="mb-1.5 px-2 text-color-text-placeholder">
             {{ state.eventTipContent.startDay }} {{ state.eventTipContent.startTime }} ~

--- a/packages/vue/src/tooltip/src/mobile-first.vue
+++ b/packages/vue/src/tooltip/src/mobile-first.vue
@@ -136,6 +136,8 @@ export default defineComponent({
                 component: {
                   render: () => {
                     let content = getContent(this)
+                    // 当内容为纯文本时，添加一层wrapper，其他情况（插槽、renderContent）原样输出
+                    const addWrapper = typeof content === 'string'
                     let propsData = { on: { 'after-leave': this.doDestroy } }
                     let mouseenter = () => this.setExpectedState(true)
                     let mouseleave = () => {
@@ -163,7 +165,11 @@ export default defineComponent({
                         aria-hidden={this.disabled || !this.state.showPopper ? 'true' : 'false'}
                         onMouseenter={() => mouseenter()}
                         onMouseleave={() => mouseleave()}>
-                        <div style={`overflow:auto; max-height:${this.contentMaxHeight}`}>{content}</div>
+                        {addWrapper ? (
+                          <div style={`overflow:auto;max-height:${this.contentMaxHeight}`}>{content}</div>
+                        ) : (
+                          content
+                        )}
                         {this.visibleArrow ? (
                           <div
                             x-arrow


### PR DESCRIPTION
增加tooltip内容的最大高度和溢出处理，优化显示效果

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Enhanced tooltip appearance by setting a maximum height of 80% of the viewport and enabling automatic scrolling for overflowing content.
  
- **New Features**
  - Improved tooltip behavior by conditionally wrapping plain text content for better readability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->