### PR TITLE
fix(input): add pre=true for tiny-tooltip

### DIFF
--- a/packages/vue/src/input/src/mobile-first.vue
+++ b/packages/vue/src/input/src/mobile-first.vue
@@ -48,6 +48,7 @@
           placement="top"
           :popper-class="state.tooltipConfig.popperClass || ''"
           :popper-options="{ bubbling: true }"
+          pre
           @mouseenter.native="handleEnterDisplayOnlyContent"
         >
           <span

--- a/packages/vue/src/input/src/pc.vue
+++ b/packages/vue/src/input/src/pc.vue
@@ -56,6 +56,7 @@
           :content="state.displayOnlyTooltip"
           placement="top"
           :popper-class="state.tooltipConfig.popperClass || ''"
+          pre
           @mouseenter.native="handleEnterDisplayOnlyContent"
         >
           <span class="tiny-input-display-only__content" v-if="type === 'password'">{{ state.hiddenPassword }}</span>


### PR DESCRIPTION
# PR
给input 的只读模式时， tooltip的pre为true
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced tooltip display for input fields by enabling improved formatting in tooltips for non-textarea types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->