### PR TITLE
fix(modal): [modal] modify the messageClosable in Vue2 version to not display the close button

### DIFF
--- a/examples/sites/demos/apis/modal.js
+++ b/examples/sites/demos/apis/modal.js
@@ -241,7 +241,7 @@ export default {
             'en-US': "Whether the 'message' type pop-up window displays a close button"
           },
           mode: ['pc'],
-          pcDemo: 'message-closable'
+          pcDemo: 'message-close'
         },
         {
           name: 'min-height',

--- a/packages/vue/src/modal/src/pc.vue
+++ b/packages/vue/src/modal/src/pc.vue
@@ -267,12 +267,14 @@ export default defineComponent({
                       {
                         class: 'tiny-modal__close-wrapper'
                       },
-                      h(iconClose(), {
-                        class: ['tiny-modal__close-btn'],
-                        on: {
-                          click: this.closeEvent
-                        }
-                      })
+                      [
+                        h(iconClose(), {
+                          class: ['tiny-modal__close-btn'],
+                          on: {
+                            click: this.closeEvent
+                          }
+                        })
+                      ]
                     )
                   : null
               ]


### PR DESCRIPTION
… display the close button

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the rendering structure of the close button in the message modal to enhance consistency.
  * Updated the demo reference for the modal's closable message example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->