### PR TITLE
fix: [file-upload] Fix the bug of uncontrollable file name length in SaaS mode and mobile first mode

### DIFF
--- a/packages/vue/src/upload-list/src/mobile-first.vue
+++ b/packages/vue/src/upload-list/src/mobile-first.vue
@@ -69,14 +69,8 @@
                   class="flex-1 sm:mr-6 text-xs sm:text-sm leading-5.5 text-color-text-primary overflow-hidden text-ellipsis whitespace-nowrap"
                 >
                   <span :title="file.name">{{
-                    file.name
-                      .split('.')
-                      .filter((item, i, arr) => arr.length - 1 > i || arr.length === 1)
-                      .join('.')
+                    file.name.length > maxNameLength ? file.name.substring(0, maxNameLength) + '...' : file.name
                   }}</span>
-                  <span v-if="file.name.includes('.')"
-                    >.{{ file.name.split('.')[file.name.split('.').length - 1] }}</span
-                  >
                 </div>
                 <div
                   data-tag="tiny-upload-list-operate"

--- a/packages/vue/src/upload-list/src/pc.vue
+++ b/packages/vue/src/upload-list/src/pc.vue
@@ -63,12 +63,8 @@
             <div class="file-name">
               <div class="file-name-box">
                 <span :title="file.name">{{
-                  file.name
-                    .split('.')
-                    .filter((item, i, arr) => arr.length - 1 > i || arr.length === 1)
-                    .join('.')
+                  file.name.length > maxNameLength ? file.name.substring(0, maxNameLength) + '...' : file.name
                 }}</span>
-                <span v-if="file.name.includes('.')">.{{ file.name.split('.')[file.name.split('.').length - 1] }}</span>
               </div>
               <div class="operate-panel">
                 <slot name="operate" :file="file">


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified file name display in the upload list by showing the full name truncated with an ellipsis if it exceeds a maximum length, instead of splitting and displaying the extension separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->