### PR TITLE
fix: [fluent-editor] Fix the issue where tables can still be edited when disabled

### DIFF
--- a/packages/theme/src/fluent-editor/index.less
+++ b/packages/theme/src/fluent-editor/index.less
@@ -238,6 +238,14 @@
       border: none;
     }
 
+    &.ql-disabled {
+      .ql-editor {
+        .quill-better-table-wrapper {
+          pointer-events: none;
+        }
+      }
+    }
+
     .ql-editor {
       padding: 8px 0 86px 0;
       margin: 0 16px;


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the editor’s disabled state to prevent interactions with table elements, ensuring a more controlled and predictable user experience when the editor is in read-only mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->