### PR TITLE
feat(cascader): Add the tooltip function for cascading panels

### DIFF
--- a/packages/vue/src/cascader-node/package.json
+++ b/packages/vue/src/cascader-node/package.json
@@ -12,6 +12,7 @@
     "//postversion": "pnpm build"
   },
   "dependencies": {
+    "@opentiny/vue-directive": "workspace:~",
     "@opentiny/utils": "workspace:~",
     "@opentiny/vue-checkbox": "workspace:~",
     "@opentiny/vue-common": "workspace:~",

--- a/packages/vue/src/cascader-node/src/pc.vue
+++ b/packages/vue/src/cascader-node/src/pc.vue
@@ -17,12 +17,14 @@ import Radio from '@opentiny/vue-radio'
 import { isEqual } from '@opentiny/utils'
 import { iconLoadingShadow, iconChevronRight, iconYes } from '@opentiny/vue-icon'
 import type { PropType } from '@opentiny/vue-common'
+import { AutoTip } from '@opentiny/vue-directive'
 import type { ICascaderNodeApi, ICascaderNodeRenderlessParams } from '@opentiny/vue-renderless/types/cascader-node.type'
 import type { ICascaderPanelNode } from '@opentiny/vue-renderless/types/cascader-panel.type'
 import '@opentiny/vue-theme/cascader-node/index.less'
 
 export default defineComponent({
   name: $prefix + 'CascaderNode',
+  directives: { AutoTip },
   components: {
     TinyCheckbox: Checkbox,
     TinyRadio: Radio,
@@ -120,7 +122,11 @@ export default defineComponent({
       const vnode = render ? render({ node, data: node.data }) : null
 
       // 可用 state.nodeLabel 简化
-      return <span class="tiny-cascader-node__label">{vnode || node.label}</span>
+      return (
+        <span class="tiny-cascader-node__label" v-auto-tip>
+          {vnode || node.label}
+        </span>
+      )
     }
 
     const { state } = this


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cascader node labels now support automatic tooltips, improving readability for long or truncated text when hovering.
* **Chores**
  * Updated dependencies to enable the new tooltip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->