### PR TITLE
fix(input):fix textarea height in Multiple line placeholders

### DIFF
--- a/examples/sites/src/App.vue
+++ b/examples/sites/src/App.vue
@@ -136,11 +136,6 @@ const handleShowTinyRobot = () => {
     padding: 34px 0 0;
   }
 }
-.right-panel {
-  :deep(.tr-container) {
-    z-index: 9999;
-  }
-}
 
 .style-settings-icon {
   position: fixed;

--- a/examples/sites/src/App.vue
+++ b/examples/sites/src/App.vue
@@ -136,6 +136,12 @@ const handleShowTinyRobot = () => {
     padding: 34px 0 0;
   }
 }
+  
+.right-panel:not(.collapsed) {
+  :deep(.tr-container) {
+    z-index: 9999;
+  }
+}
 
 .style-settings-icon {
   position: fixed;

--- a/packages/renderless/src/input/index.ts
+++ b/packages/renderless/src/input/index.ts
@@ -124,7 +124,9 @@ export const calcTextareaHeight =
     const { paddingSize, borderSize, boxSizing, contextStyle } = api.calculateNodeStyling(targetElement)
 
     hiddenTextarea.setAttribute('style', `${contextStyle};${HIDDEN_STYLE}`)
-    hiddenTextarea.value = targetElement.value || targetElement.placeholder || ''
+    // 多行placeholder只计算单行高度防止撑高scrollHeight
+    const safePlaceholder = targetElement.placeholder ? targetElement.placeholder.trim().split('\n')[0] : ''
+    hiddenTextarea.value = targetElement.value || safePlaceholder || ''
 
     let height = hiddenTextarea.scrollHeight
     const textareaStyle: {
@@ -161,11 +163,7 @@ export const calcTextareaHeight =
         minHeight = props.height
       }
       if (!state.isDisplayOnly) {
-        if (props.autosize) {
-          height = Math.max(minHeight, height)
-        } else {
-          height = Math.min(minHeight, height)
-        }
+        height = Math.max(minHeight, height)
         textareaStyle.minHeight = `${Math.floor(minHeight)}px`
       } else {
         textareaStyle.minHeight = `0px`


### PR DESCRIPTION
# PR
fix:多行占位符导致文本域高度计算错误

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multi-line placeholders in input fields to prevent unnecessary increase in textarea height.
  * Simplified height adjustment logic for input fields when autosize is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->