### PR TITLE
fix(utils): fix tooltip arrow safe padding

### DIFF
--- a/packages/utils/src/popper/index.ts
+++ b/packages/utils/src/popper/index.ts
@@ -703,9 +703,10 @@ export class PopperJS {
     let center = reference[side] + (arrowOffset || reference[calcProp] / 2 - arrowSize / 2)
     let sideValue = center - popper[side]
 
-    // 猜测是上下边距留下8px的距离。 确保箭头不太靠顶靠底。
-    // 此时sideValue为“popper的顶- 箭头 - 8px” 的位置。
-    sideValue = Math.max(Math.min(popper[calcProp] - arrowSize - 8, sideValue), 8)
+    // 猜测是上下边距留下4px的距离。 确保箭头不太靠顶靠底。
+    // 此时sideValue为“popper的顶- 箭头 - 4px” 的位置。
+    const safeLeft = 4
+    sideValue = Math.max(Math.min(popper[calcProp] - arrowSize - safeLeft, sideValue), safeLeft)
     arrowStyle[side] = sideValue
     arrowStyle[altSide] = ''
 
@@ -713,7 +714,7 @@ export class PopperJS {
     const params = this._options.placement.split('-')
     if (this._options.adjustArrow && ~['top', 'bottom'].indexOf(params[0]) && side === 'left') {
       if (params[1] === 'start') {
-        arrowStyle.left = 8
+        arrowStyle.left = safeLeft
       } else if (!params[1]) {
         arrowStyle.left = (popperRect.width - arrowRect.width) / 2
       }


### PR DESCRIPTION
# PR
修改popper的边距 从8px改完4px， 解决refrence元素宽度小的情况下，tooltip箭头对不齐问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Reduced the minimum margin between the popper arrow and its edges for a more compact appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->