### PR TITLE
fix(grid): fix tree table children edit revert error

### DIFF
--- a/packages/vue/src/grid/src/body/src/body.tsx
+++ b/packages/vue/src/grid/src/body/src/body.tsx
@@ -752,6 +752,8 @@ export default defineComponent({
 
     hooks.watch(tbody, (tbody) => {
       if (tbody && $table.dropConfig) {
+        vm.rowSortable?.destroy()
+        vm.columnSortable?.destroy()
         // 初始化行列拖拽
         const { plugin, row = true, column = true, scheme } = $table.dropConfig
 
@@ -787,8 +789,8 @@ export default defineComponent({
 
       body.value?.removeEventListener('scroll', vm._throttleScrollHandler)
       vm._throttleScrollHandler = null
-      rowSortable && rowSortable.destroy()
-      columnSortable && columnSortable.destroy()
+      rowSortable?.destroy()
+      columnSortable?.destroy()
       resizeObserver.disconnect()
     })
 

--- a/packages/vue/src/grid/src/edit/src/methods.ts
+++ b/packages/vue/src/grid/src/edit/src/methods.ts
@@ -279,7 +279,7 @@ export default {
    * 如果还额外传了field则还原指定单元格。
    */
   _revertData(rows, field) {
-    let { tableSourceData, tableSynchData } = this
+    let { tableSynchData } = this
 
     if (arguments.length && rows && !isArray(rows)) {
       rows = [rows]
@@ -291,7 +291,7 @@ export default {
 
     for (let i = 0; i < rows.length; i++) {
       let row = rows[i]
-      let oRow = find(tableSourceData, (item) => getRowid(this, row) === getRowid(this, item))
+      let oRow = this.getOriginRow(row)
 
       if (oRow && row) {
         if (field) {

--- a/packages/vue/src/grid/src/table/src/methods.ts
+++ b/packages/vue/src/grid/src/table/src/methods.ts
@@ -325,25 +325,70 @@ const Methods = {
       resolve()
     })
   },
+  getOriginRow(row) {
+    const { backupMap } = this
+
+    return backupMap.has(row) ? backupMap.get(row) : null
+  },
+  setOriginRow(row, record) {
+    const { backupMap } = this
+
+    if (backupMap.has(row) && record) {
+      backupMap.set(row, record)
+    }
+  },
   reloadRow(row, record, field) {
-    let { tableData, tableSourceData } = this
-    let rowIndex = this.getRowIndex(row)
-    let originRow = tableSourceData[rowIndex]
-    let hasSrc = originRow && row
-    let hasSrcNoField = hasSrc && !field
+    const { tableData, treeConfig, treeOrdered } = this
+    const { children: childrenKey, temporaryIndex = '_$index_' } = treeConfig || {}
+    const rowKey = getRowkey(this)
+    const originRow = this.getOriginRow(row)
+    const hasSrc = originRow && row
+    const hasSrcNoField = hasSrc && !field
+
     if (hasSrc && field) {
       set(originRow, field, get(record || row, field))
     }
+
     if (hasSrcNoField && record) {
-      tableSourceData[rowIndex] = record
+      const backupRow = this.defineField({ ...record, [rowKey]: originRow[rowKey] })
+      let rowChildren, clonedRow
+
+      if (treeConfig) {
+        backupRow[childrenKey] = undefined
+        rowChildren = row[childrenKey]
+
+        if (!treeOrdered) {
+          backupRow[temporaryIndex] = originRow[temporaryIndex]
+        }
+      }
+
+      clonedRow = clone(backupRow, true)
+
+      if (treeConfig) {
+        backupRow[childrenKey] = originRow[childrenKey]
+      }
+
+      this.setOriginRow(row, backupRow)
       clear(row, undefined)
-      Object.assign(row, this.defineField({ ...record }))
+      Object.assign(row, clonedRow, treeConfig ? { [childrenKey]: rowChildren } : null)
       this.updateCache()
     }
+
     if (hasSrcNoField && !record) {
-      destructuring(originRow, clone(row, true))
+      let clonedRow
+
+      if (treeConfig) {
+        clonedRow = clone({ ...row, [childrenKey]: undefined }, true)
+        clonedRow[childrenKey] = originRow[childrenKey]
+      } else {
+        clonedRow = clone(row, true)
+      }
+
+      destructuring(originRow, clonedRow)
     }
+
     this.tableData = tableData.slice(0)
+
     return this.$nextTick()
   },
   // 从新加载列配置


### PR DESCRIPTION
# PR
修复树表子行编辑无法恢复问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new methods to better manage and restore original row data, improving support for tree-structured tables.

* **Bug Fixes**
  * Improved destruction of sortable instances to prevent issues when updating table content.
  * Enhanced data reversion logic for more reliable row and field restoration.

* **Refactor**
  * Streamlined internal methods for safer and more maintainable handling of table data and backups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->