### PR TITLE
fix(upload): add the "relative" style to the root node of "upload"

### DIFF
--- a/packages/vue/src/upload/src/mobile-first.vue
+++ b/packages/vue/src/upload/src/mobile-first.vue
@@ -112,7 +112,7 @@ export default defineComponent({
         data-tag="tiny-upload"
         class={[
           !displayOnly && listType === 'text'
-            ? `flex mt-4 mb-2 ${isBubbleMode ? 'sm:my-0' : !isShowTitle ? 'sm:mt-0' : 'sm:my-3'}`
+            ? `flex mt-4 relative mb-2 ${isBubbleMode ? 'sm:my-0' : !isShowTitle ? 'sm:mt-0' : 'sm:my-3'}`
             : 'h-full',
           showFileList ? 'sm:mb-3' : 'sm:mb-0'
         ]}>


### PR DESCRIPTION
# PR
upload 的多端模板增加 relative,  防止 加号 添加文件的svg漂移到页面顶部。
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout styling for text list uploads on mobile devices by updating container positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->