### PR TITLE
chore: added the cdn address of Huicharts component runtime, and updated the version number of docs to 3.22.3

### DIFF
--- a/examples/sites/package.json
+++ b/examples/sites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/vue-docs",
-  "version": "3.22.1",
+  "version": "3.22.3",
   "license": "MIT",
   "scripts": {
     "start": "vite",
@@ -33,9 +33,9 @@
     "@opentiny/vue-design-saas": "workspace:~",
     "@opentiny/vue-design-smb": "workspace:~",
     "@opentiny/vue-directive": "workspace:~",
+    "@opentiny/vue-flowchart": "workspace:~",
     "@opentiny/vue-hooks": "workspace:~",
     "@opentiny/vue-huicharts": "workspace:~",
-    "@opentiny/vue-flowchart": "workspace:~",
     "@opentiny/vue-icon": "workspace:~",
     "@opentiny/vue-icon-multicolor": "workspace:~",
     "@opentiny/vue-icon-saas": "workspace:~",
@@ -48,16 +48,16 @@
     "@opentiny/vue-vite-import": "~1.2.0",
     "@unocss/reset": "0.38.2",
     "@vue/repl": "^2.5.5",
+    "@vueuse/core": "^12.7.0",
     "@vueuse/head": "0.7.13",
     "github-markdown-css": "~5.1.0",
     "highlight.js": "^11.5.1",
     "marked": "^4.3.0",
-    "@vueuse/core": "^12.7.0",
     "prismjs": "^1.28.0",
     "sortablejs": "1.15.0",
     "tailwindcss": "^3.2.4",
     "vue": "^3.4.31",
-    "vue-i18n": "^9.1.10",
+    "vue-i18n": "~9.14.3",
     "vue-router": "4.1.5"
   },
   "devDependencies": {

--- a/examples/sites/playground/App.vue
+++ b/examples/sites/playground/App.vue
@@ -78,6 +78,7 @@ const createImportMap = (version) => {
     '@opentiny/vue-locale': `${getRuntime(version)}tiny-vue-locale.mjs`,
     '@opentiny/vue-common': `${getRuntime(version)}tiny-vue-common.mjs`,
     '@opentiny/vue-directive': `${getRuntime(version)}tiny-vue-directive.mjs`,
+    '@opentiny/vue-huicharts': `${getRuntime(version)}tiny-vue-huicharts.mjs`,
     '@opentiny/vue-theme/': `${cdnHost}/@opentiny/vue-theme${versionDelimiter}${version}/${fileDelimiter}`,
     '@opentiny/vue-theme-mobile/': `${cdnHost}/@opentiny/vue-theme-mobile${versionDelimiter}${version}/${fileDelimiter}`,
     '@opentiny/vue-renderless/': `${cdnHost}/@opentiny/vue-renderless${versionDelimiter}${version}/${fileDelimiter}`,


### PR DESCRIPTION
添加huicharts组件runtime的cdn地址，docs更新版本号至3.22.3

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package version and adjusted dependency order in the dependency list.
  - Updated version constraint for vue-i18n.

- **New Features**
  - Added import mapping for @opentiny/vue-huicharts in the playground application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->