### PR TITLE
fix: [grid] Add a scroll bar at the bottom of the SaaS theme table to be placed inside the table, with only one border at the bottom

### DIFF
--- a/packages/theme-saas/src/grid/table.less
+++ b/packages/theme-saas/src/grid/table.less
@@ -271,6 +271,22 @@
     }
   }
 
+  // tiny新增滚动条放置表格内
+  tbody tr:last-child {
+    @apply relative;
+
+    &::after {
+      @apply content-[''];
+      @apply absolute;
+      @apply bottom-0;
+      @apply left-0;
+      @apply right-0;
+      @apply bottom-0;
+      @apply h-px;
+      @apply bg-color-bg-1;
+    }
+  }
+
   &&__border,
   &&__border-saas {
     // 启用 border 只有表头生效，默认不建议启用 border 属性，另外如果内嵌列，则表头会自动启用 border 属性


### PR DESCRIPTION
# PR
改前：
![image](https://github.com/user-attachments/assets/9b1b6c1a-1f96-4041-b1e8-02adaaa08d3e)
改后：
![image](https://github.com/user-attachments/assets/5245b5d5-a9c8-47df-9fba-ff70a1676aa2)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved the appearance of tables by adding a subtle horizontal line at the bottom of the last row, enhancing visual separation and containment within the grid component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->