### PR TITLE
fix(transfer): fix the default selection does not checked  in the tree component under Vue 2

### DIFF
--- a/packages/renderless/src/transfer/index.ts
+++ b/packages/renderless/src/transfer/index.ts
@@ -349,6 +349,8 @@ export const setCheckedOnMounted =
   ({ props, vm, Tree }) =>
   () => {
     if (props.render && props.render.plugin.name === Tree) {
-      vm.$refs.leftPanel?.$refs?.plugin?.setCheckedKeys(props.modelValue)
+      setTimeout(() => {
+        vm.$refs.leftPanel?.$refs?.plugin?.setCheckedKeys(props.modelValue)
+      }, 50)
     }
   }


### PR DESCRIPTION

# PR
修复穿梭组件在Vue2时，在mounted时， tree组件未能完全加载数据， 从而设置勾选数据失败。
使用nextTick仍不行， 所以延时处理


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of the checked state in the transfer panel by adjusting the timing of initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->