### PR TITLE
fix: change mobile-first input suffix and prefix svg color

### DIFF
--- a/packages/vue/src/input/src/mobile-first.vue
+++ b/packages/vue/src/input/src/mobile-first.vue
@@ -149,7 +149,7 @@
       <span
         data-tag="tiny-input-prefix"
         ref="prefix"
-        class="left-2 transition-all duration-300 ease-in-out text-xs sm:text-sm absolute top-1/2 -translate-y-1/2 text-center text-color-text-placeholder flex items-center"
+        class="left-2 transition-all fill-color-icon-placeholder duration-300 ease-in-out text-xs sm:text-sm absolute top-1/2 -translate-y-1/2 text-center text-color-text-placeholder flex items-center"
         v-if="(slots.prefix || prefixIcon) && !state.isDisplayOnly"
       >
         <slot name="prefix"></slot>
@@ -171,7 +171,7 @@
         class="right-2 transition-all duration-300 ease-in-out pointer-events-none text-xs absolute top-1/2 -translate-y-1/2 text-center text-color-text-placeholder flex items-center z-[1]"
         v-if="!state.isDisplayOnly && getSuffixVisible()"
       >
-        <span class="pointer-events-auto text-xs flex justify-start items-center">
+        <span class="pointer-events-auto text-xs fill-color-icon-placeholder flex justify-start items-center">
           <icon-close
             v-if="state.showClear"
             :class="


### PR DESCRIPTION
# PR
适配规范，修改多端模板input suffix 和prefix插槽的svg颜色
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the visual styling of placeholder elements to enhance icon color consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->