### PR TITLE
fix(vue-common): [icon]resolves the loading icon after multiple calls to render function nesting levels

### DIFF
--- a/packages/vue-common/src/index.ts
+++ b/packages/vue-common/src/index.ts
@@ -360,11 +360,14 @@ export function svg({ name = 'Icon', component }) {
 
           // 解决多个相同的渐变图标svg中有相同id时，在display：none，情况下导致的样式异常问题
           if (GRADIENT_ICONS_LIST.includes(name)) {
-            const render = component.render
+            if (!component.__raw_render) {
+              component.__raw_render = component.render
+            }
+
             component.render = function (...args) {
               // 指向正确的this对象，保证vue2运行正常
-              const newRender = render.bind(this)
-              const vnode = newRender(args)
+              const newRender = component.__raw_render.bind(this) // 每次使用原始render, 以避免递归render函数。
+              const vnode = newRender(...args)
               generateIcon(vnode)
               return vnode
             }


### PR DESCRIPTION
修复loading图标在多次调用后，render函数嵌套层数增长的问题

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of certain icons to prevent potential rendering issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->