### PR TITLE
fix(grid): fix popper edit element blur when set edit-config blurOutside

### DIFF
--- a/packages/vue/src/grid/src/table/src/methods.ts
+++ b/packages/vue/src/grid/src/table/src/methods.ts
@@ -1130,6 +1130,11 @@ const Methods = {
       isScrollY = containerScrollHeight + scrollbarSize > containerHeight
     }
 
+    // 虚拟滚动如果没有height的话，表格滚动到底部表头会发生偏移，将height设置为max-height可避免
+    if (!this.height) {
+      this.bodyWrapperHeight = containerScrollHeight > this.bodyWrapperMaxHeight ? this.bodyWrapperMaxHeight : null
+    }
+
     Object.assign(this, {
       overflowX: isScrollX,
       overflowY: isScrollY,
@@ -1179,6 +1184,18 @@ const Methods = {
       }
 
       if (typeof editConfig.blurOutside === 'function') {
+        const bodyEl = document.body
+        if (
+          getEventTargetNode(event, bodyEl, 'tiny-autocomplete-suggestion').flag ||
+          getEventTargetNode(event, bodyEl, 'tiny-select-dropdown').flag ||
+          getEventTargetNode(event, bodyEl, 'tiny-cascader__dropdown').flag ||
+          getEventTargetNode(event, bodyEl, 'tiny-cascader-menus').flag ||
+          getEventTargetNode(event, bodyEl, 'tiny-picker-panel').flag ||
+          getEventTargetNode(event, bodyEl, 'tiny-popper').flag ||
+          getEventTargetNode(event, bodyEl, 'tiny-dialog-box').flag
+        ) {
+          return true
+        }
         return Boolean(editConfig.blurOutside({ cell: args.cell, event, $table: this }))
       }
 

--- a/packages/vue/src/grid/src/table/src/utils/updateStyle.ts
+++ b/packages/vue/src/grid/src/table/src/utils/updateStyle.ts
@@ -67,10 +67,6 @@ export function handleLayout(_vm) {
     _vm.bodyWrapperMinHeight = minHeight
   }
 
-  if (scrollYLoad && !_vm.bodyWrapperHeight) {
-    _vm.bodyWrapperHeight = maxHeight
-  }
-
   _vm.bodyTableWidth = scrollXLoad
     ? tableColumn.reduce((previous, column) => previous + column.renderWidth, 0)
     : totalWidth


### PR DESCRIPTION
# PR
修复配置了editConfig的blurOutside后，弹出类编辑会使表格失焦
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual scrolling to prevent header misalignment when the table height is not set.
  * Enhanced blur detection to avoid unintended loss of focus when interacting with dropdowns and popups.

* **Refactor**
  * Updated internal scroll height handling logic for more consistent behavior in virtual scrolling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->