### PR TITLE
fix(grid): fix index not update at drag row

### DIFF
--- a/packages/vue/src/grid/src/dragger/src/rowDrop.ts
+++ b/packages/vue/src/grid/src/dragger/src/rowDrop.ts
@@ -25,7 +25,6 @@
 import { findTree } from '@opentiny/vue-renderless/grid/static/'
 import Modal from '@opentiny/vue-modal'
 import GlobalConfig from '../../config'
-import { isVue2 } from '@opentiny/vue-common'
 
 export const createHandlerOnEnd = ({ _vm, refresh }) => {
   return (event) => {
@@ -79,8 +78,7 @@ export const createHandlerOnEnd = ({ _vm, refresh }) => {
 
     // 如果变动了树层级，需要刷新数据
     _vm.$emit('row-drop-end', event, _vm, _vm.scrollYLoad ? tableTreeData : _vm.tableFullData)
-    // 因为vue2劫持了数组方法，所以在data通过splice改变数组时（数组长度不变）会触发更新，但是vue3是浅层响应，所以需要通过传递数据让表格更新
-    refresh && _vm.data && !isVue2 && _vm.refreshData(_vm.data)
+    refresh && _vm.data && _vm.refreshData(_vm.data)
   }
 }
 


### PR DESCRIPTION
# PR
修复行拖拽场景下，序号列不会发生变化的问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the logic for refreshing table data after a row drag-and-drop operation, ensuring consistent behavior across different Vue versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->