### PR TITLE
fix:[docs]Hide the plus document drill field button

### DIFF
--- a/examples/sites/src/views/components-doc/components/demo.vue
+++ b/examples/sites/src/views/components-doc/components/demo.vue
@@ -29,6 +29,7 @@
             />
 
             <i
+              v-if="!isPlus" 
               v-auto-tip="{ content: i18nByKey('playground'), effect: 'light', always: true }"
               class="i-ti-playground ml8 ti-w16 ti-h16 ti-cur-hand"
               @click="openPlayground(demo)"
@@ -115,6 +116,7 @@ const { currentThemeKey } = useTheme()
 const isMobileFirst = computed(() => {
   return templateModeState.mode === 'mobile-first'
 })
+const isPlus = computed(() => import.meta.env.VITE_APP_MODE === 'plus')
 const demoContainer = ref(null)
 const cmp = shallowRef(null)
 const showPreview = inject('showPreview')

--- a/examples/sites/src/views/overview.vue
+++ b/examples/sites/src/views/overview.vue
@@ -86,7 +86,7 @@ export default defineComponent({
       palceMenus: new Array(14)
     })
 
-    const isPlus = computed(() => location.href.includes('tiny-vue-plus'))
+    const isPlus = computed(() => import.meta.env.VITE_APP_MODE === 'plus')
     function debounce(fn, delay) {
       let timeout = 0
       return (value) => {


### PR DESCRIPTION
# PR
plus文档隐藏演练场按钮

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the detection of "plus" mode by using an environment variable instead of the URL, ensuring consistent behavior across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->