### PR TITLE
fix(date-picker):date-range should return an empty array when click clear button

### DIFF
--- a/examples/sites/demos/pc/app/date-panel/custom-week.spec.ts
+++ b/examples/sites/demos/pc/app/date-panel/custom-week.spec.ts
@@ -24,7 +24,7 @@ test('[DatePanel] 测试周次序号', async ({ page }) => {
   await page.locator('div:nth-child(2) > .tiny-date-range-picker__header > button:nth-child(2)').click()
   await expect(page.getByText('12w')).toBeVisible()
 
-  await page.getByText('13').nth(1).click()
-  await page.getByText('17').nth(2).click()
+  await page.locator('#custom-weeks').getByText('13').nth(1).click()
+  await page.locator('#custom-weeks').getByText('17').nth(2).click()
   await expect(page.locator('.value1')).toHaveText('[ "2025-02-13", "2025-02-17" ]')
 })

--- a/packages/renderless/src/date-range/index.ts
+++ b/packages/renderless/src/date-range/index.ts
@@ -211,7 +211,7 @@ export const handleClear =
     // tiny 新增下面行
     state.rangeState.endDate = null
 
-    emit('pick', null)
+    emit('pick', [])
   }
 
 export const handleChangeRange = (state, props) => (val) => {


### PR DESCRIPTION
# PR
fix:时间区间清空应返回空数组

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision when selecting week numbers in the date panel, ensuring interactions only occur within the correct container.
  * Clearing a date range selection now emits an empty array instead of null, providing clearer feedback when the selection is reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->