### PR TITLE
fix(examples): 修正autocomplete案例标题size值与示例文字不符，容易误导用户。

### DIFF
--- a/examples/sites/demos/pc/app/autocomplete/size-composition-api.vue
+++ b/examples/sites/demos/pc/app/autocomplete/size-composition-api.vue
@@ -23,7 +23,7 @@
       ></tiny-autocomplete>
     </div>
     <div>
-      <div class="title">small:</div>
+      <div class="title">mini:</div>
       <tiny-autocomplete
         size="mini"
         v-model="value"

--- a/examples/sites/demos/pc/app/autocomplete/size.vue
+++ b/examples/sites/demos/pc/app/autocomplete/size.vue
@@ -23,7 +23,7 @@
       ></tiny-autocomplete>
     </div>
     <div>
-      <div class="title">small:</div>
+      <div class="title">mini:</div>
       <tiny-autocomplete
         size="mini"
         v-model="value"


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated label text for the "mini" size autocomplete component from "small:" to "mini:" for improved clarity in examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->