### PR TITLE
fix(color-select-panel): 颜色类型选择下拉框样式异常

### DIFF
--- a/packages/theme/src/color-select-panel/index.less
+++ b/packages/theme/src/color-select-panel/index.less
@@ -18,7 +18,7 @@
 
   &__tools {
     display: flex;
-    line-height: var(--tv-ColorSelectPanel-tools-line-height);
+    margin: 6px 0;
 
     .tiny-input {
       flex: 1 0 0;

--- a/packages/vue/src/color-select-panel/src/pc.vue
+++ b/packages/vue/src/color-select-panel/src/pc.vue
@@ -4,7 +4,7 @@
     <alpha-select v-if="alpha" :color="state.color" @ready="onAlphaReady" />
     <div class="tiny-color-select-panel__tools">
       <div class="tiny-color-select-panel__tools__format-select" v-if="state.formats.length">
-        <tiny-select v-model="state.currentFormat">
+        <tiny-select v-model="state.currentFormat" size="small">
           <tiny-option
             v-for="formatValue in state.formats"
             :key="formatValue"


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

<img width="863" height="379" alt="image" src="https://github.com/user-attachments/assets/5b546dca-31fc-4cbc-b37c-46ddc52b0362" />

颜色类型组件的大小不正确，样式有点奇怪排查后发现是使用了  line-height 导致了，现在使用 `margin: 6px 0;` 来实现上下边距

Issue Number: N/A

## What is the new behavior?

<img width="831" height="392" alt="image" src="https://github.com/user-attachments/assets/d8999cce-648a-49d4-9f8d-8cb1eeaab886" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing in the color select panel for a cleaner appearance.
  * Adjusted the select dropdown to a smaller size for a more compact interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->