### PR TITLE
fix: select options add default value

### DIFF
--- a/packages/vue/src/select/package.json
+++ b/packages/vue/src/select/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opentiny/vue-select",
   "type": "module",
-  "version": "3.25.0",
+  "version": "3.25.1",
   "description": "",
   "license": "MIT",
   "sideEffects": false,
@@ -21,14 +21,14 @@
     "@opentiny/vue-input": "workspace:~",
     "@opentiny/vue-locale": "workspace:~",
     "@opentiny/vue-option": "workspace:~",
+    "@opentiny/vue-recycle-scroller": "workspace:~",
     "@opentiny/vue-renderless": "workspace:~",
-    "@opentiny/vue-tag": "workspace:~",
     "@opentiny/vue-scrollbar": "workspace:~",
     "@opentiny/vue-select-dropdown": "workspace:~",
+    "@opentiny/vue-tag": "workspace:~",
+    "@opentiny/vue-theme": "workspace:~",
     "@opentiny/vue-tooltip": "workspace:~",
-    "@opentiny/vue-tree": "workspace:~",
-    "@opentiny/vue-recycle-scroller": "workspace:~",
-    "@opentiny/vue-theme": "workspace:~"
+    "@opentiny/vue-tree": "workspace:~"
   },
   "devDependencies": {
     "@opentiny-internal/vue-test-utils": "workspace:*",

--- a/packages/vue/src/select/src/index.ts
+++ b/packages/vue/src/select/src/index.ts
@@ -112,7 +112,10 @@ export default defineComponent({
     label: String,
     loading: Boolean,
     disabled: Boolean,
-    options: Array,
+    options: {
+      type: Array,
+      default: () => []
+    },
     dataset: Object,
     textField: {
       type: String,


### PR DESCRIPTION
# PR
select组件options新增默认值，兼容流式返回场景
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Select component now provides a default empty options list, preventing undefined values and avoiding shared state across instances when no options are passed.

* **Chores**
  * Bumped version to 3.25.1.
  * Updated dependencies and added new workspace packages to improve consistency and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->