### PR TITLE
fix(site): use purple for attr's color

### DIFF
--- a/examples/sites/src/assets/custom-markdown.css
+++ b/examples/sites/src/assets/custom-markdown.css
@@ -162,7 +162,7 @@ html.dark.dark .markdown-body code {
       color: #e1e4e8;
     }
     .attr-name {
-      color: #f97583;
+      color: #b392f0;
     }
     .attr-value {
       color: #9ecbff;


### PR DESCRIPTION
# PR
md文件中的代码高亮中， 属性应该使用紫色
 
![image](https://github.com/user-attachments/assets/2e58fa53-ce44-48f9-b94d-a42f0ee3dc7c)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the color styling for HTML attribute names in code blocks when using dark mode, changing from red to purple for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->