### PR TITLE
Revert "fix(tabs): Optimize multi terminal caching logic, add add add delete operations to trigger sub component destruction and reconstruction logic"

### DIFF
--- a/packages/renderless/src/tabs-mf/vue.ts
+++ b/packages/renderless/src/tabs-mf/vue.ts
@@ -45,9 +45,7 @@ export const renderless = (props, hooks, { vm, emit, nextTick }) => {
     swipeable: computed(() => api.computedSwipeable()),
     maxTabSwipeHeight: 0,
     itemOrderKey: '',
-    tabsId: ++uniqueId,
-    tabPanelCache: {},
-    includeNames: computed(() => state.items.map((item) => item.name))
+    tabsId: ++uniqueId
   })
 
   const api = {}

--- a/packages/vue/src/tabs/src/mobile-first.vue
+++ b/packages/vue/src/tabs/src/mobile-first.vue
@@ -1,6 +1,6 @@
 <script lang="tsx">
 import { renderless, api } from '@opentiny/vue-renderless/tabs-mf/vue'
-import { props, setup, defineComponent, h, isVue2 } from '@opentiny/vue-common'
+import { props, setup, defineComponent, h, isVue2, KeepAlive } from '@opentiny/vue-common'
 import Carousel from '@opentiny/vue-carousel'
 import TabBar from './mobile-first/tab-bar.vue'
 import TabPanel from './mobile-first/tab-panel.vue'
@@ -40,41 +40,31 @@ export default defineComponent({
     let tabWrapper
 
     if (optimized) {
-      if (!state.tabPanelCache) {
-        state.tabPanelCache = {}
-      }
-      const panelCache = state.tabPanelCache
-      const currentName = state.currentItem?.name
+      let defaultSlot, vnodes
 
-      const includeNames = state.includeNames
-      Object.keys(panelCache).forEach((name) => {
-        if (!includeNames.includes(name)) {
-          delete panelCache[name]
-        }
-      })
+      if (state.currentItem) {
+        defaultSlot = isVue2 ? state.currentItem.vm.$scopedSlots.default : state.currentItem.slotDefault
+      }
+
+      vnodes = []
 
       state.items.forEach((item) => {
-        const cacheKey = item.name
-        const itemDefSlot = isVue2 ? item.vm.$scopedSlots.default : item.slotDefault
-        const props = {
-          attrs: { 'data-tag': 'tiny-tab-panel' },
-          class: 'w-full',
-          props: { item },
-          key: item.name
+        if (item !== state.currentItem) {
+          return
         }
 
-        if (!panelCache[cacheKey] && item === state.currentItem) {
-          panelCache[cacheKey] = isVue2
-            ? h(TabPanel, { scopedSlots: { default: () => runFnuc(itemDefSlot) }, ...props })
-            : h(TabPanel, props, () => runFnuc(itemDefSlot))
-        } else if (panelCache[cacheKey]) {
-          if (panelCache[cacheKey].elm) {
-            panelCache[cacheKey].elm.style.display = item.name === currentName ? 'block' : 'none'
-          }
-        }
-
-        tabPanel.push(panelCache[cacheKey])
+        vnodes.push(
+          isVue2
+            ? h(TabPanel, {
+                props: { item },
+                key: state.currentItem.name,
+                scopedSlots: { default: () => runFnuc(defaultSlot) }
+              })
+            : h(TabPanel, { props: { item }, key: state.currentItem.name }, () => runFnuc(defaultSlot))
+        )
       })
+
+      tabPanel.push(isVue2 ? <KeepAlive>{vnodes}</KeepAlive> : h(KeepAlive, {}, () => vnodes))
     } else {
       state.items.forEach((item, i) => {
         if (item.lazy && item !== state.currentItem && !item.rendered) {


### PR DESCRIPTION
Reverts opentiny/tiny-vue#3601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the rendering logic for tab panels, removing the use of a cache and optimizing how active tab content is displayed and preserved.
  * Simplified internal state management for tabs.

No changes to public APIs or user-facing controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->