### PR TITLE
fix(pop-upload): Fix uploadTip slot error issue

### DIFF
--- a/packages/vue/src/pop-upload/src/pc.vue
+++ b/packages/vue/src/pop-upload/src/pc.vue
@@ -81,7 +81,7 @@
             :headers="state.headers"
             :action="state.action"
             :auto-upload="false"
-            :re-uploadable="slots.uploadTip"
+            :re-uploadable="!!slots.uploadTip"
           >
             <template #trigger>
               <tiny-button>{{ state.multiple ? state.uploadsButtonText : state.uploadButtonText }}</tiny-button>


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Re-upload option in the upload dialog now toggles reliably based on whether an upload tip is provided, eliminating inconsistent behavior.
  * Prevents accidental enabling/disabling of re-upload, improving clarity and predictability for users during file uploads.
  * No visual or workflow changes beyond the corrected toggle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->