### PR TITLE
fix(popeditor): fix popeditor can not set grid props

### DIFF
--- a/packages/vue/src/popeditor/src/pc.vue
+++ b/packages/vue/src/popeditor/src/pc.vue
@@ -64,6 +64,7 @@
         <tiny-grid
           ref="suggest"
           v-if="state.showSuggestPanel"
+          v-bind="gridOp"
           auto-resize
           :loading="state.loading"
           max-height="300px"
@@ -172,6 +173,7 @@
                 <div v-if="state.activeName === 'history'" class="tabs-body-item">
                   <tiny-grid
                     ref="historyGrid"
+                    v-bind="gridOp"
                     height="290px"
                     size="mini"
                     :highlight-current-row="true"
@@ -187,6 +189,7 @@
                 <div v-if="state.activeName === 'source'" class="tabs-body-item">
                   <tiny-grid
                     v-if="multi"
+                    v-bind="gridOp"
                     auto-resize
                     :loading="state.loading"
                     ref="sourceGrid"
@@ -204,6 +207,7 @@
                   <tiny-grid
                     v-else
                     ref="sourceGrid"
+                    v-bind="gridOp"
                     auto-resize
                     :loading="state.loading"
                     height="290px"
@@ -268,6 +272,7 @@
                   <tiny-grid
                     v-else
                     ref="selectedGrid"
+                    v-bind="gridOp"
                     auto-resize
                     :columns="state.baseColumns"
                     :data="state.selectedDatas"


### PR DESCRIPTION
# PR
popeditor透传表格属性
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced grid components with additional configuration options for improved customization and consistency across suggest panel, history, conditional source, and selected data grids.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->