### PR TITLE
fix(select): remove the binding of dropStyle to the scrollbar

### DIFF
--- a/packages/vue/src/select/src/pc.vue
+++ b/packages/vue/src/select/src/pc.vue
@@ -475,7 +475,6 @@
             tag="ul"
             :wrap-class="['tiny-select-dropdown__wrap']"
             :view-class="['tiny-select-dropdown__list']"
-            :wrapStyle="dropStyle"
             @mousedown.stop
             :class="{
               'is-empty': !allowCreate && state.query && state.filteredOptionsCount === 0


### PR DESCRIPTION
# PR

## PR Checklist

回退dropStyle的透传给 select-dropdown__wrap的做法。

将select的 dropStyle透传给scrollbar后，引起2个问题
1、 双滚动条的风险， 当dropStyle配置的宽度小于select的宽度时，  scrollbar 和它的子列表会有2个滚动条。
2、select的弹出层flip时， 会向下几个像素， 造成select跟popper重叠了。

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed inline style application from the dropdown list’s scrollbar wrapper to streamline appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->