### PR TITLE
feat(silder-button): add displayed attribute

### DIFF
--- a/examples/sites/demos/apis/slider-button.js
+++ b/examples/sites/demos/apis/slider-button.js
@@ -17,6 +17,28 @@ export default {
           mfDemo: ''
         },
         {
+          name: 'displayed',
+          type: 'Boolean',
+          defaultValue: '',
+          desc: {
+            'zh-CN': '按钮内容是否全部展示，默认false',
+            'en-US': 'Set whether the button content is fully displayed, default is false'
+          },
+          mode: ['mobile-first'],
+          mfDemo: ''
+        },
+        {
+          name: 'disabled',
+          type: 'Boolean',
+          defaultValue: '',
+          desc: {
+            'zh-CN': '设置滑块项禁用态',
+            'en-US': ''
+          },
+          mode: ['mobile-first'],
+          mfDemo: ''
+        },
+        {
           name: 'label',
           type: 'Number / String',
           defaultValue: '',

--- a/examples/sites/demos/mobile-first/app/slider-button/basic-usage.vue
+++ b/examples/sites/demos/mobile-first/app/slider-button/basic-usage.vue
@@ -1,9 +1,9 @@
 <template>
-  <tiny-slider-button-group v-model="radio2">
-    <tiny-slider-button label="1">选项</tiny-slider-button>
-    <tiny-slider-button label="2">选项选项选选项</tiny-slider-button>
-    <tiny-slider-button label="3">选项</tiny-slider-button>
-    <tiny-slider-button label="4">选项选项</tiny-slider-button>
+  <tiny-slider-button-group v-model="radio2" :displayed="false">
+    <tiny-slider-button label="1">选项选项选项选项选项选项</tiny-slider-button>
+    <tiny-slider-button label="2">选项选项选项选项选项选项</tiny-slider-button>
+    <tiny-slider-button label="3">选项选项</tiny-slider-button>
+    <tiny-slider-button label="4">选项</tiny-slider-button>
   </tiny-slider-button-group>
 </template>
 

--- a/examples/sites/demos/mobile-first/app/slider-button/webdoc/slider-button.js
+++ b/examples/sites/demos/mobile-first/app/slider-button/webdoc/slider-button.js
@@ -10,7 +10,7 @@ export default {
       },
       desc: {
         'zh-CN':
-          '<p>通过 <code>v-model</code> 绑定变量，设置的变量值为默认选中的 <code>Button</code>，变量值对应 <code>label</code> 属性的值。<br>\n          通过 <code>text</code> 也可以配置显示文本，与默认插槽配置纯文本的结果一致<br>\n          <code>label</code> 可以是 <code>String、Number 或 Boolean</code>。</p>',
+          '<p>通过 <code>v-model</code> 绑定变量，设置的变量值为默认选中的 <code>Button</code>，变量值对应 <code>label</code> 属性的值。<br>\n          通过 <code>text</code> 也可以配置显示文本，与默认插槽配置纯文本的结果一致<br>\n          <code>label</code> 可以是 <code>String、Number 或 Boolean</code>。<code>displayed</code>按钮内容是否全部展示。</p>',
         'en-US': '<p>button type</p>'
       },
       codeFiles: ['basic-usage.vue']

--- a/packages/renderless/src/slider-button-group/vue.ts
+++ b/packages/renderless/src/slider-button-group/vue.ts
@@ -58,6 +58,8 @@ export const renderless = (props, { reactive, provide, onMounted, onBeforeUnmoun
 
   provide('disabled', props.disabled)
 
+  provide('displayed', props.displayed)
+
   onMounted(() => {
     api.getChangePosition(props.modelValue)
     api.watchVisible()

--- a/packages/renderless/src/slider-button/vue.ts
+++ b/packages/renderless/src/slider-button/vue.ts
@@ -9,6 +9,7 @@ export const renderless = (
 ) => {
   const state = reactive({
     disabled: inject('disabled', null) || props.disabled,
+    displayed: inject('displayed', null) || props.displayed,
     type: inject('sliderType', null),
     value: computed({
       get: () => api.getValue(),

--- a/packages/vue/src/slider-button-group/src/index.ts
+++ b/packages/vue/src/slider-button-group/src/index.ts
@@ -44,6 +44,10 @@ export default defineComponent({
     disabled: {
       type: Boolean,
       default: false
+    },
+    displayed: {
+      type: Boolean,
+      default: false
     }
   },
   setup(props, context) {

--- a/packages/vue/src/slider-button-group/src/mobile-first.vue
+++ b/packages/vue/src/slider-button-group/src/mobile-first.vue
@@ -75,7 +75,8 @@ export default defineComponent({
     'noArrow',
     'flex',
     'delay',
-    'disabled'
+    'disabled',
+    'displayed'
   ],
   setup(props, context): any {
     return setup({ props, context, renderless, api })

--- a/packages/vue/src/slider-button/src/index.ts
+++ b/packages/vue/src/slider-button/src/index.ts
@@ -22,6 +22,10 @@ export default defineComponent({
     disabled: {
       type: Boolean,
       default: false
+    },
+    displayed: {
+      type: Boolean,
+      default: false
     }
   },
   setup(props, context) {

--- a/packages/vue/src/slider-button/src/mobile-first.vue
+++ b/packages/vue/src/slider-button/src/mobile-first.vue
@@ -49,7 +49,8 @@
             ? state.type === 'icon'
               ? 'fill-color-icon-disabled cursor-not-allowed'
               : 'text-color-text-disabled cursor-not-allowed'
-            : ''
+            : '',
+          state.displayed ? 'max-w-none' : ''
         )
       "
       @keydown.stop
@@ -65,7 +66,7 @@ import { renderless, api } from '@opentiny/vue-renderless/slider-button/vue'
 import { props, setup, defineComponent } from '@opentiny/vue-common'
 
 export default defineComponent({
-  props: [...props, 'label', 'events', 'text', 'disabled'],
+  props: [...props, 'label', 'events', 'text', 'disabled', 'displayed'],
   setup(props, context): any {
     return setup({ props, context, renderless, api })
   }


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:
添加多端属性
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a displayed prop to SliderButton and SliderButtonGroup to toggle full content visibility; enabling it shows button text without truncation.

- UI
  - Mobile-first variant expands label width when displayed is true for improved readability.

- Demos
  - Basic usage demo updated to showcase displayed, with longer sample labels.

- Documentation
  - Chinese documentation updated to describe the new displayed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->