### PR TITLE
fix(form-item): The mobile disabled status is not obvious in saas mode

### DIFF
--- a/packages/renderless/src/form-item/vue.ts
+++ b/packages/renderless/src/form-item/vue.ts
@@ -119,7 +119,7 @@ const initState = ({
     validateIcon: computed(() => api.computedValidateIcon()),
     isErrorInline: computed(() => api.computedIsErrorInline()),
     isErrorBlock: computed(() => api.computedIsErrorBlock()),
-    disabled: computed(() => state.formInstance.disabled),
+    disabled: computed(() => state.formInstance.disabled || props.disabled),
     tooltipType: computed(() => state.formInstance.state.tooltipType),
     // 标记表单项下是否有多个子节点
     isMultiple: false

--- a/packages/theme-saas/src/form-item/index.less
+++ b/packages/theme-saas/src/form-item/index.less
@@ -185,6 +185,10 @@
     @apply whitespace-nowrap;
     @apply text-ellipsis;
     @apply text-right;
+
+    &.is-disabled {
+      @apply text-color-text-disabled;
+    }
   }
 
   &__content {

--- a/packages/vue/src/form-item/src/mobile-first.vue
+++ b/packages/vue/src/form-item/src/mobile-first.vue
@@ -39,7 +39,7 @@
             state.labelPosition === 'top' && !state.hideRequiredAsterisk
               ? 'overflow-visible relative before:absolute before:-left-2.5'
               : '',
-            state.disabled ? 'text-color-icon-placeholder sm:text-color-text-secondary' : 'text-color-text-secondary',
+            state.disabled ? 'text-color-icon-placeholder sm:text-color-text-disabled' : 'text-color-text-secondary',
             state.formItemSize !== 'mini' ? 'sm:text-sm' : 'sm:text-xs'
           )
         "
@@ -188,6 +188,10 @@ export default defineComponent({
     showMessage: {
       type: Boolean,
       default: true
+    },
+    disabled: {
+      type: Boolean,
+      default: false
     },
     size: String,
     tipContent: String,

--- a/packages/vue/src/form-item/src/pc.vue
+++ b/packages/vue/src/form-item/src/pc.vue
@@ -51,6 +51,10 @@ export default defineComponent({
       type: Boolean,
       default: undefined
     },
+    disabled: {
+      type: Boolean,
+      default: false
+    },
     error: String,
     for: String,
     inlineMessage: {
@@ -131,8 +135,8 @@ export default defineComponent({
       typeof this.appendToBody === 'boolean'
         ? this.appendToBody
         : typeof formAppendToBody === 'boolean'
-        ? formAppendToBody
-        : true
+          ? formAppendToBody
+          : true
     const validatePosition = this.validatePosition || state.formInstance?.validatePosition || 'top-end'
 
     const popperOptions = {
@@ -285,7 +289,8 @@ export default defineComponent({
               {
                 class: {
                   [`${classPrefix}form-item__label`]: true,
-                  'is-ellipsis': isMobile && ellipsis
+                  'is-ellipsis': isMobile && ellipsis,
+                  'is-disabled': state.disabled
                 },
                 style: state.labelStyle,
                 attrs: {


### PR DESCRIPTION
# PR
fix:移动端禁用状态显示不明显

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FormItem now supports a disabled prop, enabling per-item disabling on both mobile and desktop.
  * Disabled state respects both form-level and item-level settings for consistent behavior.

* **Style**
  * Disabled form item labels now use a disabled text color and receive an is-disabled class for clearer visual indication.
  * Styling updates ensure consistent theming of disabled labels without affecting non-disabled items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->