### PR TITLE
fix(grid): fix dirty flag not clear after refreshData

### DIFF
--- a/packages/vue-directive/src/clickoutside.ts
+++ b/packages/vue-directive/src/clickoutside.ts
@@ -41,12 +41,12 @@ const createDocumentHandler = (el, binding, vnode) =>
     // composedPath() 会返回事件的完整路径，即使事件穿过了 Shadow DOM 的边界。
     // 这确保了即使 popperElm 在 Shadow DOM 外部（或组件本身在 Shadow DOM 内部），
     // 我们也能准确判断点击是否发生在组件或其 popper 内部。
-    const mousedownPath = (mousedown?.composedPath && mousedown.composedPath()) || [mousedown?.target]
-    const mouseupPath = (mouseup?.composedPath && mouseup.composedPath()) || [mouseup.target]
+    const mousedownPath = mousedown?.composedPath?.() || [mousedown?.target]
+    const mouseupPath = mouseup?.composedPath?.() || [mouseup?.target]
     const isClickInEl = mousedownPath.includes(el) || mouseupPath.includes(el)
     const isClickInPopper = popperElm && (mousedownPath.includes(popperElm) || mouseupPath.includes(popperElm))
 
-    if (!mousedown.target || !mouseup.target || isClickInEl || isClickInPopper) {
+    if (!mousedown?.target || !mouseup?.target || isClickInEl || isClickInPopper) {
       return
     }
 

--- a/packages/vue/src/grid/src/table/src/methods.ts
+++ b/packages/vue/src/grid/src/table/src/methods.ts
@@ -230,6 +230,7 @@ const Methods = {
   refreshData(data) {
     const next = () => {
       this.tableData = []
+      this.cellStatus.clear()
       return this.loadTableData(data || this.tableFullData)
     }
     return this.$nextTick().then(next)


### PR DESCRIPTION
# PR
修复表格脏数据角标不消失问题，修复clickoutside指定带修饰符情况报错问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event handling to prevent potential runtime errors when processing click events outside elements.
  * Ensured that cell status is properly reset whenever table data is refreshed, leading to more consistent table behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->