### PR TITLE
fix: the issue of modifying line breaks for display

### DIFF
--- a/packages/theme-saas/src/grid/modal.less
+++ b/packages/theme-saas/src/grid/modal.less
@@ -144,7 +144,6 @@
       .@{grid-modal-prefix-cls}__body {
         @apply whitespace-normal;
         word-wrap: break-word;
-        @apply break-all;
         @apply overflow-auto;
       }
     }


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:
修改控制文本的换行显示：使用break-word即可，实现换行。而break-all 是 word-break 属性的一个值，它允许在单词的任意位置进行换行，即使这个位置不是默认的换行点。
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated modal body text behavior to improve word wrapping and prevent words from breaking at arbitrary points in message, alert, and confirm modals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->