### PR TITLE
docs(float-settings): Change the triggering mode of the floating settings component to click

### DIFF
--- a/examples/sites/src/components/float-settings.vue
+++ b/examples/sites/src/components/float-settings.vue
@@ -43,9 +43,8 @@
     <tiny-popover
       width="180"
       placement="left-end"
-      trigger="manual"
+      trigger="click"
       :visible-arrow="false"
-      v-model="demoStyleVisible"
       popper-class="opt-menu style-settings-menu theme-settings-popover"
     >
       <div v-for="(item, index) in styleSettings" :key="index" class="style-settings-item">
@@ -60,11 +59,7 @@
       </div>
       <template #reference>
         <div>
-          <div
-            class="settings-btn style-settings-btn"
-            @click="demoStyleVisible = !demoStyleVisible"
-            @blur="demoStyleVisible = false"
-          >
+          <div class="settings-btn style-settings-btn">
             <style-settings-icon class="settings-icon style-settings-icon"></style-settings-icon>
           </div>
         </div>
@@ -121,7 +116,6 @@ export default defineComponent({
     const floatSettings = ref(null)
 
     const state = reactive({
-      demoStyleVisible: false,
       themeData: [],
       styleSettings: getStyleSettings(i18nByKey),
       settingsStyle: {


### PR DESCRIPTION
docs(float-settings): 修改浮动设置组件的触发方式为点击，并移除不必要的状态管理
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the "demo style" popover to open and close automatically on click, simplifying its behavior and removing manual visibility controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->