### PR TITLE
fix(tag): restores the default color of the tag to blue

### DIFF
--- a/packages/design/aurora/src/select/index.ts
+++ b/packages/design/aurora/src/select/index.ts
@@ -34,7 +34,7 @@ export default {
         if (~['small', 'mini'].indexOf(state.selectSize)) {
           size = state.selectSize
         } else if (~['medium', 'default'].indexOf(state.selectSize)) {
-          size = 'default'
+          size = 'small'
         }
 
         return size

--- a/packages/design/saas/src/select/index.ts
+++ b/packages/design/saas/src/select/index.ts
@@ -36,7 +36,7 @@ export default {
         if (~['small', 'mini'].indexOf(state.selectSize)) {
           size = state.selectSize
         } else if (~['medium', 'default'].indexOf(state.selectSize)) {
-          size = 'default'
+          size = 'small'
         }
 
         return size

--- a/packages/theme-saas/src/tag/index.less
+++ b/packages/theme-saas/src/tag/index.less
@@ -51,12 +51,12 @@
 
   &&--default {
     .tag-variant(
-      theme('colors.color.text.primary'),
+      theme('colors.color.info.primary.DEFAULT'),
       theme('colors.transparent'),
-      theme('colors.color.bg.3'),
-      theme('colors.color.icon.primary'),
-      theme('colors.color.icon.primary'),
-      theme('colors.color.none.DEFAULT')
+      theme('colors.color.info.primary.subtler'),
+      theme('colors.color.info.primary.DEFAULT'),
+      theme('colors.color.info.primary.DEFAULT'),
+      theme('colors.color.info.primary.subtle')
     );
   }
 


### PR DESCRIPTION
# PR
fix(tag): 还原 tag的default颜色为蓝色。 同时修改design中，函数会返回 size="default"的错误情况。  【6.7.77】

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated default Tag color scheme to use the info-primary palette for clearer, more consistent visuals.
  * Adjusted collapsed Tag size in Select: “default” and “medium” now render as “small” for a more compact appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->