### PR TITLE
fix(grid): fix use title function text can not overflow ellipsis

### DIFF
--- a/packages/vue/src/grid/src/cell/src/cell.ts
+++ b/packages/vue/src/grid/src/cell/src/cell.ts
@@ -277,7 +277,7 @@ export const Cell = {
     }
 
     if (typeof title === 'function') {
-      return [title(h, params)]
+      return [h('div', { class: 'tiny-grid-cell-text' }, [title(h, params)])]
     }
 
     if (type === 'card') {


### PR DESCRIPTION
# PR
修复表格使用title function文本溢出不显示省略号问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Grid column headers defined via functions now display with the same text wrapper as static and slot-based titles, ensuring consistent styling across all header types.
  - Resolves visual inconsistencies such as alignment, spacing, and text truncation/wrapping in function-based header titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->