### PR TITLE
fix(examples/sites/demos/apis): 修复 issue #3030 中提到的图表配置项拼写错误

### DIFF
--- a/examples/sites/demos/apis/chart-demo.js
+++ b/examples/sites/demos/apis/chart-demo.js
@@ -53,7 +53,7 @@ export default {
         {
           name: 'extend',
           typeAnchorName: 'chart#IChartProps',
-          type: 'objcet',
+          type: 'object',
           defaultValue: '',
           desc: {
             'zh-CN': 'echarts 的配置项',

--- a/examples/sites/demos/apis/chart-docs.js
+++ b/examples/sites/demos/apis/chart-docs.js
@@ -53,7 +53,7 @@ export default {
         {
           name: 'extend',
           typeAnchorName: 'chart#IChartProps',
-          type: 'objcet',
+          type: 'object',
           defaultValue: '',
           desc: {
             'zh-CN': 'echarts 的配置项',

--- a/examples/sites/demos/apis/chart-events.js
+++ b/examples/sites/demos/apis/chart-events.js
@@ -53,7 +53,7 @@ export default {
         {
           name: 'extend',
           typeAnchorName: 'chart#IChartProps',
-          type: 'objcet',
+          type: 'object',
           defaultValue: '',
           desc: {
             'zh-CN': 'echarts 的配置项',

--- a/examples/sites/demos/apis/chart-question.js
+++ b/examples/sites/demos/apis/chart-question.js
@@ -53,7 +53,7 @@ export default {
         {
           name: 'extend',
           typeAnchorName: 'chart#IChartProps',
-          type: 'objcet',
+          type: 'object',
           defaultValue: '',
           desc: {
             'zh-CN': 'echarts 的配置项',

--- a/examples/sites/demos/apis/chart.js
+++ b/examples/sites/demos/apis/chart.js
@@ -53,7 +53,7 @@ export default {
         {
           name: 'extend',
           typeAnchorName: 'chart#IChartProps',
-          type: 'objcet',
+          type: 'object',
           defaultValue: '',
           desc: {
             'zh-CN': 'echarts 的配置项',


### PR DESCRIPTION
## 问题描述  
修复 issue #3030 中报告的图表配置项拼写错误，具体问题为：  
- **错误拼写**：`objcet`（chart 配置项）  
- **正确拼写**：`object`  

## 修改内容  
1. **文件路径**：  
examples\sites\demos\apis\chart.js
examples\sites\demos\apis\chart-demo.js
examples\sites\demos\apis\chart-docs.js
examples\sites\demos\apis\chart-events.js
examples\sites\demos\apis\chart-question.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typographical error in the type annotation for the 'extend' property in chart component API documentation and demos, changing "objcet" to "object". No functional changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->