### PR TITLE
fix(grid): fix grid error when columns config from null change to empty array

### DIFF
--- a/packages/vue/src/grid/package.json
+++ b/packages/vue/src/grid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opentiny/vue-grid",
   "type": "module",
-  "version": "3.25.0",
+  "version": "3.25.1",
   "description": "",
   "license": "MIT",
   "sideEffects": false,
@@ -12,6 +12,7 @@
     "//postversion": "pnpm build"
   },
   "dependencies": {
+    "@opentiny/utils": "workspace:~",
     "@opentiny/vue-common": "workspace:~",
     "@opentiny/vue-directive": "workspace:~",
     "@opentiny/vue-dropdown": "workspace:~",
@@ -26,8 +27,7 @@
     "@opentiny/vue-renderless": "workspace:~",
     "@opentiny/vue-tag": "workspace:~",
     "@opentiny/vue-theme": "workspace:~",
-    "@opentiny/vue-tooltip": "workspace:~",
-    "@opentiny/utils": "workspace:~"
+    "@opentiny/vue-tooltip": "workspace:~"
   },
   "devDependencies": {
     "@opentiny-internal/vue-test-utils": "workspace:*",

--- a/packages/vue/src/grid/src/composable/useHeader.ts
+++ b/packages/vue/src/grid/src/composable/useHeader.ts
@@ -21,7 +21,7 @@ export const calcHeader = (collectColumn) => {
 
         traverseTree(item.children, level + 1, item)
       })
-    } else {
+    } else if (parent) {
       leafColumns.push(parent)
     }
   }


### PR DESCRIPTION
# PR
修复当columns从null变为空数组时，表格报错问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected grid header generation to include leaf columns when subtrees are empty, ensuring accurate multi-level headers, rowspans, and alignment in complex column setups.

* **Chores**
  * Bumped @opentiny/vue-grid to 3.25.1.
  * Removed an internal utility dependency with no functional impact to end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->