### PR TITLE
fix(tooltip): fix tooltip's box-shadow and invalid text of form-item's style

### DIFF
--- a/packages/theme-saas/src/tooltip/index.less
+++ b/packages/theme-saas/src/tooltip/index.less
@@ -29,7 +29,7 @@
     @apply ~'z-[2000]';
     word-wrap: break-word;
     @apply rounded;
-    @apply shadow;
+    @apply shadow-md;
 
     .popper__arrow,
     .popper__arrow::after {

--- a/packages/theme-saas/theme/theme.json
+++ b/packages/theme-saas/theme/theme.json
@@ -972,7 +972,7 @@
     "boxShadow": {
       "--tiny-boxShadow-sm": "0px 1px 6px 0px rgba(0, 0, 0, 0.08)",
       "--tiny-boxShadow-DEFAULT": "0px 4px 12px 0px rgba(0, 0, 0, 0.08)",
-      "--tiny-boxShadow-md": "1px 4px 12px 0px rgba(0, 0, 0, 0.16)",
+      "--tiny-boxShadow-md": "0 4px 12px 0px rgba(0, 0, 0, 0.16)",
       "--tiny-boxShadow-lg": "0px 8px 24px 0px rgba(0, 0, 0, 0.16)",
       "--tiny-boxShadow-xl": "0px 16px 48px 0px rgba(0, 0, 0, 0.16)",
       "--tiny-boxShadow-2xl": "0px 24px 40px 0px rgba(0, 0, 0, 0.12)",

--- a/packages/vue/src/form-item/src/mobile-first.vue
+++ b/packages/vue/src/form-item/src/mobile-first.vue
@@ -120,7 +120,7 @@
         <div
           :class="
             m(
-              'relative sm:absolute left-0 bottom-1 sm:-bottom-4 text-color-error text-xs leading-4 line-clamp-3 sm:line-clamp-1 break-all',
+              'sm:absolute left-0 bottom-1 sm:-bottom-4 text-color-error text-xs leading-4 line-clamp-3 sm:line-clamp-1 break-all',
               (typeof inlineMessage === 'boolean' && inlineMessage) || state.inlineMessage
                 ? 'relative top-auto left-auto inline-block'
                 : ''


### PR DESCRIPTION
 
# PR
1、 tooltip 的theme-saas中的样式， 外阴影修改为shadow-md
2、 多端的校验文本距离上面的表单元素没有空白，去掉relative可以有空白。

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated tooltip shadow styling for improved visual appearance.
  - Adjusted error message container positioning in forms, which may affect layout on some screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->