### PR TITLE
fix(popper): [tooltip,popover] enhance the isScrollElement function to add judgment on element type and scroll bar

### DIFF
--- a/packages/utils/src/popper/index.ts
+++ b/packages/utils/src/popper/index.ts
@@ -99,13 +99,19 @@ const getBoundingClientRect = (el: HTMLElement) => {
 
 /** 判断el的overflow是不是可能滚动的 */
 const isScrollElement = (el: HTMLElement) => {
-  const scrollTypes = ['scroll', 'auto']
+  if (!el || el.nodeType !== 1) {
+    return false
+  }
+  // 针对overflow的判断,并且增加了对元素是否有滚动条的判断
+  const css = window.getComputedStyle(el, null)
+  const overflow = css.overflow
+  const overflowX = css.overflowX
+  const overflowY = css.overflowY
+  const pattern = /(auto|scroll|overlay|clip)/
 
-  return (
-    scrollTypes.includes(getStyleComputedProperty(el, 'overflow')) ||
-    scrollTypes.includes(getStyleComputedProperty(el, 'overflow-x')) ||
-    scrollTypes.includes(getStyleComputedProperty(el, 'overflow-y'))
-  )
+  const hasScrollableContent = el.scrollHeight > el.clientHeight || el.scrollWidth > el.clientWidth
+
+  return hasScrollableContent && pattern.test(overflow + overflowY + overflowX)
 }
 
 /** 设置transform等样式后，fixed定位不再相对于视口，使用1X1PX透明元素获取fixed定位相对于视口的修正偏移量。 */


### PR DESCRIPTION
fix(popper): 增强isScrollElement函数，增加对元素类型和滚动条的判断
![image](https://github.com/user-attachments/assets/ebe51eda-cb6b-4960-af5a-c83d9c963a17)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of scrollable elements, ensuring more accurate behavior when identifying elements with scrollable content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->