### PR TITLE
fix(grid): fix resize bar cover by header

### DIFF
--- a/packages/theme-saas/src/grid/table.less
+++ b/packages/theme-saas/src/grid/table.less
@@ -707,7 +707,7 @@
     @apply left-0;
     @apply ~'w-0.5';
     @apply h-full;
-    @apply ~'z-[4]';
+    @apply ~'z-[21]';
 
     &:before {
       @apply content-[''];

--- a/packages/theme/src/grid/table.less
+++ b/packages/theme/src/grid/table.less
@@ -638,7 +638,7 @@
     left: 0;
     width: 1px;
     height: 100%;
-    z-index: 4;
+    z-index: 21;
 
     &:before {
       content: '';


### PR DESCRIPTION
# PR
修复拖拽列宽线被表头遮挡问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visibility of the column resize bar in tables by increasing its stacking order, ensuring it appears above more elements during column resizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->