### PR TITLE
fix(autocomplete,search,base-select,cascader,date-panel, date-range,date-picker,dropdown,input,select,tree): The component under the shadowRoot node event  is invalid.

### DIFF
--- a/packages/renderless/src/search/index.ts
+++ b/packages/renderless/src/search/index.ts
@@ -76,7 +76,11 @@ export const searchEnterKey =
 export const clickOutside =
   ({ parent, props, state }: Pick<ISearchRenderlessParams, 'parent' | 'props' | 'state'>) =>
   (event: Event) => {
-    if (!parent.$el.contains(event.target)) {
+    // 优先使用 event.composedPath() 来判断事件源是否在组件内部，以兼容 Shadow DOM。
+    // 在 Shadow DOM 中，事件冒泡穿过 Shadow Root 后，event.target 会被重定向为 host 元素，
+    // 导致传统的 contains 判断失效。composedPath 则能提供真实的事件路径。
+    const path = event.composedPath && event.composedPath()
+    if (path ? !path.includes(parent.$el) : !parent.$el.contains(event.target)) {
       state.show = false
       props.mini && !state.currentValue && (state.collapse = true)
     }

--- a/packages/vue-directive/src/clickoutside.ts
+++ b/packages/vue-directive/src/clickoutside.ts
@@ -35,16 +35,18 @@ if (!isServer) {
 
 const createDocumentHandler = (el, binding, vnode) =>
   function (mouseup = {}, mousedown = {}) {
-    let popperElm = vnode.context.popperElm || (vnode.context.state && vnode.context.state.popperElm)
+    const popperElm = vnode.context.popperElm || (vnode.context.state && vnode.context.state.popperElm)
 
-    if (
-      !mouseup?.target ||
-      !mousedown?.target ||
-      el.contains(mouseup.target) ||
-      el.contains(mousedown.target) ||
-      el === mouseup.target ||
-      (popperElm && (popperElm.contains(mouseup.target) || popperElm.contains(mousedown.target)))
-    ) {
+    // 使用 event.composedPath() 来处理 Shadow DOM 场景。
+    // composedPath() 会返回事件的完整路径，即使事件穿过了 Shadow DOM 的边界。
+    // 这确保了即使 popperElm 在 Shadow DOM 外部（或组件本身在 Shadow DOM 内部），
+    // 我们也能准确判断点击是否发生在组件或其 popper 内部。
+    const mousedownPath = (mousedown?.composedPath && mousedown.composedPath()) || [mousedown?.target]
+    const mouseupPath = (mouseup?.composedPath && mouseup.composedPath()) || [mouseup.target]
+    const isClickInEl = mousedownPath.includes(el) || mouseupPath.includes(el)
+    const isClickInPopper = popperElm && (mousedownPath.includes(popperElm) || mouseupPath.includes(popperElm))
+
+    if (!mousedown.target || !mouseup.target || isClickInEl || isClickInPopper) {
       return
     }
 
@@ -56,10 +58,6 @@ const createDocumentHandler = (el, binding, vnode) =>
   }
 
 /**
- * v-clickoutside
- * @desc 点击元素外面才会触发的事件
- * @example
- * 两个修饰符，mousedown、mouseup
  * 当没有修饰符时，需要同时满足在目标元素外同步按下和释放鼠标才会触发回调。
  * ```html
  * <div v-clickoutside="handleClose"> // 在元素外部点击时触发
@@ -110,7 +108,6 @@ export default {
     if (nodeList.length === 0 && startClick) {
       startClick = null
     }
-
     delete el[nameSpace]
   }
 }


### PR DESCRIPTION
# PR
fix：shadow-root节点下组件点击事件失效以及search面板闪动问题

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the click outside directive to correctly detect clicks inside Shadow DOM elements, ensuring more reliable behavior when using web components or elements with shadow roots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->