### PR TITLE
fix(milestone):fix the milestone color matching logic is in saas mode.

### DIFF
--- a/packages/design/saas/src/milestone/index.ts
+++ b/packages/design/saas/src/milestone/index.ts
@@ -2,16 +2,16 @@ export default {
   renderless: (props, hooks, { constants }, api) => {
     return {
       getMileIcon: (node) => {
-        const status = node[props.statusField]
-        const statusColor = props.milestonesStatus[status]
-        const isCompleted = status === constants.STATUS_COMPLETED
+        const status = props.milestonesStatus[node[props.statusField]] || constants.DEFAULT_COLOR
 
-        if (statusColor) {
-          return {
-            background: props.solid ? statusColor : '',
-            color: props.solid && !isCompleted ? '#ffffff' : statusColor,
-            'border-color': statusColor
-          }
+        const isCompleted = node[props.statusField] === props.completedField
+        const switchColor = isCompleted && !props.solid
+        const { r, g, b } = api.hexToRgb(status)
+
+        return {
+          background: (switchColor ? constants.DEFAULT_BACK_COLOR : status) + '!important',
+          color: (switchColor ? status : constants.DEFAULT_BACK_COLOR) + '!important',
+          boxShadow: `rgba(${r},${g},${b},.4) ${constants.BOX_SHADOW_PX}`
         }
       },
       getFlagStyle: ({ index, idx }) => {

--- a/packages/renderless/src/search/index.ts
+++ b/packages/renderless/src/search/index.ts
@@ -79,7 +79,7 @@ export const clickOutside =
     // 优先使用 event.composedPath() 来判断事件源是否在组件内部，以兼容 Shadow DOM。
     // 在 Shadow DOM 中，事件冒泡穿过 Shadow Root 后，event.target 会被重定向为 host 元素，
     // 导致传统的 contains 判断失效。composedPath 则能提供真实的事件路径。
-    const path = event.composedPath && event.composedPath()
+    const path = event?.composedPath && event.composedPath()
     if (path ? !path.includes(parent.$el) : !parent.$el.contains(event.target)) {
       state.show = false
       props.mini && !state.currentValue && (state.collapse = true)


### PR DESCRIPTION
# PR
fix:saas模式下，里程碑颜色匹配逻辑

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the appearance of milestone icons with enhanced color handling and consistent styling, including new shadow effects and better fallback colors.

* **Bug Fixes**
  * Resolved a potential error when detecting clicks outside a component, ensuring more robust event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->