### PR TITLE
fix(fluent-editor): Fix click issues with rich text components in Edge browser

### DIFF
--- a/packages/renderless/src/fluent-editor/index.ts
+++ b/packages/renderless/src/fluent-editor/index.ts
@@ -141,7 +141,7 @@ export const keyDownHandler =
       if (e.keyCode === 27 && state.isFullscreen) {
         state.isFullscreen = !state.isFullscreen
       }
-    } else {
+    } else if (e.type === 'click') {
       state.isFullscreen = !state.isFullscreen
     }
   }


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fullscreen toggle now reliably responds to clicks on the on-screen control (mouse/touch), improving usability.
  * Escape key behavior for exiting fullscreen remains consistent, ensuring parity across keyboard and mouse interactions.
  * No changes to user-facing settings or configuration; behavior is more consistent without altering workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->