### PR TITLE
fix(grid): fix user passed  scrollY value is null

### DIFF
--- a/packages/vue/src/grid/src/table/src/table.ts
+++ b/packages/vue/src/grid/src/table/src/table.ts
@@ -710,7 +710,9 @@ export default defineComponent({
     const optimizeOpts = hooks.computed(() => extend(true, {}, GlobalConfig.optimization, props.optimization))
     const rowHeight = hooks.computed(
       () =>
-        optimizeOpts.value?.scrollY.rHeight || GlobalConfig.rowHeight[tinyTheme.value]?.[vSize.value || 'default'] || 40
+        optimizeOpts.value?.scrollY?.rHeight ||
+        GlobalConfig.rowHeight[tinyTheme.value]?.[vSize.value || 'default'] ||
+        40
     )
     const headerRowHeight = hooks.computed(
       () => GlobalConfig.headerRowHeight[tinyTheme.value]?.[vSize.value || 'default'] || 40


### PR DESCRIPTION
# PR
修复用户主动将scrollY 传值为Null时的报错
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents rare runtime errors when calculating row height in tables without a vertical scroll configuration.
  * Maintains existing fallback behavior for row heights, ensuring consistent display.
  * No impact on header row height; overall stability improved without altering visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->