### PR TITLE
fix(auto-tip): fixed the bug that a message is displayed on the page when the element displayed in the tooltip needs to be removed and uninstalled.

### DIFF
--- a/packages/vue-directive/src/auto-tip.ts
+++ b/packages/vue-directive/src/auto-tip.ts
@@ -111,6 +111,10 @@ const bind = (el, { value }: { value: BoundingValueType }) => {
 
 const unbind = (el) => {
   if (el.boundingValue?.listened) {
+    const tooltip = globalTooltip.value
+    if (tooltip && el === tooltip.state.referenceElm && tooltip.state.showPopper) {
+      tooltip.hide()
+    }
     el.removeEventListener('mouseenter', mouseenterHandler)
     el.removeEventListener('mouseleave', mouseleaveHandler)
   }


### PR DESCRIPTION
# PR
v-auto-tip:  修复 tooltip 显示的元素，需要消失卸载时， 提示会留在页面的bug
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that tooltips are properly hidden when elements are unbound, preventing visible tooltips from lingering after elements are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->