### PR TITLE
fix(grid): fix scroll to bottom header not visible

### DIFF
--- a/packages/vue/src/grid/src/table/src/utils/updateStyle.ts
+++ b/packages/vue/src/grid/src/table/src/utils/updateStyle.ts
@@ -28,7 +28,7 @@ import GlobalConfig from '../../../config'
 
 // 计算表格整体宽高
 export function handleLayout(_vm) {
-  const { tableFullData, height, parentHeight, scrollXLoad, tableColumn } = _vm
+  const { tableFullData, height, parentHeight, scrollXLoad, scrollYLoad, tableColumn } = _vm
   let { maxHeight, minHeight, totalWidth } = _vm
   let customHeight, scaleToPx
 
@@ -65,6 +65,10 @@ export function handleLayout(_vm) {
     }
 
     _vm.bodyWrapperMinHeight = minHeight
+  }
+
+  if (scrollYLoad && !_vm.bodyWrapperHeight) {
+    _vm.bodyWrapperHeight = maxHeight
   }
 
   _vm.bodyTableWidth = scrollXLoad


### PR DESCRIPTION
# PR
修复当有横向滚动条时，虚拟滚动表格滚动到底部表头会多出滚动条偏移量的问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table layout handling to ensure proper height assignment when vertical scroll loading is enabled and no explicit body wrapper height is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->