### PR TITLE
fix(collapse): adjust the padding style within the mobile-first component to optimize the visual effect

### DIFF
--- a/packages/vue/src/collapse-item/src/mobile-first.vue
+++ b/packages/vue/src/collapse-item/src/mobile-first.vue
@@ -65,7 +65,7 @@
         :aria-labelledby="`tiny-collapse-head-${state.id}`"
         :id="`tiny-collapse-content-${state.id}`"
       >
-        <div class="pb-6 pt-0 px-4 sm:pt-0 sm:pr-0 sm:pl-4 sm:pb-4 text-xs text-color-text-primary leading-relaxed">
+        <div class="pb-3 pt-0 px-4 sm:pt-0 sm:pr-0 sm:pl-4 sm:pb-4 text-xs text-color-text-primary leading-relaxed">
           <slot></slot>
         </div>
       </div>


### PR DESCRIPTION
调整 mobile-first 组件内的内边距样式，优化视觉效果

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the layout of a collapsible item by reducing the bottom spacing, resulting in a more compact and streamlined appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->