### PR TITLE
fix(select):Fix default multi-select tags color

### DIFF
--- a/packages/theme-saas/src/tag/index.less
+++ b/packages/theme-saas/src/tag/index.less
@@ -51,12 +51,12 @@
 
   &&--default {
     .tag-variant(
-      theme('colors.color.info.primary.DEFAULT'),
+      theme('colors.color.text.primary'),
       theme('colors.transparent'),
-      theme('colors.color.info.primary.subtler'),
-      theme('colors.color.info.primary.DEFAULT'),
-      theme('colors.color.info.primary.DEFAULT'),
-      theme('colors.color.info.primary.subtle')
+      theme('colors.color.bg.3'),
+      theme('colors.color.icon.primary'),
+      theme('colors.color.icon.primary'),
+      theme('colors.color.none.DEFAULT')
     );
   }
 


### PR DESCRIPTION
# PR
fix:修复select默认尺寸多选tag颜色

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the color scheme of the default tag variant to align with the info tag variant for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->