### PR TITLE
fix(autocomplete): autocomplete component defaults to 100% of the width

### DIFF
--- a/packages/theme-saas/src/autocomplete/index.less
+++ b/packages/theme-saas/src/autocomplete/index.less
@@ -8,6 +8,7 @@
 .@{autocomplete-prefix-cls} {
   @apply relative;
   @apply inline-block;
+  @apply w-full;
 
   &.show-auto-width {
     @apply w-full;
@@ -30,7 +31,8 @@
     }
 
     // 兼容ie10-ie11
-    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    @media screen and (-ms-high-contrast: active),
+    (-ms-high-contrast: none) {
       &__wrap {
         margin-bottom: -17px !important;
         @apply ~'pb-1.5';
@@ -69,6 +71,7 @@
       }
 
       &:only-of-type {
+
         &,
         &:hover {
           @apply bg-color-bg-3;

--- a/packages/theme/src/autocomplete/index.less
+++ b/packages/theme/src/autocomplete/index.less
@@ -18,6 +18,7 @@
 .@{autocomplete-prefix-cls} {
   position: relative;
   display: inline-block;
+  width: 100%;
 
   &.show-auto-width {
     width: 100%;


### PR DESCRIPTION
# PR

## PR Checklist
autocomplete组件的宽度，默认就100%


Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated autocomplete component styles to ensure it uses the full width of its container by default.
  - Minor formatting improvements for better readability; no impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->