### PR TITLE
fix(theme-saas): add margin-bottom:4px  for select-dropdown flip to top

### DIFF
--- a/packages/theme-saas/src/select-dropdown/index.less
+++ b/packages/theme-saas/src/select-dropdown/index.less
@@ -26,6 +26,7 @@
 
   &.@{popper-prefix-cls} {
     @apply mt-1;
+    @apply mb-1;
   }
 
   & .@{scrollbar-prefix-cls} {


### PR DESCRIPTION
# PR
select的下拉面板翻转到上面的时候，应该在底部有4px的间距


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved vertical spacing for the select dropdown component by adding a small bottom margin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->