### PR TITLE
feat(calendar-view):[calendar-view]The calendar view tip time support configure

### DIFF
--- a/examples/sites/demos/apis/calendar-view.js
+++ b/examples/sites/demos/apis/calendar-view.js
@@ -150,6 +150,20 @@ export default {
           mfDemo: 'basic-usage'
         },
         {
+          name: 'show-tip-time',
+          type: 'Boolean',
+          defaultValue: 'true',
+          desc: {
+            'zh-CN': '显示日程tips时间',
+            'en-US': 'Show schedule tips time'
+          },
+          meta: {
+            stable: '3.23.0'
+          },
+          mode: ['pc', 'mobile-first'],
+          mfDemo: ''
+        },
+        {
           name: 'v-model',
           type: 'String',
           defaultValue: '',

--- a/packages/vue/src/calendar-view/src/index.ts
+++ b/packages/vue/src/calendar-view/src/index.ts
@@ -80,6 +80,10 @@ export const calendarViewProps = {
   showBackToday: {
     type: Boolean,
     default: true
+  },
+  showTipTime: {
+    type: Boolean,
+    default: true
   }
 }
 

--- a/packages/vue/src/calendar-view/src/mobile-first.vue
+++ b/packages/vue/src/calendar-view/src/mobile-first.vue
@@ -4,7 +4,7 @@
       <template #content>
         <div class="p-2 max-h-[80vh] overflow-auto">
           <div class="px-1.5 mb-1.5 border-l-2 border-color-brand">{{ state.eventTipContent.title }}</div>
-          <div class="mb-1.5 px-2 text-color-text-placeholder">
+          <div v-if="showTipTime" class="mb-1.5 px-2 text-color-text-placeholder">
             {{ state.eventTipContent.startDay }} {{ state.eventTipContent.startTime }} ~
             {{ state.eventTipContent.endDay }} {{ state.eventTipContent.endTime }}
           </div>
@@ -370,7 +370,8 @@ export default defineComponent({
     'height',
     'mark-color',
     'multi-select',
-    'showBackToday'
+    'showBackToday',
+    'showTipTime'
   ],
   setup(props, context) {
     return setup({

--- a/packages/vue/src/calendar-view/src/pc.vue
+++ b/packages/vue/src/calendar-view/src/pc.vue
@@ -216,7 +216,7 @@
       <template #content>
         <div class="tooltip-main">
           <div class="title">{{ state.eventTipContent.title }}</div>
-          <div class="date">
+          <div v-if="showTipTime" class="date">
             {{ state.eventTipContent.startDay }} {{ state.eventTipContent.startTime }} ~
             {{ state.eventTipContent.endDay }} {{ state.eventTipContent.endTime }}
           </div>
@@ -284,7 +284,8 @@ export default defineComponent({
     'events',
     'height',
     'markColor',
-    'multiSelect'
+    'multiSelect',
+    'showTipTime'
   ],
   setup(props, context) {
     return setup({


### PR DESCRIPTION
# PR
日历视图详细时间支持配置隐藏

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option in the calendar view that lets users toggle the display of schedule tip times. This enhancement offers greater control over how and when schedule tips are shown across both desktop and mobile interfaces, improving overall customization for viewing events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->