### PR TITLE
fix(grid): grid can not validate on active

### DIFF
--- a/packages/theme-saas/src/grid/table-global.less
+++ b/packages/theme-saas/src/grid/table-global.less
@@ -12,7 +12,6 @@
   @apply overflow-hidden;
   @apply text-xs;
   @apply text-color-text-primary;
-  font-family: Helvetica, Arial, 'Microsoft YaHei', sans-serif;
   @apply bg-color-bg-1;
 
   &.show__foot {

--- a/packages/theme-saas/src/grid/table.less
+++ b/packages/theme-saas/src/grid/table.less
@@ -16,7 +16,6 @@
   @apply overflow-hidden;
   @apply text-xs;
   @apply text-color-text-primary;
-  font-family: Helvetica, Arial, 'Microsoft YaHei', sans-serif;
   @apply bg-color-bg-1;
 
   &.show__foot {

--- a/packages/vue/src/grid/src/config.ts
+++ b/packages/vue/src/grid/src/config.ts
@@ -41,7 +41,7 @@ const GlobalConfig = {
     message: 'tooltip',
     icon: iconError()
   },
-  editConfig: { trigger: 'click', mode: 'cell', showStatus: true },
+  editConfig: { trigger: 'click', mode: 'cell', showStatus: true, validateOnActive: true },
   // 默认开启点击头部单元格触发排序
   sortConfig: { multipleColumnSort: false },
   // 默认不开启隔行换色和行高亮，不暴露此配置

--- a/packages/vue/src/grid/src/table/src/methods.ts
+++ b/packages/vue/src/grid/src/table/src/methods.ts
@@ -1348,7 +1348,11 @@ const Methods = {
       .catch((e) => e)
       .then(() => {
         this.handleActived(params, event)
-          .then(() => this.triggerValidate('change'))
+          .then(() => {
+            if (this.editConfig?.validateOnActive) {
+              this.triggerValidate('change')
+            }
+          })
           .catch((e) => e)
       })
   },

--- a/packages/vue/src/grid/src/table/src/methods.ts
+++ b/packages/vue/src/grid/src/table/src/methods.ts
@@ -1350,7 +1350,7 @@ const Methods = {
         this.handleActived(params, event)
           .then(() => {
             if (this.editConfig?.validateOnActive) {
-              this.triggerValidate('change')
+              return this.triggerValidate('change')
             }
           })
           .catch((e) => e)


### PR DESCRIPTION
# PR
统一表格字体 & 支持进入编辑态不校验
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a setting that controls validation when activating a grid cell; enabled by default to provide immediate validation feedback on cell activation.

- **Style**
  - Removed hardcoded font-family from table/grid components so they inherit the app’s global font, improving theme consistency and custom font support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->