### PR TITLE
fix(tree-menu): change the color of the dark mode icon

### DIFF
--- a/packages/theme/src/tree-menu/index.less
+++ b/packages/theme/src/tree-menu/index.less
@@ -210,16 +210,22 @@
         }
 
         .tree-node-name {
+          display: flex;
           align-items: center;
           padding: 0 var(--tv-TreeMenu-node-body-text-padding-x);
 
           &:hover {
             font-weight: var(--tv-TreeMenu-node-name-hover-font-weight);
             color: var(--tv-TreeMenu-node-name-hover-color);
+
+            svg {
+              fill: var(--tv-TreeMenu-node-icon-hover-color);
+            }
           }
 
           svg {
             margin-right: var(--tv-TreeMenu-prefix-icon-margin-right);
+            fill: var(--tv-TreeMenu-node-icon-fill-color);
           }
         }
       }
@@ -254,6 +260,10 @@
           .tree-node-body {
             font-weight: bold;
             color: var(--tv-TreeMenu-node-body-selected-color);
+
+            svg {
+              fill: var(--tv-TreeMenu-node-icon-hover-color);
+            }
           }
         }
 

--- a/packages/theme/src/tree-menu/vars.less
+++ b/packages/theme/src/tree-menu/vars.less
@@ -31,6 +31,8 @@
   --tv-TreeMenu-node-body-text-color: var(--tv-color-text-control, #191919);
   // 节点悬浮背景色
   --tv-TreeMenu-node-hover-bg-color: var(--tv-color-bg-hover, #f5f5f5);
+  // 图标颜色
+  --tv-TreeMenu-node-icon-fill-color: var(--tv-color-icon, #808080);
   // 折叠图标颜色
   --tv-TreeMenu-collapse-icon-fill-color: var(--tv-color-icon, #808080);
   // 底部折叠按钮


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved alignment of tree menu node names with flexbox and vertical centering.
  - Enhanced icon color consistency by updating icon fill colors on hover and selection states.
  - Introduced a new variable for customizing tree menu node icon colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->