### PR TITLE
fix(grid): fix has footer last row border duplicate

### DIFF
--- a/packages/theme-saas/src/grid/table.less
+++ b/packages/theme-saas/src/grid/table.less
@@ -285,7 +285,7 @@
     }
   }
 
-  &:has(.@{grid-prefix-cls}__footer-wrapper) tbody tr.row__last-visible {
+  &:has(.@{grid-prefix-cls}__footer-wrapper) tbody tr.row__last-visible::after {
     display: none;
   }
 


### PR DESCRIPTION
# PR
修复含表尾的最后一行，下边框重复显示
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the last visible table row could appear hidden when a footer was present.
  * Only the bottom separator line is now suppressed, preventing a double border while keeping the row visible.
  * Improves visual consistency between the table body and footer.
  * No impact on data or interactions; this is a visual refinement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->