### PR TITLE
fix(grid): [grid] fix input no cursor when dropConfig set filter

### DIFF
--- a/examples/sites/demos/apis/grid.js
+++ b/examples/sites/demos/apis/grid.js
@@ -3544,6 +3544,9 @@ interface IDropConfig {
   filter?: string
   // 如果变动了树层级，可以指定是否需要刷新数据
   refresh?: boolean
+  // 配置 filter 时，设置为 false 可以允许输入框正常聚焦
+  preventOnFilter?: boolean
+  // 更多其余参数请参考 sortablejs 插件配置
   }
       `
     },

--- a/packages/vue/src/grid/src/dragger/src/methods.ts
+++ b/packages/vue/src/grid/src/dragger/src/methods.ts
@@ -8,6 +8,7 @@ export default {
     const columnDropContainer = headerEl.querySelector('.tiny-grid__header .tiny-grid-header__row')
 
     const columnDropOptions = {
+      ...this.dropConfig,
       handle: '.tiny-grid-header__column:not(.col__fixed)',
       filter,
       onEnd: (event) => {
@@ -76,6 +77,7 @@ export default {
       handle = '.tiny-grid-body__row>td.col__index>.row__drop-handle'
     }
     const rowDropOptions = {
+      ...this.dropConfig,
       handle,
       filter,
       onEnd: createHandlerOnEnd({ _vm: this, refresh }),


### PR DESCRIPTION
# PR
修复拖拽配置设置了filter后，输入框无法获取光标问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new option to control drag-and-drop behavior during filtering, allowing input boxes to maintain normal focus if desired.

- **Enhancements**
  - Improved configuration flexibility for drag-and-drop features by supporting additional options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->