### PR TITLE
chore(site): update VITE_PLAYGROUND_URL path and upgrade the practice site version to 3.23

### DIFF
--- a/examples/sites/env/.env.pages
+++ b/examples/sites/env/.env.pages
@@ -5,4 +5,4 @@ VITE_BUILD_TARGET='inner'
 VITE_APP_MODE='pc'
 
 VITE_APP_BUILD_BASE_URL='/tiny-vue/'
-VITE_PLAYGROUND_URL=/playground.html
+VITE_PLAYGROUND_URL=/tiny-vue/playground.html

--- a/examples/sites/playground/App.vue
+++ b/examples/sites/playground/App.vue
@@ -11,7 +11,7 @@ import logoUrl from './assets/opentiny-logo.svg?url'
 import GitHub from './icons/Github.vue'
 import Share from './icons/Share.vue'
 
-const VERSION = 'tiny-vue-version-3.22'
+const VERSION = 'tiny-vue-version-3.23'
 const NOTIFY_KEY = 'tiny-vue-playground-notify'
 const LAYOUT = 'playground-layout'
 const LAYOUT_REVERSE = 'playground-layout-reverse'
@@ -23,7 +23,7 @@ const isMobileFirst = tinyMode === 'mobile-first'
 const isSaas = tinyTheme === 'saas'
 const isPreview = searchObj.get('openMode') === 'preview' // 是否多端弹窗预览
 
-const versions = ['3.22', '3.21', '3.20']
+const versions = ['3.23', '3.22', '3.21']
 const getVersion = () => {
   if (isPreview) {
     return versions[0]


### PR DESCRIPTION
chore(site): 更新VITE_PLAYGROUND_URL路径并升级演练场版本号至3.23
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the playground environment URL to use the new `/tiny-vue` path prefix.
	- Updated the playground to reflect the latest version, now displaying version 3.23 as the newest available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->