### PR TITLE
fix(grid): Limit the size attribute value of the paging component to 'mini' or an empty string to prevent warnings

### DIFF
--- a/packages/vue/src/grid/src/pager/src/methods.ts
+++ b/packages/vue/src/grid/src/pager/src/methods.ts
@@ -45,7 +45,8 @@ export default {
       pager.component = pager.component || (fetchData && fetchData.api ? Pager : null)
       res = h(hooks.toRaw(pager.component), {
         props: {
-          size: vSize,
+          // 只允许 'mini' 或 ''，否则传空字符串，防止分页组件报警告
+          size: ['mini', ''].includes(vSize) ? vSize : '', // 兼容 grid 的 size 传递
           loading: loading || tableLoading,
           isBeforePageChange: _vm.isBeforePageChange || _vm.showSaveMsg,
           accurateJumper: _vm.autoLoad,

--- a/packages/vue/src/grid/src/pager/src/methods.ts
+++ b/packages/vue/src/grid/src/pager/src/methods.ts
@@ -45,8 +45,8 @@ export default {
       pager.component = pager.component || (fetchData && fetchData.api ? Pager : null)
       res = h(hooks.toRaw(pager.component), {
         props: {
-          // 只允许 'mini' 或 ''，否则传空字符串，防止分页组件报警告
-          size: ['mini', ''].includes(vSize) ? vSize : '', // 兼容 grid 的 size 传递
+          // tiny-grid 的 size 为 small/mini 时，pager 传 mini；为 medium 时，pager 传空字符串
+          size: vSize === 'medium' ? '' : ['small', 'mini'].includes(vSize) ? 'mini' : '', // 兼容 grid 的 size 传递
           loading: loading || tableLoading,
           isBeforePageChange: _vm.isBeforePageChange || _vm.showSaveMsg,
           accurateJumper: _vm.autoLoad,


### PR DESCRIPTION
fix(grid): 限制分页组件的 size 属性值为 'mini' 或空字符串，防止警告
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility of the pager component by normalizing size values, preventing warnings related to invalid size properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->