### PR TITLE
feat: [tabs] Add left button for mobile-first mode

### DIFF
--- a/packages/renderless/src/tabs-mf/index.ts
+++ b/packages/renderless/src/tabs-mf/index.ts
@@ -290,6 +290,10 @@ export const getBoundRect = (vm) => () => vm.$el.getBoundingClientRect()
 
 export const handleClickDropdownItem = (tabs) => (name) => tabs.clickMore(name)
 
+export const scrollToLeft = (tabs) => () => {
+  tabs.scrollTo(tabs.state.navs[0].name)
+}
+
 export const key = (opt) => opt.name + '-' + random()
 
 export const emitAdd = (tabs) => () => {

--- a/packages/renderless/src/tabs-mf/vue-bar.ts
+++ b/packages/renderless/src/tabs-mf/vue-bar.ts
@@ -1,10 +1,10 @@
 import { addResizeListener, removeResizeListener } from '@opentiny/utils'
-import { wheelListener, getBoundRect, handleClickDropdownItem, key, emitAdd } from './index'
+import { wheelListener, getBoundRect, handleClickDropdownItem, key, emitAdd, scrollToLeft } from './index'
 import { getAddWheelListener } from './wheel'
 
 const { addWheelListener, removeWheelListener } = getAddWheelListener(window, document)
 
-export const api = ['state', 'wheelListener', 'handleClickDropdownItem', 'key', 'emitAdd']
+export const api = ['state', 'wheelListener', 'handleClickDropdownItem', 'key', 'emitAdd', 'scrollToLeft']
 
 export const renderless = (props, { onMounted, onBeforeUnmount, reactive, watch, inject, computed }, { vm }) => {
   const tabs = inject('tabs', null)
@@ -25,7 +25,8 @@ export const renderless = (props, { onMounted, onBeforeUnmount, reactive, watch,
     getBoundRect: getBoundRect(vm),
     handleClickDropdownItem: handleClickDropdownItem(tabs),
     key,
-    emitAdd: emitAdd(tabs)
+    emitAdd: emitAdd(tabs),
+    scrollToLeft: scrollToLeft(tabs)
   }
 
   Object.assign(api, {

--- a/packages/vue/src/tabs/src/mobile-first/tab-bar.vue
+++ b/packages/vue/src/tabs/src/mobile-first/tab-bar.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { renderless, api } from '@opentiny/vue-renderless/tabs-mf/vue-bar'
 import { props, setup, defineComponent, h } from '@opentiny/vue-common'
-import { IconPopup, IconPlus } from '@opentiny/vue-icon'
+import { IconPopup, IconPlus, IconChevronLeft } from '@opentiny/vue-icon'
 import Dropdown from '@opentiny/vue-dropdown'
 import DropdownMenu from '@opentiny/vue-dropdown-menu'
 import DropdownItem from '@opentiny/vue-dropdown-item'
@@ -14,9 +14,11 @@ export default defineComponent({
     return setup({ props, context, renderless, api, mono: true })
   },
   render() {
-    const { state, handleClickDropdownItem, key, emitAdd } = this
-    const tabNavClass =
-      state.moreList.length > 0 ? 'w-max inline-block' : 'w-full inline-flex justify-around sm:w-max sm:inline-block'
+    const { state, handleClickDropdownItem, key, emitAdd, scrollToLeft } = this
+    const isShowLeftButton = state.moreList.length > 0
+    const tabNavClass = isShowLeftButton
+      ? 'w-max inline-block'
+      : 'w-full inline-flex justify-around sm:w-max sm:inline-block'
 
     return h('div', { attrs: { 'data-tag': 'tiny-tab-bar' }, class: 'w-full h-11 sm:h-10 overflow-hidden relative' }, [
       h(
@@ -27,10 +29,11 @@ export default defineComponent({
             'scrollbar-size-0 w-full overflow-x-auto whitespace-nowrap',
             'before:block before:absolute before:w-0 before:h-11 sm:before:h-10',
             'after:block after:absolute after:top-0 after:right-0 after:w-0 after:h-11 sm:after:h-10',
-            'before:shadow-[1px_-10px_4px_4px_rgba(0,0,0,0.08)] after:shadow-[-1px_-10_4px_4px_rgba(0,0,0,0.08)]',
+            'after:shadow-[-1px_-10_4px_4px_rgba(0,0,0,0.08)]',
             !state.moreLeft && !state.moreRight ? 'before:hidden after:hidden' : '',
             !state.moreLeft ? 'before:hidden' : '',
-            !state.moreRight ? 'after:hidden' : ''
+            !state.moreRight ? 'after:hidden' : '',
+            isShowLeftButton ? 'sm:ml-6' : 'before:shadow-[1px_-10px_4px_4px_rgba(0,0,0,0.08)]'
           ]
         },
         [
@@ -41,6 +44,22 @@ export default defineComponent({
           })
         ]
       ),
+      // 左滑按钮改为绝对定位
+      isShowLeftButton
+        ? h(
+            'div',
+            {
+              class:
+                'hidden sm:inline-flex w-6 h-11 sm:h-10 text-sm cursor-pointer items-center justify-center absolute left-0 top-0 z-10 bg-color-bg-1',
+              on: { click: scrollToLeft }
+            },
+            [
+              h(IconChevronLeft(), {
+                class: 'fill-color-icon-primary hover:fill-color-icon-focus'
+              })
+            ]
+          )
+        : null,
       h('div', {
         class: [
           state.separator


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a left scroll button to the tab bar, allowing users to quickly scroll to the first tab when there are overflow tabs.
- **Style**
  - Updated tab bar styling to conditionally show or hide the left shadow and position the new scroll button appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->