### PR TITLE
fix(pager): fix init pager-size error when not match page-sizes

### DIFF
--- a/packages/renderless/src/pager/vue.ts
+++ b/packages/renderless/src/pager/vue.ts
@@ -91,6 +91,7 @@ export const renderless = (
     showPager: computed(() => api.computedShowPager()),
     internalLayout: computed(() => api.computedInternalLayout()),
     totalText: computed(() => api.computedTotalText()),
+    internalPageSizes: computed(() => props.pageSizes || [10, 20, 30, 40, 50, 100]),
     internalPageCount: computed(() => api.computedInternalPageCount()),
     showJumperSuffix: designConfig?.state?.showJumperSuffix ?? true,
     align: computed(() => props.align || designConfig?.state?.align || 'right'),

--- a/packages/vue/src/pager/src/index.ts
+++ b/packages/vue/src/pager/src/index.ts
@@ -34,8 +34,7 @@ export const pagerProps = {
     type: String
   },
   pageSizes: {
-    type: Array as PropType<number[]>,
-    default: () => [10, 20, 30, 40, 50, 100]
+    type: Array as PropType<number[]>
   },
   pagerCount: {
     type: Number,

--- a/packages/vue/src/pager/src/pc.vue
+++ b/packages/vue/src/pager/src/pc.vue
@@ -123,7 +123,7 @@
           <div class="tiny-pager__selector-body">
             <ul class="tiny-pager__selector-poplist">
               <li
-                v-for="(sizeItem, sizeIndex) in pageSizes"
+                v-for="(sizeItem, sizeIndex) in state.internalPageSizes"
                 :key="sizeIndex"
                 :class="['list-item', sizeItem === state.internalPageSize ? 'is-selected select-pre' : '']"
                 :title="String(sizeItem)"


### PR DESCRIPTION
# PR
修复分页组件page-size初始化赋值被page-sizes默认值影响问题。
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The pager component now uses an internal default set of page sizes when no custom values are provided.

* **Refactor**
  * The page size selector now references an internal state property for its options instead of directly using the prop.

* **Chores**
  * The default value for page sizes has been removed from the component’s props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->