### PR TITLE
fix(grid): [grid] fix duplicate empty when set is-center-empty

### DIFF
--- a/packages/vue/src/grid/src/table/src/table.ts
+++ b/packages/vue/src/grid/src/table/src/table.ts
@@ -105,16 +105,15 @@ function mergeTreeConfig(_vm) {
 }
 
 const renderEmptyPartFn = (opt) => {
-  const { _vm, tableData } = opt
-  const { $grid = {}, renderEmpty } = _vm
-  const { slots } = $grid
+  const { _vm } = opt
   return () => {
     let emptyPartVnode = null
-    let { computerTableBodyHeight } = _vm
 
-    if (_vm.isCenterEmpty && !tableData.length) {
+    if (_vm.viewType === V_DEFAULT && _vm.isCenterEmpty && !opt.tableData.length) {
+      const { $grid = {}, renderEmpty } = _vm
+      const { slots } = $grid
+      let { computerTableBodyHeight } = _vm
       let emptyVnodes
-      let noEmptyClass = _vm.viewType === V_CARD || _vm.viewType === V_LIST
 
       if (slots.empty) {
         emptyVnodes = slots.empty.call(_vm, h)
@@ -130,7 +129,7 @@ const renderEmptyPartFn = (opt) => {
       emptyPartVnode = h(
         'div',
         {
-          class: [{ 'empty-center-block': !noEmptyClass }, _vm.viewCls('emptyData')],
+          class: [{ 'empty-center-block': true }, _vm.viewCls('emptyData')],
           style: {
             height: computerTableBodyHeight
           }


### PR DESCRIPTION
# PR
修复当配置了is-center-empty后，甘特图视图会出现重复的空数据的问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the display logic for empty tables to ensure a consistent presentation when no data is available. Users will notice that the empty state now appears only under the correct conditions, providing a more reliable and streamlined viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->