### PR TITLE
fix(tabs): Fix the issue where multiple clicks on mobile-first tabs do not take effect

### DIFF
--- a/packages/design/aurora/src/dropdown-item/index.ts
+++ b/packages/design/aurora/src/dropdown-item/index.ts
@@ -37,6 +37,7 @@ export default {
             dataStore.showContent,
             props.disabled
           ])
+          emit('click', dataStore.itemData, event)
 
           dispatch('TinyDropdown', 'is-disabled', [props.disabled])
         } else {
@@ -47,6 +48,7 @@ export default {
             emit('item-click', [props.itemData, vm, props.disabled])
           }
 
+          emit('click', props.itemData, event)
           dispatch('TinyDropdown', 'menu-item-click', [props.itemData, vm, props.disabled])
           dispatch('TinyDropdown', 'is-disabled', [props.disabled])
           dispatch('TinyDropdown', 'selected-index', [state.currentIndex])

--- a/packages/design/aurora/src/dropdown-item/index.ts
+++ b/packages/design/aurora/src/dropdown-item/index.ts
@@ -30,6 +30,7 @@ export default {
 
           dispatch('TinyDropdown', 'selected-index', [dataStore.currentIndex])
 
+          emit('click', dataStore.itemData, event)
           dispatch('TinyDropdownMenu', 'menu-item-click', [
             dataStore.itemData,
             vm,
@@ -37,7 +38,6 @@ export default {
             dataStore.showContent,
             props.disabled
           ])
-          emit('click', dataStore.itemData, event)
 
           dispatch('TinyDropdown', 'is-disabled', [props.disabled])
         } else {

--- a/packages/renderless/src/tabs-mf/index.ts
+++ b/packages/renderless/src/tabs-mf/index.ts
@@ -288,7 +288,10 @@ export const wheelListener = ({ vm, api, tabs, state }) =>
 
 export const getBoundRect = (vm) => () => vm.$el.getBoundingClientRect()
 
-export const handleClickDropdownItem = (tabs) => (name) => tabs.clickMore(name)
+export const handleClickDropdownItem = (tabs) => (navItem, event) => {
+  tabs.$emit('click', navItem, event)
+  tabs.clickMore(navItem.name)
+}
 
 export const scrollToLeft = (tabs) => () => {
   tabs.scrollTo(tabs.state.navs[0].name)

--- a/packages/vue/src/dropdown-item/src/mobile-first.vue
+++ b/packages/vue/src/dropdown-item/src/mobile-first.vue
@@ -40,7 +40,7 @@ import { props, setup, defineComponent } from '@opentiny/vue-common'
 import { renderless, api } from '@opentiny/vue-renderless/dropdown-item/mf'
 
 export default defineComponent({
-  emits: ['update:modelValue', 'change', 'closed', 'open', 'opened', 'close', 'confirm', 'reset'],
+  emits: ['update:modelValue', 'change', 'closed', 'open', 'opened', 'close', 'confirm', 'reset', 'click'],
   props: [...props, 'disabled', 'icon', 'itemData', 'selected', 'label', 'level', 'currentIndex', 'tooltipContent'],
   setup(props, context): any {
     return setup({ props, context, renderless, api })

--- a/packages/vue/src/tabs/src/mobile-first/tab-bar.vue
+++ b/packages/vue/src/tabs/src/mobile-first/tab-bar.vue
@@ -81,7 +81,7 @@ export default defineComponent({
           state.moreList.length
             ? h('div', { class: 'hidden sm:inline-block w-11 h-11 sm:h-10 text-sm cursor-pointer' }, [
                 h('span', { class: 'inline-flex w-full h-full flex-col justify-center items-center' }, [
-                  h(Dropdown, { on: { 'item-click': handleClickDropdownItem }, props: { showIcon: false } }, [
+                  h(Dropdown, { props: { showIcon: false } }, [
                     h('span', {}, [h(IconPopup(), { class: 'fill-color-icon-focus text-base' })]),
                     h(
                       DropdownMenu,
@@ -90,9 +90,11 @@ export default defineComponent({
                         props: { popperClass: 'max-h-[theme(spacing.80)] overflow-x-hidden overflow-y-auto' }
                       },
                       state.moreOptions.map((opt: NavItem) =>
-                        h(DropdownItem, { key: key(opt), props: { itemData: opt.name } }, [
-                          opt.slotTitle ? opt.slotTitle() : opt.title
-                        ])
+                        h(
+                          DropdownItem,
+                          { key: key(opt), on: { click: handleClickDropdownItem }, props: { itemData: opt } },
+                          [opt.slotTitle ? opt.slotTitle() : opt.title]
+                        )
                       )
                     )
                   ])


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Dropdown items (standard and mobile-first) now emit a click event that includes the item's data and the original click event.
  * Tabs “More” menu items emit click events with full item data before performing navigation.

* Refactor
  * Tab bar moved from wrapper-level item-click handling to per-item click handlers, passing full option objects for more consistent event payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->