### PR TITLE
fix(picker): range-picker add tabindex

### DIFF
--- a/packages/vue/src/picker/src/mobile-first.vue
+++ b/packages/vue/src/picker/src/mobile-first.vue
@@ -111,6 +111,7 @@
           @input="handleStartInput"
           @change="handleStartChange"
           @focus="handleFocus"
+          tabindex="1"
           data-tag="tiny-range-input"
           :class="gcls('range-input')"
         />
@@ -141,6 +142,7 @@
           @input="handleEndInput"
           @change="handleEndChange"
           @focus="handleFocus"
+          tabindex="1"
           data-tag="tiny-range-input"
           :class="gcls('range-input')"
         />

--- a/packages/vue/src/picker/src/pc.vue
+++ b/packages/vue/src/picker/src/pc.vue
@@ -60,11 +60,7 @@
               class="baseClearicon"
             />
           </transition>
-          <component
-            :is="state.triggerClass"
-            @click="handleFocus"
-            class="tiny-svg-size"
-          />
+          <component :is="state.triggerClass" @click="handleFocus" class="tiny-svg-size" />
         </i>
       </template>
     </tiny-input>
@@ -103,6 +99,7 @@
         @input="handleStartInput"
         @change="handleStartChange"
         @focus="handleFocus"
+        tabindex="1"
         class="tiny-range-input"
       />
       <slot name="range-separator">
@@ -120,6 +117,7 @@
         @input="handleEndInput"
         @change="handleEndChange"
         @focus="handleFocus"
+        tabindex="1"
         class="tiny-range-input"
       />
       <i @click="handleClickIcon" v-if="state.haveTrigger" class="tiny-input__icon tiny-range__close-icon">


### PR DESCRIPTION
# PR
为range-picker的input添加tabindex
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved keyboard navigation by setting explicit tab order for start and end input fields in the date/time range picker on both mobile and desktop views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->