### PR TITLE
fix(grid): [grid] fix grid overflow-scroll when browser scale

### DIFF
--- a/packages/vue/src/grid/src/table/src/methods.ts
+++ b/packages/vue/src/grid/src/table/src/methods.ts
@@ -1016,7 +1016,8 @@ const Methods = {
     let { fit, columnStore, columnChart, isGroup } = this
     let tableHeight = bodyEl.offsetHeight
     let overflowY = bodyEl.scrollHeight > bodyEl.clientHeight
-    let bodyW = bodyEl.clientWidth
+    // 解决缩放时会出现滚动条的问题
+    let bodyW = Math.floor(bodyEl.getBoundingClientRect().width)
     let { leftList, rightList } = columnStore
 
     // 此处操作很重要，这里会计算所有列的宽度并且计算出表格整体宽度


### PR DESCRIPTION
# PR
解决浏览器缩放时，表格会出现滚动条的问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved table body width calculation to prevent unwanted scrollbars from appearing during zoom or scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->