### PR TITLE
fix(numeric): in the mobilefirst of the numeric component, the default width is set to fill the available space

### DIFF
--- a/packages/vue/src/numeric/src/token.ts
+++ b/packages/vue/src/numeric/src/token.ts
@@ -1,5 +1,5 @@
 export const classes = {
-  'numeric': 'relative flex items-center w-24 h-7 text-sm bg-color-bg-1 leading-none',
+  'numeric': 'relative flex items-center w-full h-7 text-sm bg-color-bg-1 leading-none',
   'numeric_display_none': 'hidden',
   'numeric_size': 'sm:w-full sm:h-7 sm:text-sm',
   'numeric_medium': 'sm:w-full sm:h-8 sm:text-sm',


### PR DESCRIPTION
 

# PR

numeric 组件的多端模板，默认宽度撑满空间

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the numeric component to use full width for improved layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->