### PR TITLE
ci(workflow): add origin input parameter of E2E test configuration, support specifying test domain name, and fix sticky component test cases

### DIFF
--- a/.github/workflows/test-e2e-dispatch.yml
+++ b/.github/workflows/test-e2e-dispatch.yml
@@ -1,5 +1,5 @@
 name: E2E Test Dispatch
-run-name: E2E Test Dispatch--${{ inputs.testDemos }}--
+run-name: E2E Test Dispatch--${{ inputs.testDemos }}--origin--${{ inputs.origin }}
 on:
   workflow_dispatch:
     inputs:
@@ -8,6 +8,12 @@ on:
           Name of directory from "examples/sites/demos/pc/app",
           such as `input, alert`.
         required: true
+        type: string
+      origin:
+        description: |
+          输入需要测试的域名地址，包括微服务路径，如果不输入则采用本地启动服务测试,
+          例如： `https://opentiny.github.io/tiny-vue-web-doc`.
+        required: false
         type: string
 concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}
@@ -44,7 +50,12 @@ jobs:
         run: pnpm i --no-frozen-lockfile
 
       - name: dev start
+        if: contains(inputs.origin, 'http') == false
         run: pnpm site & sleep 5
+
+      - name: Release E2E Config
+        if: contains(inputs.origin, 'http') == true
+        run: pnpm release:e2eConfig -o ${{ inputs.origin }} & sleep 5
 
       - name: Install Playwright browsers
         run: pnpm install:browser --with-deps chromium

--- a/examples/sites/demos/pc/app/sticky/offset.spec.ts
+++ b/examples/sites/demos/pc/app/sticky/offset.spec.ts
@@ -7,5 +7,7 @@ test('偏移距离', async ({ page }) => {
   const demo = page.locator('#offset')
 
   await demo.locator('i').first().scrollIntoViewIfNeeded()
+  await page.waitForTimeout(200)
+  await demo.locator('i').nth(2).scrollIntoViewIfNeeded()
   await expect(demo.locator('.tiny-sticky--fixed')).toHaveCSS('top', '100px')
 })


### PR DESCRIPTION
ci(workflow): 增加E2E测试配置的origin输入参数，支持指定测试域名，并修复sticky组件测试用例
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced end-to-end testing workflow with an optional input for specifying a remote service URL, improving flexibility in test execution.
- **Tests**
	- Improved reliability of sticky element tests by adding a short delay and an extra scroll action before verifying CSS properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->