### PR TITLE
fix(grid): fix right position error when resize multi header grid

### DIFF
--- a/packages/vue/src/grid/src/body/src/body.tsx
+++ b/packages/vue/src/grid/src/body/src/body.tsx
@@ -719,6 +719,13 @@ export default defineComponent({
       hooks.nextTick(() => (el.scrollTop = calcScrollTop($table, wrapperScrollTop)))
     })
 
+    const resetStickyWrapperScrollPos = () => {
+      const el = stickyWrapper.value
+      if (!el) return
+      el.scrollLeft = calcScrollLeft($table, wrapperScrollLeft.value)
+      el.scrollTop = calcScrollTop($table, wrapperScrollTop.value)
+    }
+
     useCellEvent({ table, $table })
     const { normalRows, footerRows } = useCellSpan(vm, props)
 
@@ -812,7 +819,8 @@ export default defineComponent({
       tbody,
       ySpace,
       normalRows,
-      footerRows
+      footerRows,
+      resetStickyWrapperScrollPos
     }
   },
   render() {

--- a/packages/vue/src/grid/src/composable/useCellSpan.ts
+++ b/packages/vue/src/grid/src/composable/useCellSpan.ts
@@ -8,7 +8,12 @@ export const useCellSpan = (bodyVm, bodyProps) => {
   const footerRows = hooks.shallowRef({})
 
   hooks.watch(
-    [() => $table.visibleColumn, () => bodyProps.tableData, () => $table.isColumnWidthAssigned],
+    [
+      () => $table.visibleColumn,
+      () => bodyProps.tableData,
+      () => $table.isColumnWidthAssigned,
+      () => $table.columnStore.resizeList
+    ],
     ([visibleColumn, tableData, isColumnWidthAssigned]) => {
       if (!Array.isArray(tableData) || !isColumnWidthAssigned) {
         return
@@ -74,7 +79,12 @@ export const useCellSpan = (bodyVm, bodyProps) => {
   )
 
   hooks.watch(
-    [() => $table.visibleColumn, () => bodyProps.footerData, () => $table.isColumnWidthAssigned],
+    [
+      () => $table.visibleColumn,
+      () => bodyProps.footerData,
+      () => $table.isColumnWidthAssigned,
+      () => $table.columnStore.resizeList
+    ],
     ([visibleColumn, footerData, isColumnWidthAssigned]) => {
       if (!Array.isArray(footerData) || !isColumnWidthAssigned) {
         return
@@ -209,14 +219,15 @@ const adjustColspan = (table, pos, isLeft) => {
       const oldColspan = attrs.colspan
       let k, posCol
 
-      if (oldColspan > 1 && (k = j + oldColspan - 1) > pos) {
+      const shouldAdjustColspan = oldColspan > 1 && (k = j + oldColspan - 1) > pos
+      if (shouldAdjustColspan) {
         attrs.colspan = pos - j + 1
 
         if (isLeft) {
           attrs._stickyClass = 'fixed-left-last__column'
         }
-
-        if ((posCol = row[pos + 1])) {
+        posCol = row[pos + 1]
+        if (posCol) {
           posCol.attrs.colspan = k - pos
 
           if (posCol.attrs.rowspan < 1) {

--- a/packages/vue/src/grid/src/table/src/methods.ts
+++ b/packages/vue/src/grid/src/table/src/methods.ts
@@ -2097,7 +2097,7 @@ const Methods = {
         fastdom.mutate(() => {
           this.restoreScollFlag = true
           this.scrollTo(lastScrollLeft, lastScrollTop)
-
+          requestAnimationFrame(() => this.$refs.tableBody?.resetStickyWrapperScrollPos())
           scrollXLoad && this.triggerScrollXEvent()
           scrollYLoad && this.triggerScrollYEvent({ target: { scrollTop: lastScrollTop } })
         })


### PR DESCRIPTION
# PR
fix: 修复多级表头列拖拽场景stickyWrapper滚动位置异常刷新问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a method to reset the scroll position of sticky table wrappers, improving scroll synchronization in grid components.

* **Refactor**
  * Enhanced internal logic for adjusting cell colspan and improved code clarity in column span handling.

* **Bug Fixes**
  * Improved responsiveness of column resizing and scroll restoration, ensuring smoother updates when columns are resized or scroll positions are restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->