### PR TITLE
fix(grid):  clear input value after click custom extend item

### DIFF
--- a/packages/vue/src/grid/src/filter/src/panel.tsx
+++ b/packages/vue/src/grid/src/filter/src/panel.tsx
@@ -678,6 +678,8 @@ export default defineComponent({
       this.confirmFilter('empty')
     },
     filterExtends(item) {
+      this.condition.input = ''
+      this.condition.empty = null
       this.condition.value = item.value || item.label
       this.condition.method = item.method
       this.confirmFilter('extend')


### PR DESCRIPTION
# PR
修复点击自定义筛选后，输入框值未清空问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter behavior to ensure previous input and empty states are cleared when applying an extended filter condition, resulting in more accurate and predictable filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->