### PR TITLE
fix(grid): fix rowspan border can not visible

### DIFF
--- a/packages/theme-saas/src/grid/footer.less
+++ b/packages/theme-saas/src/grid/footer.less
@@ -24,7 +24,7 @@
 .@{grid-prefix-cls} .@{grid-prefix-cls}__footer-border-line {
   @apply w-full;
   @apply h-px;
-  @apply bg-color-bg-4;
+  @apply bg-color-border-separator;
   @apply absolute;
   @apply z-10;
 }

--- a/packages/theme-saas/src/grid/table-global.less
+++ b/packages/theme-saas/src/grid/table-global.less
@@ -242,17 +242,7 @@
         );
       @apply bg-no-repeat;
       background-size: 1px 100%, 100% 1px;
-      background-position: 100% 0, 100% 99%;
-    }
-
-    &.is__row-span .@{grid-prefix-cls}-body__column {
       background-position: 100% 0, 100% 100%;
-    }
-
-    .@{grid-prefix-cls}-body__row:last-child {
-      .@{grid-prefix-cls}-body__column {
-        background-position: 100% 0, 100% 100%;
-      }
     }
 
     .@{grid-prefix-cls}__fixed-left-wrapper {

--- a/packages/theme-saas/src/grid/table.less
+++ b/packages/theme-saas/src/grid/table.less
@@ -268,6 +268,27 @@
     }
   }
 
+  // tiny新增滚动条放置表格内
+  tbody tr.row__last-visible {
+    @apply relative;
+
+    &::after {
+      @apply content-[''];
+      @apply absolute;
+      @apply bottom-0;
+      @apply left-0;
+      @apply right-0;
+      @apply bottom-0;
+      @apply h-px;
+      @apply bg-color-border-separator;
+      @apply ~'z-[3]';
+    }
+  }
+
+  &:has(.@{grid-prefix-cls}__footer-wrapper) tbody tr.row__last-visible {
+    display: none;
+  }
+
   &&__border,
   &&__border-saas {
     // 启用 border 只有表头生效，默认不建议启用 border 属性，另外如果内嵌列，则表头会自动启用 border 属性
@@ -321,16 +342,6 @@
       @apply bg-no-repeat;
       background-size: 1px 100%, 100% 1px;
       background-position: 100% 0, 100% 100%;
-    }
-
-    &.is__row-span .@{grid-prefix-cls}-body__column {
-      background-position: 100% 0, 100% 100%;
-    }
-
-    .@{grid-prefix-cls}-body__row:last-child {
-      .@{grid-prefix-cls}-body__column {
-        background-position: 100% 0, 100% 100%;
-      }
     }
 
     .@{grid-prefix-cls}__fixed-left-wrapper {

--- a/packages/vue/src/grid/src/body/src/body.tsx
+++ b/packages/vue/src/grid/src/body/src/body.tsx
@@ -345,6 +345,8 @@ function renderRows(_vm) {
   const seqCount = { value: 0 }
   const $seq = ''
 
+  const lastVisibleIndex = rowPool.findLastIndex(({ used }) => Boolean(used))
+
   rowPool.forEach(({ id, item: { payload: row, level: rowLevel }, used }, $rowIndex) => {
     const rowActived = editConfig && actived.row === row
     const virtualRow = isVirtualRow(row)
@@ -369,7 +371,19 @@ function renderRows(_vm) {
 
     renderRowGroupData({ $table, _vm, id, row, rowGroup, rowid, rows, used, virtualRow })
 
-    let args = { $rowIndex, $seq, $table, _vm, editStore, id, isSkipRowRender, row, rowActived, rowClassName }
+    let args = {
+      $rowIndex,
+      $seq,
+      $table,
+      _vm,
+      editStore,
+      id,
+      isSkipRowRender,
+      row,
+      rowActived,
+      rowClassName,
+      lastVisibleIndex
+    }
 
     Object.assign(args, { rowIndex, rowLevel, rowid, rows, selection, seq, treeConfig, used, selectRow })
 
@@ -426,7 +440,7 @@ function renderRowAfter({ $table, _vm, row, rowIndex, rows, id, used }) {
 
 function renderRow(args) {
   const { $rowIndex, $seq, $table, _vm, editStore, id, isSkipRowRender, row, rowActived, rowClassName } = args
-  const { rowIndex, rowLevel, rowid, rows, selection, selectRow, seq, treeConfig, used } = args
+  const { rowIndex, rowLevel, rowid, rows, selection, selectRow, seq, treeConfig, used, lastVisibleIndex } = args
 
   if (isSkipRowRender) {
     return
@@ -459,7 +473,8 @@ function renderRow(args) {
           'row__new': editStore.insertList.includes(row),
           'row__selected': selection.includes(row),
           'row__radio': selectRow === row,
-          'row__actived': rowActived
+          'row__actived': rowActived,
+          'row__last-visible': lastVisibleIndex === $rowIndex
         },
         rowClassName
           ? isFunction(rowClassName)


### PR DESCRIPTION
# PR
修复合并单元格最后一列底部边框不显示问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds a subtle separator line on the last visible table row for improved visual guidance; automatically hidden when a footer is present.
- Style
  - Updates footer border to use the standard separator color for visual consistency.
  - Standardizes background-position for table body columns, removing special-case overrides to ensure consistent gradient alignment across rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->