### PR TITLE
fix(notify): Fix the vertical offset issue of the notify component

### DIFF
--- a/examples/sites/demos/pc/app/notify/manual-close.spec.ts
+++ b/examples/sites/demos/pc/app/notify/manual-close.spec.ts
@@ -12,7 +12,7 @@ test('手动关闭通知', async ({ page }) => {
   await buttons.nth(1).click()
   await buttons.nth(2).click()
 
-  await expect(notifys).toHaveCount(5)
+  await expect(notifys).toHaveCount(3)
   await page.waitForTimeout(4100)
   await expect(notifys).toHaveCount(0)
 })

--- a/examples/sites/demos/pc/app/notify/verticalOffset.spec.ts
+++ b/examples/sites/demos/pc/app/notify/verticalOffset.spec.ts
@@ -3,7 +3,9 @@ import { test, expect } from '@playwright/test'
 test('垂直方向偏离距离', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
   await page.goto('notify#verticalOffset')
-  await page.getByRole('button', { name: '弹出提示框' }).click()
+
+  const demo = page.locator('#verticalOffset')
+  await demo.getByRole('button', { name: '弹出提示框' }).click()
   const notify = page.locator('.tiny-notify')
   const offset = await notify.getAttribute('verticalOffset')
   await expect(offset).toEqual('100')

--- a/packages/vue/src/notify/index.ts
+++ b/packages/vue/src/notify/index.ts
@@ -175,7 +175,7 @@ Notify.close = function (id: string, userOnClose?: (instance: NotifyInstance) =>
 
   let removedPosition = instance.position
   let copys = instances.slice(index)
-  let verticalOffset = 16
+  let verticalOffset = instance.state.verticalOffset ? Number(instance.state.verticalOffset) : 16
 
   instances
     .filter((item) => item.state.position === removedPosition)


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3633

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications now reposition correctly when one is closed, using the closed item's offset with a sensible default to prevent spacing glitches.
  * Maintains consistent stacking across positions; public API unchanged.

* **Tests**
  * Updated notification tests: manual-close expectations adjusted (fewer items after clicks) and a vertical-offset test now scopes actions to the demo container for more reliable selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->