### PR TITLE
fix(tag): tag remove inline-block

### DIFF
--- a/packages/vue/src/tag/src/pc.vue
+++ b/packages/vue/src/tag/src/pc.vue
@@ -80,7 +80,6 @@ export default defineComponent({
 
     if (maxWidth) {
       styles.maxWidth = maxWidth
-      styles.display = 'inline-block' // 显示省略号
     }
 
     const tagElement =


### PR DESCRIPTION
# PR

如果有inline-block, 那么不显示 关闭图标。 去掉不影响省略号
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated tag component styling so that setting a maximum width no longer forces the display to inline-block. This may affect the visual layout of tags with a max width applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->