### PR TITLE
fix(pop-upload): Change the pop-upload e2e test case to ES6 import mode

### DIFF
--- a/examples/sites/demos/pc/app/pop-upload/basic-usage.spec.ts
+++ b/examples/sites/demos/pc/app/pop-upload/basic-usage.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect } from '@playwright/test'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 test('PopUpload 基本用法', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
@@ -13,8 +18,6 @@ test('PopUpload 基本用法', async ({ page }) => {
   const cancelBtn = uploadModal.getByRole('button', { name: '取消' })
   const lists = uploadModal.locator('.tiny-popupload__dialog-table-item')
   const deleteIcon = lists.locator('.del-col')
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-  const path = require('node:path')
   const path1 = path.resolve(__dirname, '测试.jpg')
   const path2 = path.resolve(__dirname, '测试.png')
 

--- a/examples/sites/demos/pc/app/pop-upload/before-upload.spec.ts
+++ b/examples/sites/demos/pc/app/pop-upload/before-upload.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect } from '@playwright/test'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 test('PopUpload 阻止上传文件', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
@@ -11,7 +16,6 @@ test('PopUpload 阻止上传文件', async ({ page }) => {
   const selectFilesBtn = uploadModal.getByRole('button', { name: '选择文件' })
   const uploadsBtn = page.getByRole('button', { name: '开始上传' })
   const lists = uploadModal.locator('.tiny-popupload__dialog-table-item')
-  const path = require('node:path')
   const currentPath = path.resolve(__dirname, '测试.jpg')
 
   await modalAppearBtn.click()

--- a/examples/sites/demos/pc/app/pop-upload/custom-request-headers.spec.ts
+++ b/examples/sites/demos/pc/app/pop-upload/custom-request-headers.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect } from '@playwright/test'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 test('PopUpload 自定义请求头', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
@@ -9,8 +14,6 @@ test('PopUpload 自定义请求头', async ({ page }) => {
   const uploadModal = page.locator('.tiny-popupload__modal')
   const selectFilesBtn = uploadModal.getByRole('button', { name: '选择文件' })
   const uploadsBtn = uploadModal.getByRole('button', { name: '开始上传' })
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-  const path = require('node:path')
   const currentPath = path.resolve(__dirname, '测试.jpg')
 
   await modalAppearBtn.click()

--- a/examples/sites/demos/pc/app/pop-upload/file-limit.spec.ts
+++ b/examples/sites/demos/pc/app/pop-upload/file-limit.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect } from '@playwright/test'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 test('PopUpload 最大上传文件数', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
@@ -10,7 +15,6 @@ test('PopUpload 最大上传文件数', async ({ page }) => {
   const alert = uploadModal.locator('.tiny-alert')
   const selectFilesBtn = uploadModal.getByRole('button', { name: '选择批量文件' })
   const lists = uploadModal.locator('.tiny-popupload__dialog-table-item')
-  const path = require('node:path')
   const path1 = path.resolve(__dirname, '测试.jpg')
   const path2 = path.resolve(__dirname, '测试.png')
   const path3 = path.resolve(__dirname, '测试.svg')

--- a/examples/sites/demos/pc/app/pop-upload/file-type.spec.ts
+++ b/examples/sites/demos/pc/app/pop-upload/file-type.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect } from '@playwright/test'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 test('PopUpload 限制上传文件类型和大小', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
@@ -11,8 +16,6 @@ test('PopUpload 限制上传文件类型和大小', async ({ page }) => {
   const selectFilesBtn = uploadModal.getByRole('button', { name: '选择文件' })
   const uploadsBtn = uploadModal.getByRole('button', { name: '开始上传' })
   const lists = uploadModal.locator('.tiny-popupload__dialog-table-item')
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-  const path = require('node:path')
   const path1 = path.resolve(__dirname, '测试.jpg')
   const path2 = path.resolve(__dirname, '测试.png')
   const path3 = path.resolve(__dirname, '测试.svg')

--- a/examples/sites/demos/pc/app/pop-upload/http-request.spec.ts
+++ b/examples/sites/demos/pc/app/pop-upload/http-request.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect } from '@playwright/test'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 test('PopUpload 覆盖默认请求', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
@@ -10,7 +15,6 @@ test('PopUpload 覆盖默认请求', async ({ page }) => {
   const selectFilesBtn = uploadModal.getByRole('button', { name: '选择文件' })
   const uploadsBtn = uploadModal.getByRole('button', { name: '开始上传' })
   const lists = uploadModal.locator('.tiny-popupload__dialog-table-item')
-  const path = require('node:path')
   const currentPath = path.resolve(__dirname, '测试.jpg')
 
   await modalAppearBtn.click()

--- a/examples/sites/demos/pc/app/pop-upload/prevent-delete-file.spec.ts
+++ b/examples/sites/demos/pc/app/pop-upload/prevent-delete-file.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect } from '@playwright/test'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 test('PopUpload 阻止删除文件', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
@@ -11,7 +16,6 @@ test('PopUpload 阻止删除文件', async ({ page }) => {
   const selectFilesBtn = uploadModal.getByRole('button', { name: '选择文件' })
   const lists = uploadModal.locator('.tiny-popupload__dialog-table-item')
   const deleteIcon = lists.locator('.del-col')
-  const path = require('node:path')
   const currentPath = path.resolve(__dirname, '测试.jpg')
 
   await modalAppearBtn.click()

--- a/examples/sites/demos/pc/app/pop-upload/upload-events.spec.ts
+++ b/examples/sites/demos/pc/app/pop-upload/upload-events.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect } from '@playwright/test'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 test('事件是否正常触发', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
@@ -11,7 +16,6 @@ test('事件是否正常触发', async ({ page }) => {
   const uploadsBtn = page.getByRole('button', { name: '开始上传' })
   const lists = uploadModal.locator('.tiny-popupload__dialog-table-item')
   const deleteIcon = lists.locator('.del-col')
-  const path = require('node:path')
   const currentPath1 = path.resolve(__dirname, '测试.jpg')
   const currentPath2 = path.resolve(__dirname, '测试.png')
   const currentPath3 = path.resolve(__dirname, '测试.svg')


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated test files to use modern ES module import syntax instead of CommonJS-style imports for handling file paths.
  - Improved consistency and compatibility by introducing ES module equivalents for file and directory path variables.
  - No changes to test logic or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->