### PR TITLE
fix(cascader): fix When using slots in cascader-panel, the mf template will error

### DIFF
--- a/packages/renderless/src/cascader-node/vue.ts
+++ b/packages/renderless/src/cascader-node/vue.ts
@@ -45,6 +45,7 @@ export const renderless = (
     inActivePath: computed(() => api.isInPath(parent.state.activePath)),
     inCheckedPath: computed(() => api.comptCheckPath()),
     value: computed(() => props.node.getValueByOption()),
+    // 仅 mf 用到nodeLabel
     nodeLabel: computed(() => {
       return parent.state.renderLabelFn
         ? parent.state.renderLabelFn({ node: props.node, data: props.node.data })

--- a/packages/vue/src/cascader-node/src/mobile-first.vue
+++ b/packages/vue/src/cascader-node/src/mobile-first.vue
@@ -16,7 +16,12 @@
       )
     "
   >
-    <span :class="[node ? gcls('cascader-node__label_disabled') : '']">{{ state.nodeLabel }}</span>
+    <span v-if="typeof state.nodeLabel === 'string'" :class="[node ? gcls('cascader-node__label_disabled') : '']">
+      {{ state.nodeLabel }}
+    </span>
+    <span v-else :class="[node ? gcls('cascader-node__label_disabled') : '']">
+      <render-node-label :vnode="state.nodeLabel" />
+    </span>
     <icon-loading v-if="node.loading" :class="gcls('cascader-node__postfix')"></icon-loading>
     <icon-chevron-right
       v-else-if="!state.isLeaf"
@@ -43,7 +48,15 @@ export default defineComponent({
   name: $prefix + 'CascaderNode',
   components: {
     IconLoading: IconLoading(),
-    IconChevronRight: IconChevronRight()
+    IconChevronRight: IconChevronRight(),
+    RenderNodeLabel: {
+      name: 'AnyNode',
+      functional: true,
+      props: ['vnode'],
+      render(h, ctx) {
+        return h.vnode || ctx.props?.vnode // 兼容vue2,3的写法
+      }
+    }
   },
   inheritAttrs: false,
   emits: ['expand', 'update:modelValue', 'expand-change', 'active-item-change', 'change'],

--- a/packages/vue/src/cascader-node/src/pc.vue
+++ b/packages/vue/src/cascader-node/src/pc.vue
@@ -119,6 +119,7 @@ export default defineComponent({
 
       const vnode = render ? render({ node, data: node.data }) : null
 
+      // 可用 state.nodeLabel 简化
       return <span class="tiny-cascader-node__label">{vnode || node.label}</span>
     }
 


### PR DESCRIPTION
 # PR

修复 级联面板在使用插槽时， cascader-node的mf模板会报错的问题

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved rendering of node labels in mobile view, allowing support for both plain text and more complex content.

* **Style**
  * Node labels now display correctly based on their type, enhancing visual consistency.

* **Documentation**
  * Added clarifying comments in the codebase for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->