### PR TITLE
fix(from-item): fixed the problem that there would be an extra space in template compilation under vue2

### DIFF
--- a/packages/vue/src/form-item/src/mobile-first.vue
+++ b/packages/vue/src/form-item/src/mobile-first.vue
@@ -57,9 +57,7 @@
             )
           "
         >
-          <slot name="label">
-            {{ label + state.labelSuffix }}
-          </slot>
+          <slot name="label">{{ label + state.labelSuffix }}</slot>
         </span>
         <tiny-tooltip v-if="tipContent" effect="light" :content="tipContent" placement="top">
           <icon-help-circle


### PR DESCRIPTION
fix: 修复vue2下模板编译会多一个空格问题
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Simplified the template structure for label slots in form items without affecting functionality or appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->