### PR TITLE
fix(select): fix can not set grid rowId in select

### DIFF
--- a/packages/vue/src/select/src/pc.vue
+++ b/packages/vue/src/select/src/pc.vue
@@ -378,7 +378,7 @@
           <tiny-grid
             v-if="renderType === 'grid'"
             auto-resize
-            :row-id="valueField"
+            :row-id="gridOp.rowId || valueField"
             :select-config="buildSelectConfig()"
             :radio-config="buildRadioConfig()"
             ref="selectGrid"


### PR DESCRIPTION
# PR
修复vue2无法通过gridOp设置表格rowId


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the logic for determining the row identifier in the grid component, ensuring more accurate selection based on available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->