### PR TITLE
feat(tabs): add header-only

### DIFF
--- a/examples/sites/demos/apis/tabs.js
+++ b/examples/sites/demos/apis/tabs.js
@@ -294,6 +294,18 @@ export default {
           mode: ['pc', 'mobile-first'],
           pcDemo: 'overflow-title',
           mfDemo: ''
+        },
+        {
+          name: 'header-only',
+          type: 'boolean',
+          defaultValue: 'false',
+          desc: {
+            'zh-CN': '当 header-only 为 true 时，页签内容不再渲染',
+            'en-US': 'When header-only is true, the tab content is no longer rendered'
+          },
+          mode: ['pc'],
+          pcDemo: 'header-only',
+          mfDemo: ''
         }
       ],
       events: [

--- a/examples/sites/demos/apis/tabs.js
+++ b/examples/sites/demos/apis/tabs.js
@@ -300,8 +300,8 @@ export default {
           type: 'boolean',
           defaultValue: 'false',
           desc: {
-            'zh-CN': '当 header-only 为 true 时，页签内容不再渲染',
-            'en-US': 'When header-only is true, the tab content is no longer rendered'
+            'zh-CN': '当 header-only 为 true 时，页签内容不再渲染，并且 position 将被设置为固定值 top',
+            'en-US': 'When header-only is true, the tab content will no longer be rendered, and the position will be set to a fixed value of top'
           },
           mode: ['pc'],
           pcDemo: 'header-only',

--- a/examples/sites/demos/apis/tabs.js
+++ b/examples/sites/demos/apis/tabs.js
@@ -300,8 +300,8 @@ export default {
           type: 'boolean',
           defaultValue: 'false',
           desc: {
-            'zh-CN': '当 header-only 为 true 时，页签内容不再渲染，并且 position 将被设置为固定值 top',
-            'en-US': 'When header-only is true, the tab content will no longer be rendered, and the position will be set to a fixed value of top'
+            'zh-CN': '当 header-only 为 true 时，页签内容不再渲染',
+            'en-US': 'When header-only is true, the tab content is no longer rendered'
           },
           mode: ['pc'],
           pcDemo: 'header-only',

--- a/examples/sites/demos/pc/app/tabs/header-only.vue
+++ b/examples/sites/demos/pc/app/tabs/header-only.vue
@@ -1,0 +1,36 @@
+<template>
+  <tiny-tabs tab-style="card" style="width: 500px" :position="position" header-only>
+    <tiny-tab-item :key="item.name" v-for="item in tabs" :title="item.title" :name="item.name">
+      {{ item.content }}
+    </tiny-tab-item>
+  </tiny-tabs>
+</template>
+
+<script lang="jsx">
+import { TinyTabs, TinyTabItem } from '@opentiny/vue'
+
+export default {
+  components: {
+    TinyTabs,
+    TinyTabItem
+  },
+  data() {
+    return {
+      position: 'left',
+      tabs: [
+        {
+          title: 'Tab 1',
+          name: '1',
+          content: 'Tab 1 content '
+        },
+        {
+          title: 'Tab 2',
+          name: '2',
+          content: 'Tab 2 content'
+        }
+      ],
+      tabIndex: 2
+    }
+  }
+}
+</script>

--- a/examples/sites/demos/pc/app/tabs/header-only.vue
+++ b/examples/sites/demos/pc/app/tabs/header-only.vue
@@ -1,36 +1,56 @@
 <template>
-  <tiny-tabs tab-style="card" style="width: 500px" :position="position" header-only>
-    <tiny-tab-item :key="item.name" v-for="item in tabs" :title="item.title" :name="item.name">
-      {{ item.content }}
-    </tiny-tab-item>
-  </tiny-tabs>
+  <div class="tab-demo-position">
+    <tiny-radio-group v-model="position" class="mb10">
+      <tiny-radio-button label="top">top 显示</tiny-radio-button>
+      <tiny-radio-button label="bottom">bottom 显示</tiny-radio-button>
+      <tiny-radio-button label="left">left 显示</tiny-radio-button>
+      <tiny-radio-button label="right">right 显示</tiny-radio-button>
+    </tiny-radio-group>
+    <tiny-tabs v-model="activeName4" tab-style="card" :position="position" header-only>
+      <tiny-tab-item v-for="item in tabs3" :key="item.name" :title="item.title" :name="item.name">
+        {{ item.content }}
+      </tiny-tab-item>
+    </tiny-tabs>
+  </div>
 </template>
 
-<script lang="jsx">
-import { TinyTabs, TinyTabItem } from '@opentiny/vue'
+<script setup lang="jsx">
+import { ref } from 'vue'
+import { TinyTabs, TinyTabItem, TinyRadioGroup, TinyRadioButton } from '@opentiny/vue'
 
-export default {
-  components: {
-    TinyTabs,
-    TinyTabItem
+const activeName4 = ref('navigation1')
+const position = ref('left')
+const tabs3 = ref([
+  {
+    name: 'navigation1',
+    title: 'Navigation 1',
+    content: 'Navigation 1'
   },
-  data() {
-    return {
-      position: 'left',
-      tabs: [
-        {
-          title: 'Tab 1',
-          name: '1',
-          content: 'Tab 1 content '
-        },
-        {
-          title: 'Tab 2',
-          name: '2',
-          content: 'Tab 2 content'
-        }
-      ],
-      tabIndex: 2
-    }
+  {
+    name: 'navigation2',
+    title: 'Navigation 2',
+    content: 'Navigation 2'
+  },
+  {
+    name: 'navigation3',
+    title: 'Navigation 3',
+    content: 'Navigation 3'
+  },
+  {
+    name: 'navigation4',
+    title: 'Navigation 4',
+    content: 'Navigation 4'
+  },
+  {
+    name: 'navigation5',
+    title: 'Navigation 5',
+    content: 'Navigation 5'
   }
-}
+])
 </script>
+
+<style scoped>
+.tab-demo-position {
+  min-height: 250px;
+}
+</style>

--- a/examples/sites/demos/pc/app/tabs/webdoc/tabs.js
+++ b/examples/sites/demos/pc/app/tabs/webdoc/tabs.js
@@ -270,18 +270,16 @@ export default {
       codeFiles: ['tabs-events-edit.vue']
     },
     {
-      demoId: 'overflow-title',
+      demoId: 'header-only',
       name: {
-        'zh-CN': '超出显示 tooltip',
-        'en-US': 'Out of Display tooltip'
+        'zh-CN': '仅展示头部',
+        'en-US': 'Header only'
       },
       desc: {
-        'zh-CN':
-          '通过 <code>overflow-title</code> 设置标题超出一定长度（默认 256px）时隐藏并显示...，鼠标移到标题上可显示 tooltip，<code>title-width</code>设置标题超出的长度。',
-        'en-US':
-          'Use <code>overflow-title</code> to set the title to hide and show when it exceeds a certain length (default 256px)... , move the cursor to the title to display the tooltip, and set <code>title-width</code> to the excess length of the title.'
+        'zh-CN': '通过 <code>header-only</code> 仅展示头部。',
+        'en-US': 'Use <code>>header-only</code> header only.'
       },
-      codeFiles: ['overflow-title.vue']
+      codeFiles: ['header-only.vue']
     }
   ],
   features: [

--- a/examples/sites/demos/pc/app/tabs/webdoc/tabs.js
+++ b/examples/sites/demos/pc/app/tabs/webdoc/tabs.js
@@ -270,6 +270,20 @@ export default {
       codeFiles: ['tabs-events-edit.vue']
     },
     {
+      demoId: 'overflow-title',
+      name: {
+        'zh-CN': '超出显示 tooltip',
+        'en-US': 'Out of Display tooltip'
+      },
+      desc: {
+        'zh-CN':
+          '通过 <code>overflow-title</code> 设置标题超出一定长度（默认 256px）时隐藏并显示...，鼠标移到标题上可显示 tooltip，<code>title-width</code>设置标题超出的长度。',
+        'en-US':
+          'Use <code>overflow-title</code> to set the title to hide and show when it exceeds a certain length (default 256px)... , move the cursor to the title to display the tooltip, and set <code>title-width</code> to the excess length of the title.'
+      },
+      codeFiles: ['overflow-title.vue']
+    },
+    {
       demoId: 'header-only',
       name: {
         'zh-CN': '仅展示头部',

--- a/packages/renderless/src/tabs/vue.ts
+++ b/packages/renderless/src/tabs/vue.ts
@@ -62,7 +62,8 @@ const initState = ({ reactive, props }: Pick<ITabsRenderlessParams, 'reactive' |
     direction: '',
     expandPanesWidth: '',
     activeIndex: 1,
-    separator: props.separator
+    separator: props.separator,
+    headerOnly: props.headerOnly
   }) as ITabsState
 
 const initWatcher = ({

--- a/packages/renderless/types/tabs.type.ts
+++ b/packages/renderless/types/tabs.type.ts
@@ -33,6 +33,7 @@ export interface ITabsState {
   activeIndex: number
   morePanes?: ITabsPaneVm[]
   separator?: boolean
+  headerOnly?: boolean
 }
 
 /**

--- a/packages/theme/src/tabs/index.less
+++ b/packages/theme/src/tabs/index.less
@@ -1317,6 +1317,35 @@
     }
   }
 
+  // 仅渲染头部
+  &&--header-only {
+
+    &:is(.@{tabs-prefix-cls}--left) {
+      width: 120px;
+    }
+
+    &.@{tabs-prefix-cls}--left .@{tabs-prefix-cls}__header {
+      float: none;
+      margin-right: 0;
+      display: block;
+    }
+
+    &:is(.@{tabs-prefix-cls}--right) {
+      width: 120px;
+    }
+
+    &.@{tabs-prefix-cls}--right .@{tabs-prefix-cls}__header {
+      float: none;
+      margin-left: 0;
+      display: block;
+    }
+
+    &.@{tabs-prefix-cls}--bottom .@{tabs-prefix-cls}__header {
+      margin-top: 0;
+    }
+
+  }
+
   // 动效
   .slideInLeft-transition,
   .slideInRight-transition {

--- a/packages/vue/src/tab-item/src/pc.vue
+++ b/packages/vue/src/tab-item/src/pc.vue
@@ -11,7 +11,7 @@
  -->
 <template>
   <div
-    v-if="!lazy || state.loaded || state.active"
+    v-if="!state.rootTabs.headerOnly && (!lazy || state.loaded || state.active)"
     v-show="state.active"
     :aria-hidden="!state.active"
     :id="`pane-${state.paneName}`"

--- a/packages/vue/src/tabs/src/index.ts
+++ b/packages/vue/src/tabs/src/index.ts
@@ -69,7 +69,9 @@ export const tabsProps = {
   // tiny 新增
   moreShowAll: Boolean,
   panelMaxHeight: String,
-  panelWidth: String
+  panelWidth: String,
+  // 只渲染头部
+  headerOnly: Boolean
 }
 
 export default defineComponent({

--- a/packages/vue/src/tabs/src/pc.vue
+++ b/packages/vue/src/tabs/src/pc.vue
@@ -52,7 +52,8 @@ export default defineComponent({
     'titleWidth',
     'moreShowAll',
     'panelMaxHeight',
-    'panelWidth'
+    'panelWidth',
+    'headerOnly'
   ],
   components: {
     TabNav,
@@ -78,7 +79,6 @@ export default defineComponent({
       handleTabDragEnd,
       editable,
       withAdd,
-      position,
       size,
       stretch,
       showMoreTabs,
@@ -89,8 +89,11 @@ export default defineComponent({
       overflowTitle,
       titleWidth,
       panelMaxHeight,
-      panelWidth
+      panelWidth,
+      headerOnly
     } = this
+
+    const position = headerOnly ? 'top' : this.position
 
     const newButton =
       editable || withAdd ? (
@@ -150,7 +153,7 @@ export default defineComponent({
       </div>
     )
 
-    const panels = <div class="tiny-tabs__content">{this.slots.default && this.slots.default()}</div>
+    const panels = headerOnly ? this.slots.default?.() : <div class="tiny-tabs__content">{this.slots.default?.()}</div>
 
     return (
       <div

--- a/packages/vue/src/tabs/src/pc.vue
+++ b/packages/vue/src/tabs/src/pc.vue
@@ -79,6 +79,7 @@ export default defineComponent({
       handleTabDragEnd,
       editable,
       withAdd,
+      position,
       size,
       stretch,
       showMoreTabs,
@@ -92,8 +93,6 @@ export default defineComponent({
       panelWidth,
       headerOnly
     } = this
-
-    const position = headerOnly ? 'top' : this.position
 
     const newButton =
       editable || withAdd ? (
@@ -164,7 +163,8 @@ export default defineComponent({
           'tiny-tabs--border-card': tabStyle === 'border-card',
           'tiny-tabs--button-card': tabStyle === 'button-card',
           'tiny-tabs--small': size === 'small',
-          'tiny-tabs--large': size === 'large'
+          'tiny-tabs--large': size === 'large',
+          'tiny-tabs--header-only': headerOnly
         }}>
         {position !== 'bottom' ? [header, panels] : [panels, header]}
       </div>


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Tabs很多时候会作为状态控件使用。

Tabs are often used as status controls.

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a header-only option for Tabs (boolean, default: false) that displays only tab headers and prevents tab content from rendering in PC mode.
  * Updated Tabs to expose header-only visually (new class/state) so UIs can present header-only layouts.

* **Documentation**
  * Added a demo showcasing header-only behavior and updated demo listings/descriptions.

* **Style**
  * Introduced header-only layout styles for left/right/bottom header positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->