### PR TITLE
feat(release): add vue3 version option to release:aurora command and update related logic

### DIFF
--- a/internals/cli/src/commands/release/releaseAurora.ts
+++ b/internals/cli/src/commands/release/releaseAurora.ts
@@ -5,7 +5,7 @@ import fs from 'fs-extra'
 const onlyMobileFirstTemplateLists = ['popconfirm', 'card', 'card-group']
 
 // 递归遍历所有的组件，然后依次修改文件内容
-const findAllpage = (packagesPath) => {
+const findAllpage = (packagesPath, vue3version) => {
   if (
     packagesPath.includes('.png') ||
     packagesPath.includes('.gif') ||
@@ -21,7 +21,7 @@ const findAllpage = (packagesPath) => {
   if (fs.statSync(packagesPath).isDirectory()) {
     // 循环递归查找子文件夹
     fs.readdirSync(packagesPath).forEach((childPatch) => {
-      findAllpage(path.join(packagesPath, childPatch))
+      findAllpage(path.join(packagesPath, childPatch), vue3version)
     })
   } else {
     const content = fs.readFileSync(packagesPath).toString('UTF-8' as BufferEncoding)
@@ -42,6 +42,10 @@ const findAllpage = (packagesPath) => {
       .replace(/@aurora\/fluent-editor/g, '@opentiny/fluent-editor')
       .replace(/@aurora\/huicharts/g, '@opentiny/huicharts')
 
+    if (vue3version) {
+      result = result.replace(/@aurora\/vue/g, '@aurora/vue3')
+    }
+
     // 解决当AUI只有一个mobile-first模板而TinyVue有多个模板，导致Linkjs加载不到多端模板的问题
     if (
       packagesPath.endsWith('index.js') &&
@@ -54,7 +58,7 @@ const findAllpage = (packagesPath) => {
   }
 }
 
-export const releaseAurora = () => {
+export const releaseAurora = ({ vue3version }) => {
   const distLists = [
     'dist2/@aurora',
     'renderless/dist',
@@ -65,7 +69,12 @@ export const releaseAurora = () => {
     'vue-hooks/dist',
     'vue-hooks/package.json'
   ]
+
+  if (vue3version) {
+    distLists.push('dist3/@aurora')
+  }
+
   distLists.forEach((item) => {
-    findAllpage(pathFromPackages(item))
+    findAllpage(pathFromPackages(item), vue3version)
   })
 }

--- a/internals/cli/src/index.ts
+++ b/internals/cli/src/index.ts
@@ -1,14 +1,18 @@
 #!/usr/bin/env node
 import { Command, Option } from 'commander'
 import { createIconSaas } from './commands/create/index.js'
-import { buildUi, buildEntry, buildRuntime, buildReact, buildEntryReact, chartTheme } from './commands/build'
+import { buildUi, buildEntry, buildRuntime, chartTheme } from './commands/build'
 import { releaseAurora } from './commands/release/releaseAurora'
 import { releaseAlpha } from './commands/release/releaseAlpha'
 import { releaseE2EConfig } from './commands/release/releaseE2EConfig'
 
 const program = new Command()
 
-program.command('release:aurora').description('转换为aurora的包').action(releaseAurora)
+program
+  .command('release:aurora')
+  .description('转换为aurora的包')
+  .option('-v3, --vue3version', '是否使用vue3版本', false)
+  .action(releaseAurora)
 
 program
   .command('release:alpha')
@@ -23,8 +27,6 @@ program
   .action(releaseE2EConfig)
 
 program.command('create:icon-saas').description('同步生成 icon-saas').action(createIconSaas)
-
-program.command('build:entry-react').description('生成 react 组件库入口').action(buildEntryReact)
 
 program.command('build:entry').description('生成组件库入口').action(buildEntry)
 
@@ -51,16 +53,5 @@ program
   .option('-vi, --isVisualizer', '是否分析打包产物', false)
   .option('--tiny_mode', '输出的模板类型', 'pc')
   .action(buildRuntime)
-
-program
-  .command('build:react')
-  .description('打包 react 组件库')
-  .argument('[names...]', '构建指定组件，如 button alert；不指定则构建全量组件')
-  .addOption(new Option('-f --formats <formats...>', '目标格式，默认 ["es"]').choices(['es', 'cjs']))
-  .addOption(new Option('-t --build-target <buildTarget>', '组件的目标版本'))
-  .option('-s, --scope <scope>', 'npm scope，默认是 opentiny，会以 @opentiny 发布到 npm')
-  .option('-c, --clean', '清空构建目录')
-  .option('--no-dts', '不生成 dts')
-  .action(buildReact)
 
 program.parse()


### PR DESCRIPTION
为 release:aurora 命令添加 vue3 版本选项，并更新相关逻辑

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The CLI release command now includes a new option to enable Vue 3 version processing, allowing users to tailor releases based on their version preference.
  
- **Chores**
  - Removed the deprecated command for building React-based entries, streamlining the available commands and simplifying the overall release workflow.

These updates improve the release process by offering enhanced version-specific functionality and eliminating outdated options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->