### PR TITLE
fix(tree-menu): adjusting the input box of the tree menu component can clear the symbol position

### DIFF
--- a/packages/theme/src/tree-menu/index.less
+++ b/packages/theme/src/tree-menu/index.less
@@ -157,6 +157,9 @@
       border-top: 1px solid var(--tv-TreeMenu-border-top-color);
       margin-right: var(--tv-TreeMenu-input-before-margin-right);
     }
+    .@{input-prefix-cls}__suffix {
+      right: var(--tv-TreeMenu-input-suffix-right);
+    }
   }
 
   .@{tree-prefix-cls} {

--- a/packages/theme/src/tree-menu/vars.less
+++ b/packages/theme/src/tree-menu/vars.less
@@ -41,8 +41,10 @@
   --tv-TreeMenu-collapse-icon-margin-right: 20px;
   // 输入框下面的线
   --tv-TreeMenu-border-top-color: var(--tv-color-border-divider, #f0f0f0);
-  //输入框距离由边的距离
+  //输入框距离右边的距离
   --tv-TreeMenu-input-padding-right: var(--tv-space-xxxl, 32px);
+  //输入框X号距离右边的距离
+  --tv-TreeMenu-input-suffix-right: calc(var(--tv-space-base, 4px) * 11);
   //选中后左边宽度
   --tv-TreeMenu-node-content-height: var(--tv-space-xxxl, 32px);
   //输入框底下的线的定位top


### PR DESCRIPTION
…n clear the symbol position

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the positioning of the input suffix within the tree menu component for better visual alignment.

* **Documentation**
  * Clarified comments for input box padding variables to enhance understanding.

* **New Features**
  * Introduced a new CSS variable to control the distance between the input suffix and the right edge in the tree menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->