### PR TITLE
fix(modal\notify): modifying the Color of the Information Icon in the SaaS File

### DIFF
--- a/packages/theme-saas/src/grid/modal.less
+++ b/packages/theme-saas/src/grid/modal.less
@@ -225,7 +225,7 @@
 
     &.status__info {
       .@{grid-modal-prefix-cls}__status-wrapper {
-        @apply fill-color-info-secondary;
+        @apply fill-color-info-primary;
       }
     }
 

--- a/packages/theme-saas/src/modal/index.less
+++ b/packages/theme-saas/src/modal/index.less
@@ -237,7 +237,7 @@
 
     &.status__info {
       .@{modal-prefix-cls}__status-wrapper {
-        @apply fill-color-info-secondary;
+        @apply fill-color-info-primary;
       }
     }
 

--- a/packages/theme-saas/src/notify/index.less
+++ b/packages/theme-saas/src/notify/index.less
@@ -93,7 +93,7 @@
   }
 
   &--info &__icon-zone {
-    @apply fill-color-info-secondary;
+    @apply fill-color-info-primary;
   }
 
   &--warning &__icon-zone {

--- a/packages/vue/src/modal/src/mobile-first.vue
+++ b/packages/vue/src/modal/src/mobile-first.vue
@@ -351,7 +351,7 @@ export default defineComponent({
                                     'hidden sm:inline-block mr-2 fill-current',
                                     type === 'message' ? 'h-4.5 w-4.5 self-start shrink-0 mt-0.5' : 'h-6 w-auto',
                                     { 'text-color-success': status === 'success' },
-                                    { 'text-color-info-secondary': ['info', 'question'].includes(status) },
+                                    { 'text-color-info-primary': ['info', 'question'].includes(status) },
                                     { 'text-color-warning': status === 'warning' },
                                     { 'text-color-error': status === 'error' }
                                   )
@@ -364,7 +364,7 @@ export default defineComponent({
                                     'h-4 w-4 inline-block sm:hidden mr-1.5 fill-current',
                                     type === 'message' ? 'w-5 h-5 self-center shrink-0' : 'h-6 w-auto',
                                     { 'text-color-success': status === 'success' },
-                                    { 'text-color-info-secondary': ['info', 'question'].includes(status) },
+                                    { 'text-color-info-primary': ['info', 'question'].includes(status) },
                                     { 'text-color-warning': status === 'warning' },
                                     { 'text-color-error': status === 'error' }
                                   ]


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:
修改saas文件下信息图标颜色填充
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the fill and text color for "info" status icons in grid modal, modal, and notification components to use a primary color instead of a secondary color. This change affects both desktop and mobile views for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->