### PR TITLE
fix(popeditor): add three slot to popeditor

### DIFF
--- a/examples/sites/demos/apis/popeditor.js
+++ b/examples/sites/demos/apis/popeditor.js
@@ -445,6 +445,36 @@ export default {
       methods: [],
       slots: [
         {
+          name: 'title-selection',
+          defaultValue: '',
+          desc: {
+            'zh-CN': '已选择数据标题插槽',
+            'en-US': ''
+          },
+          mode: ['pc'],
+          pcDemo: ''
+        },
+        {
+          name: 'title-history',
+          defaultValue: '',
+          desc: {
+            'zh-CN': '历史数据标题插槽',
+            'en-US': ''
+          },
+          mode: ['pc'],
+          pcDemo: ''
+        },
+        {
+          name: 'title-source',
+          defaultValue: '',
+          desc: {
+            'zh-CN': '所有数据标题插槽',
+            'en-US': ''
+          },
+          mode: ['pc'],
+          pcDemo: ''
+        },
+        {
           name: 'footer',
           defaultValue: '',
           desc: {

--- a/packages/vue/src/popeditor/src/pc.vue
+++ b/packages/vue/src/popeditor/src/pc.vue
@@ -151,7 +151,9 @@
                       'tiny-popeditor__tabs-selected': state.activeName === 'history'
                     }"
                   >
-                    <span>{{ t('ui.popeditor.historyLists') }}</span>
+                    <slot name="title-history">
+                      <span>{{ t('ui.popeditor.historyLists') }}</span>
+                    </slot>
                   </li>
                   <li
                     @click="state.activeName = 'source'"
@@ -159,7 +161,9 @@
                       'tiny-popeditor__tabs-selected': state.activeName === 'source'
                     }"
                   >
-                    <span>{{ t('ui.popeditor.sourceLists') }}</span>
+                    <slot name="title-source">
+                      <span>{{ t('ui.popeditor.sourceLists') }}</span>
+                    </slot>
                   </li>
                 </ul>
               </div>
@@ -227,7 +231,9 @@
               <div class="tiny-popeditor__tabs-head">
                 <ul>
                   <li class="tiny-popeditor__tabs-selected">
-                    <span>{{ t('ui.popeditor.selectionLists') }}</span>
+                    <slot name="title-selection">
+                      <span>{{ t('ui.popeditor.selectionLists') }}</span>
+                    </slot>
                   </li>
                 </ul>
               </div>


### PR DESCRIPTION
# PR

参考A源码， 补充3个缺失的插槽
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added customizable slots for tab titles in the pop-up editor, allowing users to personalize the titles for selected data, history data, and all data when using the component in PC mode. Default titles remain available as fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->