### PR TITLE
fix(calendar-view):fix calendar view height setting does not take effect

### DIFF
--- a/packages/theme-saas/src/calendar-view/index.less
+++ b/packages/theme-saas/src/calendar-view/index.less
@@ -5,6 +5,7 @@
 .@{calendar-view-prefix-cls} {
   @apply w-full;
   @apply h-auto;
+  @apply overflow-auto;
 
   &__header {
     @apply flex;

--- a/packages/vue/src/calendar-view/src/mobile-first.vue
+++ b/packages/vue/src/calendar-view/src/mobile-first.vue
@@ -1,5 +1,9 @@
 <template>
-  <div data-tag="tiny-calendar-view" class="w-full h-auto">
+  <div
+    data-tag="tiny-calendar-view"
+    class="w-full h-auto overflow-auto"
+    :style="{ 'height': height ? `${parseInt(height)}px` : 'auto' }"
+  >
     <tiny-tooltip ref="tooltip" popper-class="absolute max-w-[theme(spacing.80)]" effect="light" placement="right">
       <template #content>
         <div class="p-2 max-h-[80vh] overflow-auto">
@@ -171,7 +175,9 @@
             >
               <span
                 class="relative mr-2.5 text-base"
-                :class="[dateIsToday(date.value) || computedSelectDay(date)  ? 'text-color-brand' : 'text-color-text-primary']"
+                :class="[
+                  dateIsToday(date.value) || computedSelectDay(date) ? 'text-color-brand' : 'text-color-text-primary'
+                ]"
               >
                 <span>{{ date.value.split('-')[2] }}</span>
                 <span
@@ -182,7 +188,11 @@
               </span>
               <span
                 class="text-sm"
-                :class="[dateIsToday(date.value) || computedSelectDay(date) ? 'text-color-brand' : 'text-color-text-placeholder']"
+                :class="[
+                  dateIsToday(date.value) || computedSelectDay(date)
+                    ? 'text-color-brand'
+                    : 'text-color-text-placeholder'
+                ]"
                 >{{ dateIsToday(date.value) ? t('ui.datepicker.today') : t(`ui.calendarView.weekDays.${index}`) }}</span
               >
             </slot>

--- a/packages/vue/src/calendar-view/src/pc.vue
+++ b/packages/vue/src/calendar-view/src/pc.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tiny-calendar-view" :style="{ 'height': typeof height === 'number' ? height + 'px' : height }">
+  <div class="tiny-calendar-view" :style="{ 'height': height ? `${parseInt(height)}px` : 'auto'}">
     <div class="tiny-calendar-view__header">
       <div>
         <tiny-button v-if="showBackToday" @click="toToday">{{ t('ui.calendarView.backToday') }}</tiny-button>


### PR DESCRIPTION
# PR
fix:修复日历视图设置高度不生效

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar view containers now support automatic scrolling when content exceeds the visible area.
  * The height of the calendar view is now consistently set based on the provided height value, ensuring a fixed pixel height.

* **Style**
  * Updated styles to enable overflow auto behavior for improved usability in the calendar view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->