### PR TITLE
fix(site): push update logs and upgrade the playground version number to the release3.26 branch

### DIFF
--- a/examples/sites/demos/pc/webdoc/changelog-en.md
+++ b/examples/sites/demos/pc/webdoc/changelog-en.md
@@ -1,197 +1,224 @@
-# Update Log
+# Changelog
 
-## v2.1.0/v3.1.0
+The Tiny Vue team uses a monthly release strategy under normal circumstances.
 
-`2023 / 02 / 19`
+On this page, you can only see the log records of the latest three iterations of our changelog. If you want to see the full record, you can view: [Release](https://github.com/opentiny/tiny-vue/releases)
 
-###'Destructive Change
+## v3.26.0/v2.26.0
 
-- [Theme variable] If the version is upgraded, the referenced theme variable becomes invalid. Due to this upgrade, theme variables are standardized and rectified. If theme variables are used in old projects, click [Subject Replacement](https://tinyuidesign.cloudbu.huawei.com/tiny-vue/en-US/os-theme/docs/theme) to enter the tutorial and replace the old and new theme variables of the project.
+`2025/09/15`
 
-### New Features
+## What's Changed
 
-- [Global scrolling switch] The PopupManager.globalScroll attribute is added to solve the problem that the pop-up layer does not follow the scrolling in some scenarios. [Reference Case] (https://w3.huawei.com/servicedesk/itservice/casemanage/#/agent?docId=KT00206971)
-- [Grid component] Add the function of dragging rows and setting the drag range. The toolbar provides the function of filtering columns by drop-down list.
-- [Select component] Add a trigger source slot.
+### Exciting New Features 🎉
 
-### Defect fixing
+- feat(steps): Add wizard style step bar itemStyle differentiated configuration by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3594
+- feat(color-picker): refactoring the ColorPicker component style by @wuyiping0628 in https://github.com/opentiny/tiny-vue/pull/3595
+- feat: modify the resource file loading mode and add postcss plugin configuration. by @zzcr in https://github.com/opentiny/tiny-vue/pull/3615
+- feat(site): connect next-sdk and ai dialog box to realize dynamic switching routing function of large models by @zzcr in https://github.com/opentiny/tiny-vue/pull/3619
+- feat(grid): saas theme add filter select style by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3626
+- feat(grid): add cascader full width grid by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3627
+- feat(button): add a list of theme tokens to the component documentation by @wuyiping0628 in https://github.com/opentiny/tiny-vue/pull/3631
+- feat(silder-button): add displayed attribute by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3639
+- feat: Add table configuration slot example usage by @zzcr in https://github.com/opentiny/tiny-vue/pull/3649
+- feat(cascader): Add the tooltip function for cascading panels by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3665
+- feat(search): Add mini search box expansion and retraction hook callback API by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3664
+- feat(tabs): add header-only by @liangguanhui0117 in https://github.com/opentiny/tiny-vue/pull/3638
 
-- [Numeric component] The component reports an error when the input value of the Numeric component is too long.
-- [Form Component] Fixed an issue where required of the FormItem component cannot be aligned when the first item is not in the first item.
-- [Dropdown component] Fixed issues related to the Dropdown component.
-- [ActionMenu] Fixed an issue where the pop-up of the ActionMenu component cannot be selected.
-- [Select component] The options that are selected and disabled by default for multiple selections can be deleted. The searchable function is invalid in vue2. The search box complies with HUAWEI CLOUD specifications. Filtering can be triggered when you enter a value.
-- [Grid component] Fixed the issue that the pagination setting and style of the personalized panel are invalid.
+### Bug Fixes 🐛
 
-###'Optimization
+- fix(dropdown):Fix the drop-down component menu spacing. by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3586
+- fix: adapt mf list view when has not grid column by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3593
+- fix(select):Fix default multi-select tags color by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3591
+- fix(calendar-view):fix calendar view height setting does not take effect by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3592
+- fix: hot and new icon fill cannot transparent transmission by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3599
+- fix(modal): [modal] modify the messageClosable in Vue2 version to not display the close button by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3600
+- fix: internationalization-related modifications, temporarily hide the entry point by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3597
+- fix(tabs): Optimize multi terminal caching logic, add add add delete operations to trigger sub component destruction and reconstruction logic by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3601
+- fix(grid): Modify the spacing between the sorting buttons in saas mode. by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3603
+- fix(grid): grid promise validate return value back to undefined by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3616
+- fix(grid,pager,cascader):Fixed the icon reference issue in the SaaS mode table. by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3618
+- fix(grid): optimize render count by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3613
+- fix(dropdown): modify the responsive adaptation of the drop-down arrow in the mobile first template by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3614
+- fix(chart): fix chart bug, resolve memory leakage issues by @Davont in https://github.com/opentiny/tiny-vue/pull/3610
+- fix(input):fix textarea height in saas model by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3608
+- fix(site): add MCP tools for query examples and jump examples by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3623
+- fix(PropType): fix import of PropType by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3620
+- fix(input): add pre=true for tiny-tooltip by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3625
+- fix(input):fix textarea height in Multiple line placeholders by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3624
+- fix(grid): fix index not update at drag row by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3622
+- fix(dropdown):Modifying the Default font size by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3629
+- fix(button):fix button padding in saas model by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3630
+- fix(lang): fix to be compatible with aui by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3628
+- fix(pager): fix pager init current page error by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3640
+- fix(user): an error event is triggered if the user does not exist by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3641
+- fix(grid): grid can not validate on active by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3643
+- fix(grid): fix scroll bar error after load data by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3644
+- fix(file-upload):Unified button text document by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3647
+- fix(tag): restores the default color of the tag to blue by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3646
+- fix(popover): increase the priority of arrow class names by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3645
+- fix(grid): fix target error in shadow dom by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3651
+- fix(tabs): Fix the problem sheet and ensure that the dividing line is fully supported by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3663
+- fix(grid): fix operation buttons render error by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3660
+- fix(tabs): Fix component font size to adapt to new specifications by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3662
+- fix(file-upload): Fix the issue of accept failure when using EDM by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3661
+- fix(popeditor): fix issue #2652 by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3656
+- fix(fluent-editor): Fix click issues with rich text components in Edge browser by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3655
+- fix(grid): fix user passed scrollY value is null by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3658
+- fix(modal): fix issue #3450 by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3650
+- fix(tabs): Fix the issue where multiple clicks on mobile-first tabs do not take effect by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3669
+- fix(pop-upload): Fix uploadTip slot error issue by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3668
+- fix(select): Add tooltip prompts by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3671
+- fix(grid): fix use title function text can not overflow ellipsis by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3670
+- fix(loading): Fix e2e error issue by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3674
+- fix(grid): fix rowspan border can not visible by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3673
+- fix(amount): Fix the issue of inconsistent currency input and display in the table by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3672
+- fix(grid): fix has footer last row border duplicate by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3678
+- fix(select): Fix the issue with the option two-layer prompts by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3680
+- fix(popeditor): fix popeditor's e2e by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3683
+- fix(vue): batch update version to 3.26 by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3684
+- fix(e2e): fix amount's e2e test by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3685
+- fix(build): fix themeSaas build errors, add LESS compilation and error handling, update gulp tasks to enhance readability and debug information by @zzcr in https://github.com/opentiny/tiny-vue/pull/3687
 
-- [Popover component] Popover component loading is optimized.
-- [Tree component] Optimize the highlight effect of the target element when the tree node is dragged.
-- [Pager component] The Go button is dimmed and hovered. The simple mode is optimized. Optimized the display of numbers in the pagination list.
-- [FileUpload] Added the function of hiding the button when the number of uploaded files reaches the limit.
-- [Official website] Added the mapping table of old and new theme variables and the tutorial on replacing old and new theme variables.
-- [Official website] Added the description of the width attribute of the PopEditor component.
-- [Official website] Added the API title of the DropDown component.
-- [Official website] Anchor redirection of the Upload component is fixed.
-- [Official Website] Repair Milestone Title
-- [Official website] Fileupload image upload optimization function
-- [Official website] Optimized the example of hiding pagination when only one page button is available for the pager component. Optimized the style of the buttons on the up and down pages.
+### Other Changes
 
----
+- refactor(site): use next-sdk and next-remoter to intelligentize the official website. by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3657
 
-## v2.4.0/v3.4.0
+## New Contributors
 
-`2023 / 01 / 13`
+- @liangguanhui0117 made their first contribution in https://github.com/opentiny/tiny-vue/pull/3638
 
-###'Destructive Change
+**Full Changelog**: https://github.com/opentiny/tiny-vue/compare/v3.25.0...v3.26.0
 
-- None.
+## v3.25.0/v2.25.0
 
-### New Features
+`2025/07/15`
 
-- [ActionMenu] The ActionMenu component is added.
+## What's Changed
 
-### Defect fixing
+### Exciting New Features 🎉
 
-- [BulletinBoard component] The function of adding more links to the BulletinBoard component is fixed.
-- [CreditCardForm Credit Card Form] Fixed an issue where the latest value cannot be changed when the number is edited when the card number is displayed.
-- [Dropdown component] The visible-change event of the Dropdown component is not triggered.
-- [Grid component] Fixed the issue that the paging setting and style of the personalized panel of the grid component are invalid.
-- [Grid component] Rectify the problem that the big data virtual scroll bar is incorrectly calculated after the setAllTreeExpansion method is executed in a tree table and all rows are expanded.
-- [Popover component] When modelValue of popover is set to true, popover display is triggered by default.
-- [Select component] The option that is selected by default and disabled for multiple selections of the Select component is fixed. The deletion of the option needs to be prohibited.
-- [ToggleMemu component] Fixed the bug that the togglememu component can obtain only the label field.
-- [ToggleMemu component] Discard getMenuDataSync and change it to asynchronous getMenuDataAsync.
+- feat: add svgs by @kagol in https://github.com/opentiny/tiny-vue/pull/3522
+- feat(grid): edit-config add blurOutside by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3521
+- feat(calendar-view): [calendar-view]add attributes by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3525
+- feat(grid): add expand trigger slot by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3518
+- feat(common): use the hotspot function provided by the ArkWeb JS engine to optimize the execution of defineProperties function in the common adaptation layer by @zzcr in https://github.com/opentiny/tiny-vue/pull/3530
+- feat(button): [button] add custom-style attribute by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3535
+- feat: add new hot svg by @kagol in https://github.com/opentiny/tiny-vue/pull/3562
+- feat(grid): add filter root attrs by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3565
+- feat(grid): add tree-node button bubbling setting by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3570
 
-###'Optimization
+### Bug Fixes 🐛
 
-- [Grid component] Added the default table pagination example and optimized the table refresh example.
-- [Grid component] The interaction and style of the table in editing state are consistent with HUAWEI CLOUD specifications.
-- [Grid component] The built-in pagination of tables is optimized. The pagination component can be displayed even when the pagination component is not introduced.
-- [Pager component] Copywriting internationalization of the redirection button of the pagination component
-- [TreeMenu component] In the expanded state, the expanded arrow turns blue only when it is changed to hover. The expanded arrow turns gray when it is moved away.
-- [Official website] Add smart customer service on the homepage
-- [Official Website] Upload Jump Anchor Fix
-- [Official website] The upload code example is optimized.
-- [Official website] Responsive layout adjustment
+- fix(input):Fix the saas theme by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3499
+- fix(date-picker):fix timezone format by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3503
+- fix(tag): tag remove inline-block by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3506
+- fix(modal): add icon status style by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3504
+- fix(loading): fix loading occur error when change frequently by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3513
+- fix(grid): Limit the size attribute value of the paging component to 'mini' or an empty string to prevent warnings by @zzcr in https://github.com/opentiny/tiny-vue/pull/3516
+- fix(anchor): fix anchor roll back issue by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3519
+- fix(theme-saas): refresh theme-saas tailwind token by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3523
+- fix(grid): fix custom setting style error at mobile-first by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3524
+- fix(grid): Fix the table css in saas mode. by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3520
+- fix(grid): fix bug after refactor by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3527
+- fix(file-upload): Fix the issue of uploading components with an empty accept error by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3529
+- fix(grid): fix grid scroll to bottom error when only set max-height by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3531
+- fix(grid): Fix the table css in saas mode by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3532
+- fix(grid): fix resize bar cover by header by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3536
+- fix(cascader): fix When using slots in cascader-panel, the mf template will error by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3537
+- fix(grid): fix drag error when tbody not render by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3538
+- fix(grid): fix scroll to bottom header not visible by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3539
+- fix(tag): resolve the issue of style deviation when tag components have null values under the SaaS theme by @wuyiping0628 in https://github.com/opentiny/tiny-vue/pull/3540
+- fix(grid): fix data undefined in mobile-first by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3541
+- fix(grid): fix tree table children edit revert error by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3542
+- fix: adapt to tree children use splice to add row by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3543
+- fix(examples/sites/demos/apis): 修复 issue #3030 中提到的图表配置项拼写错误 by @Lingchen111 in https://github.com/opentiny/tiny-vue/pull/3547
+- fix(carousel): hide touch screen slideshow demo by @wuyiping0628 in https://github.com/opentiny/tiny-vue/pull/3545
+- fix(grid): fix document does not have getAttribute error by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3548
+- fix(input): fix the problem of one more redraw caused by the immediate parameter by @zzcr in https://github.com/opentiny/tiny-vue/pull/3544
+- fix(grid): fix cell click event error on edit mode by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3549
+- fix(grid): fix popper edit element blur when set edit-config blurOutside by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3550
+- fix(autocomplete,search,base-select,cascader,date-panel, date-range,date-picker,dropdown,input,select,tree): The component under the shadowRoot node event is invalid. by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3546
+- fix(modal\notify): modifying the Color of the Information Icon in the SaaS File by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3552
+- fix(vue-common): [icon]resolves the loading icon after multiple calls to render function nesting levels by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3554
+- fix(autocomplete): add title native attributes by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3555
+- fix(grid): fix grid header divider error by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3558
+- fix(tree-menu): adjusting the input box of the tree menu component can clear the symbol position by @wuyiping0628 in https://github.com/opentiny/tiny-vue/pull/3561
+- fix(grid): fix dirty flag not clear after refreshData by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3560
+- fix: fix login typo by @kagol in https://github.com/opentiny/tiny-vue/pull/3564
+- fix(grid): clear input value after click custom extend item by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3563
+- fix(pager): fix init pager-size error when not match page-sizes by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3566
+- fix(grid): fix right position error when resize multi header grid by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3569
+- fix(milestone):fix the milestone color matching logic is in saas mode. by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3568
+- fix(auto-tip): fixed the bug that a message is displayed on the page when the element displayed in the tooltip needs to be removed and uninstalled. by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3574
+- fix(tag): When the tag is a space, the tag is misplaced in the form scenario by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3572
+- fix(grid):fix filter icon size in saas mode by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3576
+- fix(input):fix the textarea height in single row by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3573
+- fix(theme): fix dark theme in shadow dom by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3579
+- fix(grid): add grid radio class name by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3578
+- fix(select): update select's e2e test for grid update by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3577
+- fix(input):fix single row textarea in saas mode by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3580
+- fix(base-select): fix e2e test case error by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3581
+- fix(color-select-panel): 颜色类型选择下拉框样式异常 by @vaebe in https://github.com/opentiny/tiny-vue/pull/3575
+- fix(date-picker):date-range should return an empty array when click clear button by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3582
+- fix(select): fix select's e2e by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3584
 
----
+### Other Changes
 
-## v2.3.0/v3.3.0
+- refactor: optimize table performance and refactor the table by @zzcr in https://github.com/opentiny/tiny-vue/pull/3514
 
-`2022 / 12 / 16`
+## New Contributors
 
-###'Destructive Change
+- @Lingchen111 made their first contribution in https://github.com/opentiny/tiny-vue/pull/3547
 
-- None.
+## v3.24.0/v2.24.0
 
-### New Features
+`2025/06/12`
 
-- The verticalOffset attribute is added to the Notify component.
-- [FormItem component] Add the validate-icon attribute to FormItem.
-- The searchable attribute is added to the Select component. You can search for information in the lower pane.
-- [Official website] Add English documents and switch between Chinese and English.
-- [Official Website] Added the customized configuration document for internationalization.
+## What's Changed
 
-### Defect fixing
+### Exciting New Features 🎉
 
-- [RadioGroup] The problem that the value assigned to a class is not rendered to the DOM is resolved.
-- [Notify component, which solves the problem that a new component will overlap with an existing component if a component disappears after consecutive clicks.
-- [Slider component] Modify the text position of the slider.
-- [Search component] Fixed the issue that v-model values cannot be updated in real time. To listen to real-time changes of input values, use the @update:modelValue event.
-- [TreeMenu component] Restore the background color of the treemenu when it is hovering.
-- [Grid component] Fixed an issue where the position of the scroll bar is incorrectly calculated for the table component in a multi-layer tree table structure.
-- [Grid component] Fixed an issue where the multi-field sorting function of the table component is invalid.
-- [Grid Component] Fixed an issue where the table component invokes the clear filter method, but the filter parameter in the fetchData parameter still exists.
-- [Official website] Fixed an issue where the anchor point of the left component jumps in the internationalization function.
+- feat(pager): reconstruct the multi-terminal template of the pager component from the vue template by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3422>
+- feat(steps): Add style functionality for multi terminal custom step blocks by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3435>
+- feat(dialog-select): add support for clear and delete events, update related documents and sample codes by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3437>
+- feat(qr-code): Add the necessary attributes to the responsive by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3456>
+- feat(common): add support for MCP configuration in component setup by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3469>
+- feat(site): add the tiny-robot drawer to the official website. by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3467>
+- feat(dialog-select): [dialog-select] add attribute lock-scroll by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/3489>
+- feat(popeditor): [popeditor] add attribute lock-scroll by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/3490>
+- feat(grid): optimize mcp configuration usage and sample code by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3494>
 
-###'Optimization
+### Bug Fixes 🐛
 
-- [Notify component] style optimization
-- Deleted the description of the size attribute from the FileUpload component.
-- [Popover component] Added the document update of the height attribute.
-- [Message component] Modify the height of a message.
-- [Icon component] Add the corresponding class for the icon.
-- [Official website] Compression of larger sample images in vue documents
-- [Official website] Underline is added to the open-source official website, and the native scroll bar hovers.
-- [Official Website] Open the Update Log Menu on Open Source Websites
-- [Official website] Remove the top progress bar during route switchover.
-- [Official website] Optimize the theme color of the website
+- fix(file-upload): Fix bug in file-upload component where multiple selections are merge-service and uploaded by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3424>
+- fix(steps): Modify the multi terminal rendering logic and style of steps by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3441>
+- fix(drowdown): add tiny-\* className to drowdown-menu's wrapper dom by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3445>
+- fix(select): fix can not set grid rowId in select by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3448>
+- fix(tree-menu): change the color of the dark mode icon by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/3457>
+- fix(tiny-split):The panel split animation is not displayed properly by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3452>
+- fix(search): Fix the margin issue of multi terminal mode dropdown type by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3453>
+- fix(icon):Fixed the icon color issue in dark mode by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3460>
+- fix(autocomplete): autocomplete component defaults to 100% of the width by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3462>
+- fix(tag): theme saas warning token value refresh, tag component style specification refresh by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/3463>
+- fix(form): fix the textarea style issue under the form by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/3468>
+- fix(select): fix the malfunction of the select component when automatically pulling down focus by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3464>
+- fix(robot): add the role message markdown and upgrade the tiny-robot version by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3471>
+- fix(basic-usage): update SSE URL to use HTTPS for secure connection by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3472>
+- fix(date-picker):fix the init panel width and month name by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3466>
+- fix: the issue of modifying line breaks for display by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/3470>
+- fix(grid): increase the length of drag and drop lines in the grid and remove empty values when filtering by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/3475>
+- fix(robot): add examples of Perfecting AI Agents by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3476>
+- fix(dialog):fix dialog title line-height by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3477>
+- fix(icon):delete the iconPushPinSolid default color by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3479>
+- fix(calendar-view):fix the E2E test by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3483>
+- fix(robot): optimized the example and added sessions and UI adjustment. by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3484>
+- fix(robot): add the API tab of the MCP and adjust the display control of the robot. by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3485>
+- fix(package): update @opentiny/tiny-vue-mcp version to 0.0.1-alpha.1 by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3487>
+- fix(robot): message processing of the robot is optimized. by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3491>
+- fix(select): modify the DOM structure of all options in the select to be consistent with that of the regular options to solve the text alignment issue by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3488>
+- fix(grid): add a border to the last row of the grid under the saas theme by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/3492>
 
----
+## New Contributors
 
-## v2.2.0/v3.2.0
-
-`2022 / 12 / 2`
-
-###'Destructive Change
-
-- None.
-
-### New Features
-
-- The visible attribute is added to the Tooltip component.
-- The options, textField, and select events are added to the Breadcrumb component. The breadcrumb component supports profiles!
-- The label attribute and select event are added to the BreadcrumbItem component.
-- [Dropdown component] Added the menuOptions and title attributes. The drop-down menu component supports profiles!
-- The options and textField attributes are added to the DropdownMenu component.
-- [DropdownItem component] Added the label attribute.
-- [Notify component] The debounceDelay attribute is added to enable the anti-jitter function.
-
-### Defect fixing
-
-- [Search component] Fixed an issue where the height is incorrect due to layout modification. Default theme 30px, unlimited theme 32px
-- [Pager component] Fixed an issue where the display is abnormal in the webcomponents environment.
-- [Popover component] Fixed an issue where the display is abnormal in the webcomponents environment.
-- [Form component] Fixed an issue where an error is reported during form validation in the webcomponents environment.
-- [Form component] Fixed the align-lable style problem.
-- [Chart component] The extend configuration is partially invalid.
-
----
-
-## v2.1.0/v3.1.0
-
-`2022/10/31`
-
-### 📢 Breaking changes
-
-- Remove the `rich-text` component, because the third-party plug-in `quill` introduced by the component is an overdue high-risk dependency, and if you want to continue to use it, you can use the old version: `@opentiny/vue-rich-text@3.0.0`
-
-### ✨ New characteristics
-
-- The TinyVue component library supports type declarations and can be used normally in projects`typescript`
-- TinyVue component library has completed the theme configuration transformation of multiple components, and currently provides two sets of default themes: default theme and unlimited theme
-- [Added Dropdown dropdown drop-down component](https://rnd-think.huawei.com/tiny-vue/zh-CN/os-theme/components/dropdown)
-- [Added the Notify notification component](https://rnd-think.huawei.com/tiny-vue/zh-CN/os-theme/components/notify)
-
-### 🐞 Bug fixes
-
-- Tabs component, which solves the bug of uneven underline pairs of titles
-- Numeric counter component, fixed the bug that when the mouse wheel scrolls to change the value, the scroll bar of the page will also scroll with it
-- Grid table, fix the bug that merged cells and overflow was added to the table column, resulting in style exceptions
-- Grid table, fix the bug that the table data does not change after binding a static data source (array), push, splice and other operations
-- DatePicker date picker, fix the bug that the time zone selection drop-down box cannot come out
-- Select component, fix the bug of creating an entry, creating an entry selected, and then re-creating the checked, or the last selected data selected
-- Slider widget to solve the bug that cannot be dragged
-
----
-
-## v2.0.0/v3.0.0
-
-`2022/09/19`
-
-### 📢 Breaking changes
-
-not
-
-### ✨ New characteristics
-
-- [Select component to add the scroll event](http://3ms.huawei.com/hi/group/3955273/thread_9057711.html?mapId=10888105&t_type=ask)
-
-### 🐞 Bug fixes
-
-- [Search component, fixed the issue that the change event fired 2 times](http://3ms.huawei.com/hi/group/3955273/thread_9057203.html?mapId=10887597&t_type=ask)
-- [Tabs component, fix the tab component set tab component, the internal tab item will show the bug on the outer tab](https://codehub-g.huawei.com/Tiny/TinyComponent/tiny-vue/issues/14)
-- [PopEditor' component, which solves the problem that the query conditions in the pop-up box cannot be entered](http://3ms.huawei.com/hi/group/3955273/thread_9057057.html?mapId=10887445&t_type=ask)
-- Cascader component, which solves the problem of clicking on the selected option to close the selector
-- RichText component, which solves the problem of console error reporting when quickly deleting variables through v-model
+- @afkdsghk211331 made their first contribution in <https://github.com/opentiny/tiny-vue/pull/3447>

--- a/examples/sites/demos/pc/webdoc/changelog.md
+++ b/examples/sites/demos/pc/webdoc/changelog.md
@@ -4,6 +4,173 @@ Tiny Vue 团队在正常情况下使用 每月 发布策略。
 
 在此页面上，您只能看到我们的 更新日志 最新三个迭代的日志记录，如您要查看完整记录可以查看：[Release](https://github.com/opentiny/tiny-vue/releases)
 
+## v3.26.0/v2.26.0
+
+`2025/09/15`
+
+## What's Changed
+
+### Exciting New Features 🎉
+
+- feat(steps): Add wizard style step bar itemStyle differentiated configuration by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3594
+- feat(color-picker): refactoring the ColorPicker component style by @wuyiping0628 in https://github.com/opentiny/tiny-vue/pull/3595
+- feat: modify the resource file loading mode and add postcss plugin configuration. by @zzcr in https://github.com/opentiny/tiny-vue/pull/3615
+- feat(site): connect next-sdk and ai dialog box to realize dynamic switching routing function of large models by @zzcr in https://github.com/opentiny/tiny-vue/pull/3619
+- feat(grid): saas theme add filter select style by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3626
+- feat(grid): add cascader full width grid by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3627
+- feat(button): add a list of theme tokens to the component documentation by @wuyiping0628 in https://github.com/opentiny/tiny-vue/pull/3631
+- feat(silder-button): add displayed attribute by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3639
+- feat: Add table configuration slot example usage by @zzcr in https://github.com/opentiny/tiny-vue/pull/3649
+- feat(cascader): Add the tooltip function for cascading panels by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3665
+- feat(search): Add mini search box expansion and retraction hook callback API by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3664
+- feat(tabs): add header-only by @liangguanhui0117 in https://github.com/opentiny/tiny-vue/pull/3638
+
+### Bug Fixes 🐛
+
+- fix(dropdown):Fix the drop-down component menu spacing. by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3586
+- fix: adapt mf list view when has not grid column by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3593
+- fix(select):Fix default multi-select tags color by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3591
+- fix(calendar-view):fix calendar view height setting does not take effect by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3592
+- fix: hot and new icon fill cannot transparent transmission by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3599
+- fix(modal): [modal] modify the messageClosable in Vue2 version to not display the close button by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3600
+- fix: internationalization-related modifications, temporarily hide the entry point by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3597
+- fix(tabs): Optimize multi terminal caching logic, add add add delete operations to trigger sub component destruction and reconstruction logic by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3601
+- fix(grid): Modify the spacing between the sorting buttons in saas mode. by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3603
+- fix(grid): grid promise validate return value back to undefined by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3616
+- fix(grid,pager,cascader):Fixed the icon reference issue in the SaaS mode table. by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3618
+- fix(grid): optimize render count by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3613
+- fix(dropdown): modify the responsive adaptation of the drop-down arrow in the mobile first template by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3614
+- fix(chart): fix chart bug, resolve memory leakage issues by @Davont in https://github.com/opentiny/tiny-vue/pull/3610
+- fix(input):fix textarea height in saas model by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3608
+- fix(site): add MCP tools for query examples and jump examples by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3623
+- fix(PropType): fix import of PropType by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3620
+- fix(input): add pre=true for tiny-tooltip by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3625
+- fix(input):fix textarea height in Multiple line placeholders by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3624
+- fix(grid): fix index not update at drag row by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3622
+- fix(dropdown):Modifying the Default font size by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3629
+- fix(button):fix button padding in saas model by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3630
+- fix(lang): fix to be compatible with aui by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3628
+- fix(pager): fix pager init current page error by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3640
+- fix(user): an error event is triggered if the user does not exist by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3641
+- fix(grid): grid can not validate on active by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3643
+- fix(grid): fix scroll bar error after load data by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3644
+- fix(file-upload):Unified button text document by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3647
+- fix(tag): restores the default color of the tag to blue by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3646
+- fix(popover): increase the priority of arrow class names by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3645
+- fix(grid): fix target error in shadow dom by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3651
+- fix(tabs): Fix the problem sheet and ensure that the dividing line is fully supported by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3663
+- fix(grid): fix operation buttons render error by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3660
+- fix(tabs): Fix component font size to adapt to new specifications by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3662
+- fix(file-upload): Fix the issue of accept failure when using EDM by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3661
+- fix(popeditor): fix issue #2652 by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3656
+- fix(fluent-editor): Fix click issues with rich text components in Edge browser by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3655
+- fix(grid): fix user passed scrollY value is null by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3658
+- fix(modal): fix issue #3450 by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3650
+- fix(tabs): Fix the issue where multiple clicks on mobile-first tabs do not take effect by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3669
+- fix(pop-upload): Fix uploadTip slot error issue by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3668
+- fix(select): Add tooltip prompts by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3671
+- fix(grid): fix use title function text can not overflow ellipsis by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3670
+- fix(loading): Fix e2e error issue by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3674
+- fix(grid): fix rowspan border can not visible by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3673
+- fix(amount): Fix the issue of inconsistent currency input and display in the table by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3672
+- fix(grid): fix has footer last row border duplicate by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3678
+- fix(select): Fix the issue with the option two-layer prompts by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3680
+- fix(popeditor): fix popeditor's e2e by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3683
+- fix(vue): batch update version to 3.26 by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3684
+- fix(e2e): fix amount's e2e test by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3685
+- fix(build): fix themeSaas build errors, add LESS compilation and error handling, update gulp tasks to enhance readability and debug information by @zzcr in https://github.com/opentiny/tiny-vue/pull/3687
+
+### Other Changes
+
+- refactor(site): use next-sdk and next-remoter to intelligentize the official website. by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3657
+
+## New Contributors
+
+- @liangguanhui0117 made their first contribution in https://github.com/opentiny/tiny-vue/pull/3638
+
+**Full Changelog**: https://github.com/opentiny/tiny-vue/compare/v3.25.0...v3.26.0
+
+## v3.25.0/v2.25.0
+
+`2025/07/15`
+
+## What's Changed
+
+### Exciting New Features 🎉
+
+- feat: add svgs by @kagol in https://github.com/opentiny/tiny-vue/pull/3522
+- feat(grid): edit-config add blurOutside by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3521
+- feat(calendar-view): [calendar-view]add attributes by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3525
+- feat(grid): add expand trigger slot by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3518
+- feat(common): use the hotspot function provided by the ArkWeb JS engine to optimize the execution of defineProperties function in the common adaptation layer by @zzcr in https://github.com/opentiny/tiny-vue/pull/3530
+- feat(button): [button] add custom-style attribute by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3535
+- feat: add new hot svg by @kagol in https://github.com/opentiny/tiny-vue/pull/3562
+- feat(grid): add filter root attrs by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3565
+- feat(grid): add tree-node button bubbling setting by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3570
+
+### Bug Fixes 🐛
+
+- fix(input):Fix the saas theme by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3499
+- fix(date-picker):fix timezone format by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3503
+- fix(tag): tag remove inline-block by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3506
+- fix(modal): add icon status style by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3504
+- fix(loading): fix loading occur error when change frequently by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3513
+- fix(grid): Limit the size attribute value of the paging component to 'mini' or an empty string to prevent warnings by @zzcr in https://github.com/opentiny/tiny-vue/pull/3516
+- fix(anchor): fix anchor roll back issue by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3519
+- fix(theme-saas): refresh theme-saas tailwind token by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3523
+- fix(grid): fix custom setting style error at mobile-first by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3524
+- fix(grid): Fix the table css in saas mode. by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3520
+- fix(grid): fix bug after refactor by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3527
+- fix(file-upload): Fix the issue of uploading components with an empty accept error by @chenxi-20 in https://github.com/opentiny/tiny-vue/pull/3529
+- fix(grid): fix grid scroll to bottom error when only set max-height by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3531
+- fix(grid): Fix the table css in saas mode by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3532
+- fix(grid): fix resize bar cover by header by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3536
+- fix(cascader): fix When using slots in cascader-panel, the mf template will error by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3537
+- fix(grid): fix drag error when tbody not render by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3538
+- fix(grid): fix scroll to bottom header not visible by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3539
+- fix(tag): resolve the issue of style deviation when tag components have null values under the SaaS theme by @wuyiping0628 in https://github.com/opentiny/tiny-vue/pull/3540
+- fix(grid): fix data undefined in mobile-first by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3541
+- fix(grid): fix tree table children edit revert error by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3542
+- fix: adapt to tree children use splice to add row by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3543
+- fix(examples/sites/demos/apis): 修复 issue #3030 中提到的图表配置项拼写错误 by @Lingchen111 in https://github.com/opentiny/tiny-vue/pull/3547
+- fix(carousel): hide touch screen slideshow demo by @wuyiping0628 in https://github.com/opentiny/tiny-vue/pull/3545
+- fix(grid): fix document does not have getAttribute error by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3548
+- fix(input): fix the problem of one more redraw caused by the immediate parameter by @zzcr in https://github.com/opentiny/tiny-vue/pull/3544
+- fix(grid): fix cell click event error on edit mode by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3549
+- fix(grid): fix popper edit element blur when set edit-config blurOutside by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3550
+- fix(autocomplete,search,base-select,cascader,date-panel, date-range,date-picker,dropdown,input,select,tree): The component under the shadowRoot node event is invalid. by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3546
+- fix(modal\notify): modifying the Color of the Information Icon in the SaaS File by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3552
+- fix(vue-common): [icon]resolves the loading icon after multiple calls to render function nesting levels by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3554
+- fix(autocomplete): add title native attributes by @James-9696 in https://github.com/opentiny/tiny-vue/pull/3555
+- fix(grid): fix grid header divider error by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3558
+- fix(tree-menu): adjusting the input box of the tree menu component can clear the symbol position by @wuyiping0628 in https://github.com/opentiny/tiny-vue/pull/3561
+- fix(grid): fix dirty flag not clear after refreshData by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3560
+- fix: fix login typo by @kagol in https://github.com/opentiny/tiny-vue/pull/3564
+- fix(grid): clear input value after click custom extend item by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3563
+- fix(pager): fix init pager-size error when not match page-sizes by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3566
+- fix(grid): fix right position error when resize multi header grid by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3569
+- fix(milestone):fix the milestone color matching logic is in saas mode. by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3568
+- fix(auto-tip): fixed the bug that a message is displayed on the page when the element displayed in the tooltip needs to be removed and uninstalled. by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3574
+- fix(tag): When the tag is a space, the tag is misplaced in the form scenario by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3572
+- fix(grid):fix filter icon size in saas mode by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3576
+- fix(input):fix the textarea height in single row by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3573
+- fix(theme): fix dark theme in shadow dom by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3579
+- fix(grid): add grid radio class name by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3578
+- fix(select): update select's e2e test for grid update by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3577
+- fix(input):fix single row textarea in saas mode by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3580
+- fix(base-select): fix e2e test case error by @gimmyhehe in https://github.com/opentiny/tiny-vue/pull/3581
+- fix(color-select-panel): 颜色类型选择下拉框样式异常 by @vaebe in https://github.com/opentiny/tiny-vue/pull/3575
+- fix(date-picker):date-range should return an empty array when click clear button by @discreted66 in https://github.com/opentiny/tiny-vue/pull/3582
+- fix(select): fix select's e2e by @shenjunjian in https://github.com/opentiny/tiny-vue/pull/3584
+
+### Other Changes
+
+- refactor: optimize table performance and refactor the table by @zzcr in https://github.com/opentiny/tiny-vue/pull/3514
+
+## New Contributors
+
+- @Lingchen111 made their first contribution in https://github.com/opentiny/tiny-vue/pull/3547
+
 ## v3.24.0/v2.24.0
 
 `2025/06/12`
@@ -55,390 +222,3 @@ Tiny Vue 团队在正常情况下使用 每月 发布策略。
 ## New Contributors
 
 - @afkdsghk211331 made their first contribution in <https://github.com/opentiny/tiny-vue/pull/3447>
-
-## v2.23.0/v3.23.0
-
-`2025/05/21`
-
-## What's Changed
-
-### Exciting New Features 🎉
-
-- feat(number-animation): Add NumberAnimation component by @lcy0620 in <https://github.com/opentiny/tiny-vue/pull/3301>
-- feat(design-config): design-config adds arbitrary attribute features of global configuration components by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3419>
-- feat(config-provider): config-provider adds theme configuration function by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3353>
-- feat(release): add vue3 version option to release:aurora command and update related logic by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3280>
-- feat(calendar-view):[calendar-view]The calendar view tip time support configure by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3274>
-- feat:[calendar-view]The calendar view supports click events by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3279>
-- feat(popconfirm): [popconfirm] enable message slot by @betavs in <https://github.com/opentiny/tiny-vue/pull/3176>
-- feat(transfer): [transfer] adds the ability to customize the panel width for the transfer component by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3285>
-- feat(date-picker):[date-picker]The first selected date will be displayed in the output box. by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3300>
-- feat(card-group): modify saas style by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/3305>
-- feat(card-group): modify sass style by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/3310>
-- feat(vue-hooks): add type annotations to multiple files to enhance type safety by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3302>
-- feat: [tabs] Add left button for mobile-first mode by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3317>
-- feat: [form] add type definitions to utils to enhance type safety by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3322>
-- feat: Add utils test commands and add utils package change check in CI by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3327>
-- feat: [input]update E2E test workflow to automatically detect changed components by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3331>
-- feat(grid): the renderer configuration of the table supports events event collections by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3342>
-- feat(flowchart): add automatic prompt instructions so that prompt pop-ups will appear when necessary by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3360>
-- feat(flowchart): Add the property configuration to display the hand-shaped mouse function by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3366>
-- feat(dialog-select): supports transparent transmission of selectAll, selectChange and radioChange events by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3398>
-- feat(calendar-view):The schedule mode support hidden the time by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3405>
-- feat(calendar-view):Mobile-first supports the hidden time in schedule mode. by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3408>
-- feat(modal): change the text size from md to default by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/3412>
-
-### Bug Fixes 🐛
-
-- fix: [file-upload] Fix font style issue in file list by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3266>
-- fix(grid): [grid] resolve the issue of empty icon by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/3269>
-- fix:[time-picker] fix e2e test by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3272>
-- fix(collapse): adjust the padding style within the mobile-first component to optimize the visual effect by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3267>
-- fix(grid): [grid] fix viewType change table column width error by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3273>
-- fix(transfer): [transfer] fixed a bug in the tree mode of transfer by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3277>
-- fix(input): [input] fix input text word no break after warp span by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3281>
-- fix: [file-upload] Optimize the position of mobile icons by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3278>
-- fix(grid): [grid] fix modal not import by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3283>
-- fix(card-group): [card-group] add empty icon by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/3299>
-- fix(grid): [grid] fix not import error by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3306>
-- fix(tree): [tree] elevate the priority #3119 by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/3284>
-- fix(date-picker):[date-picker]Fix partially disabled in the same year year not selectable by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3307>
-- fix:[docs]Hide the plus document drill field button by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3309>
-- fix: modifying the tree-menu component document #3069 by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/3314>
-- fix(button): fixed the border color and text color of the multi-ended button disabled button by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3311>
-- fix: modifying the steps component document #3076 by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/3312>
-- fix: [file-upload] Fix the bug of uncontrollable file name length in SaaS mode and mobile first mode by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3318>
-- fix(picker): range-picker add tabindex by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3313>
-- fix: modifying the tag component document #3074 by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/3315>
-- fix(from-item): fixed the problem that there would be an extra space in template compilation under vue2 by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3316>
-- fix(tag): fix tag component multi-terminal template running error by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3320>
-- fix: [fluent-editor] Fix the issue where tables can still be edited when disabled by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3297>
-- fix(form): fix form-item margin bottom by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3319>
-- fix: fix textarea displayOnly word break by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3330>
-- fix(numeric): in the mobilefirst of the numeric component, the default width is set to fill the available space by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3326>
-- fix(autocomplete): [autocomplete] fix dispatch form-item validate error by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3329>
-- fix(grid): [grid]Fixed the problem of invalid event monitoring for configuration table selection by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3328>
-- fix(numeric): [numeric] fixed the issue that numberic reported an error when processing scientific notation with BigInt syntax by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3325>
-- fix(tree-select): [base-select, tree-select] fix deleteTag not working by @kagol in <https://github.com/opentiny/tiny-vue/pull/3332>
-- fix(picker): [date-picker]enhance the compatibility of the date picker on mobile and PC, add isPCMode parameter to control the display logic by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3336>
-- fix(form): fix small size form validation position by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3334>
-- fix(grid): [grid] fix input no cursor when dropConfig set filter by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3343>
-- fix(grid): [grid] fix grid overflow-scroll when browser scale by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3341>
-- fix(grid): [grid] fix grid not visible at custom apply by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3339>
-- fix(transfer): fix the default selection does not checked in the tree component under Vue 2 by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3344>
-- fix(examples): 修正autocomplete案例标题size值与示例文字不符，容易误导用户。 by @sakurajiajia in <https://github.com/opentiny/tiny-vue/pull/3351>
-- fix(grid,dropdown,select, pager,tooltip):fix the saas theme by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3347>
-- fix(grid): fix date-picker input style error in filter panel by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3346>
-- fix(utils): fix tooltip arrow safe padding by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3354>
-- fix(grid,tooltip,select,tag):Fix saas theme by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3358>
-- fix(flowchart): The hand mouse is not displayed when the component node is unavailable, and the error reporting problem of flowchart drill field is fixed by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3356>
-- fix: fix tsconfig paths not working by @kagol in <https://github.com/opentiny/tiny-vue/pull/3362>
-- fix(tooltip,grid):Fix the saas theme by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3361>
-- fix: [grid] Add a scroll bar at the bottom of the SaaS theme table to be placed inside the table, with only one border at the bottom by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3365>
-- fix(input): [input] modify the border issue of the input component under the saas theme by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/3367>
-- fix(grid): [grid] modify the size of the grid component header icon under the saas theme by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/3370>
-- fix(time-spinner): [time-spinner] fix startDate & endDate prop type issue when isRan… by @Darkingtail in <https://github.com/opentiny/tiny-vue/pull/3296>
-- fix: [image] Fixed the bug of previewing large blank images during asynchronous initialization operations by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3371>
-- fix(select): remove the binding of dropStyle to the scrollbar by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3381>
-- fix: modify the SaaS theme style of the dialog-box window by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/3380>
-- fix(cascader): Fixes the issue where cascader components use asynchronous data in hover mode, but cannot accurately locate the selected item when binding value updates by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3374>
-- fix(input): Modify the color of the placeholder in the bottom right corner of the input component textarea type in the SaaS theme by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3375>
-- fix: fixed the problem that fullscreen style would pollute the global by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3379>
-- fix: Fixed the issue of misalignment between the clear and search buttons for four different sizes in mobile first mode of the search component by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3378>
-- fix(utils): fix popper flip error by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3386>
-- fix: Fix the title line height of mobile first steps by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3385>
-- fix(dropdown,tooltip):Fix the saas theme by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3384>
-- fix(textarea): Update the background color and related styles of the counter by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3387>
-- fix(number-animation): add version information for the number animation component and fix the loading error problem under the SaaS theme by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3390>
-- fix(date-picker):Fix the default time zone is not displayed by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3389>
-- fix(theme-saas): add margin-bottom:4px for select-dropdown flip to top by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3388>
-- fix(file-upload): Modify the import method of e2e test case path for file-upload component by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3393>
-- fix(pop-upload): Change the pop-upload e2e test case to ES6 import mode by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3395>
-- fix(site): rewrite the theme of code highlight by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3397>
-- fix(site): use purple for attr's color by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3406>
-- fix(grid):Fix the table bottom border display exception. by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3402>
-- fix(steps): Modify the rendering logic of the steps component based on the design draft by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3399>
-- fix(upload): add the "relative" style to the root node of "upload" by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3409>
-- fix(popper): [tooltip,popover] enhance the isScrollElement function to add judgment on element type and scroll bar by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3411>
-- fix(popeditor): add three slot to popeditor by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3416>
-- fix(export): handle special values ​​in CSV export, ensure null, undefined and NaN are displayed correctly by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3418>
-- fix: fix grid width error when grid has scrollbar by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3421>
-- fix(tooltip): fix tooltip's box-shadow and invalid text of form-item's style by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3420>
-- fix(vue-common): compatible with camel case format and mutton string format of transferred attributes, optimized attribute overwriting logic by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3427>
-- fix(date-picker):Fix the e2e test by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3430>
-- fix(popeditor): fix popeditor can not set grid props by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3431>
-
-### Other Changes
-
-- docs: add hu-qi as a contributor for doc by @allcontributors in <https://github.com/opentiny/tiny-vue/pull/3287>
-- docs: add tsinghua-lau as a contributor for doc by @allcontributors in <https://github.com/opentiny/tiny-vue/pull/3288>
-- docs: add Darkingtail as a contributor for doc by @allcontributors in <https://github.com/opentiny/tiny-vue/pull/3290>
-- docs: add hashiqi12138 as a contributor for bug by @allcontributors in <https://github.com/opentiny/tiny-vue/pull/3291>
-- docs: add discreted66 as a contributor for code by @allcontributors in <https://github.com/opentiny/tiny-vue/pull/3292>
-- docs: add lcy0620 as a contributor for code by @allcontributors in <https://github.com/opentiny/tiny-vue/pull/3293>
-- docs: [anchor] Add offsetTop API documentation and optimize example documentation by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3298>
-- docs: add changelog v3.22.0 by @kagol in <https://github.com/opentiny/tiny-vue/pull/3303>
-- docs: update runtime usage documentation to avoid misleading user by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3368>
-- docs: added configuration examples to improve all TinyVue related dependencies to solve the problem that pnpm projects need to install multiple sub-packages by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3377>
-- docs: add sakurajiajia as a contributor for doc by @allcontributors in <https://github.com/opentiny/tiny-vue/pull/3400>
-- docs: add 552847957 as a contributor for doc by @allcontributors in <https://github.com/opentiny/tiny-vue/pull/3401>
-
-## New Contributors
-
-- @sakurajiajia made their first contribution in <https://github.com/opentiny/tiny-vue/pull/3351>
-- @552847957 made their first contribution in <https://github.com/opentiny/tiny-vue/pull/3352>
-
-## v2.22.0/v3.22.0
-
-`2025/04/07`
-
-## What's Changed
-
-### Exciting New Features 🎉
-
-- feat: Support dark theme🎉 [#2946](https://github.com/opentiny/tiny-vue/pull/2946) [#2948](https://github.com/opentiny/tiny-vue/pull/2948) [#2951](https://github.com/opentiny/tiny-vue/pull/2951) and so on.
-- feat(mobile): optimize the mobile common package name and import path and improve xss dependency by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2777>
-- feat: go through the mobile packaging build and release process and fix the bugs found during the build and release by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2780>
-- feat(theme-mobile): optimize the theme-mobile project css variable names and add undefined css variables by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2782>
-- feat(pager): [pager] add change-compat to control whether trigger cha… by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/2783>
-- feat: add license to mobile components by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2802>
-- feat(dropdown): [dropdown] add visible attribute to support user-defined panel display. by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/2774>
-- feat(tree-menu): [tree-menu] Add static data and unused topic variables for rectification by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/2803>
-- feat: add next/cloud-icons project by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2821>
-- feat(theme-mobile): [button] Adjust the theme of mobile by @MomoPoppy in <https://github.com/opentiny/tiny-vue/pull/2820>
-- feat(vue/image): [image]the image component supports binary stream base64 format by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2829>
-- feat(date-panel): [date-panel,date-picker] DatePicker support using only date panel by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/2818>
-- feat(modal): [modal] add show-close feature by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/2840>
-- feat(image): [image] The image component supports base64 in svg format by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2858>
-- feat(vue-hooks): add hooks package packaging logic by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2866>
-- feat:[date-panel,date-range,date-picker]DatePicker support using only date range panel by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/2869>
-- feat(utils): add a whitelist for xss in rich text components by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2879>
-- feat:[month-range,year-range,date-panel,date-picker]The DatePanel supports the month/year range panel by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/2875>
-- feat(theme): [button] add dark themes, modify other theme variables and component level variables by @MomoPoppy in <https://github.com/opentiny/tiny-vue/pull/2898>
-- feat(theme): add tinyDarkTheme for themeTool and add dark-theme router for sites by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2904>
-- feat(steps): add content-center prop to steps and add two saas icons by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2907>
-- feat(site): the official website adds the function of dynamically switching between light and dark themes by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2911>
-- feat(date-panel):[date-picker,date-panel] DatePanel supports the month and year panels by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/2909>
-- feat: add huicharts runtime and update docs by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2981>
-- feat(progress): [progress] add slot support for custom status icons by @gweesin in <https://github.com/opentiny/tiny-vue/pull/2979>
-- feat(tag): [tag] improve close icon interaction by @gweesin in <https://github.com/opentiny/tiny-vue/pull/3006>
-- feat(grid): [grid] expose getTreeExpandeds function by @gweesin in <https://github.com/opentiny/tiny-vue/pull/2996>
-- feat(grid): [grid] add mobile first empty slot by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3018>
-- feat(calendar): [calendar] add year and month specification demo and tests by @gweesin in <https://github.com/opentiny/tiny-vue/pull/3039>
-- feat(utils): resolve common function ts error by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/2903>
-- feat: Adds variable default value handling in build theme by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3122>
-- feat: base var style adapt shadow-root by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3155>
-- feat: optimize the dark mode switching method, reduce the size of non-dark theme user packages, and add dark theme switching documents by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3153>
-- feat(theme): [select] modify the scrollbar and popper to unify the style by @MomoPoppy in <https://github.com/opentiny/tiny-vue/pull/3160>
-- feat: Add default values to theme variables by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3162>
-- feat(utils): use cursor to add comments, ts type declarations, and vitest test cases to utils functions by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3138>
-- feat(utils): add comments, ts type declarations, and vitest test cases to utils functions by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3154>
-- feat: [file-upload] Add file names to restricted prompt texts by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3171>
-- feat(theme): [tag] adjust the common variable and adapt the tag component by @MomoPoppy in <https://github.com/opentiny/tiny-vue/pull/3173>
-- feat(svg): update svg resource file to adapt dark theme by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3223>
-- feat: [skeleton] Add Skeleton mobile first by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3222>
-- feat(modal): [modal] enhance TINYModal functionality, add type definition andoption interface by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3247>
-- feat(loading): [loading] added type definition and interface of Loading component to optimize loading style processing by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3253>
-- feat(message): add Message component type definition and update the type annotation of the installation method by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3252>
-- feat(notify): [notify] enhance notification function, add type definition and option interface, optimize code structure by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3251>
-
-### Bug Fixes 🐛
-
-- fix(select): [select] fix the problem that both tooltip and title are displayed when the select command is run in display-only mode. by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2772>
-- fix(pager): [pager] fix pager type error by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/2801>
-- fix: modify the mobile layout and click the example/API. The browser address anchor is not defined, the composition code is hidden, and the home page icon is not found by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/2806>
-- fix(e2e): fix all e2e test error by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2811>
-- fix(grid): [grid] fix grid error e2e test by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2815>
-- fix(vue2): fix vue2 dev startup error by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2822>
-- fix(sites): fix the error when installing vue-docs dependencies in pnpm by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2816>
-- fix(grid): [grid] fix amount label wrap bug by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/2828>
-- fix(utils): fixed the issue that the release version of the utils package could not correspond by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2837>
-- fix(dialog-select): fixed an issue where grid data could not be loaded when initially visible was set to true by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2835>
-- fix(color-picker): [color-picker] fix color-picker props valid error by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2841>
-- fix(select): [select] fix component error caused by vue2 deep cleanup memory leak by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2843>
-- fix(e2e): [pop-upload, file-upload] Fix e2e test case errors after internationalization by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/2847>
-- fix(dialog-box): [dialog-box] right pop-up window height style issue by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/2844>
-- fix(grid): [grid] validate successful add return value in promise sense by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/2851>
-- fix(user): [user] fix the issue of incorrect file names in the demo by @MomoPoppy in <https://github.com/opentiny/tiny-vue/pull/2855>
-- fix(load-list): avoid tinyList and tinyTimeLine regisiter twice by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2854>
-- fix(alert): move close icon to center by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2856>
-- fix(time-line-new): [time-line-new] update timeline-new demos ,to avoid compiled error by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2859>
-- fix(dialog-select): [dialog-select] fixed an issue where grid data could not be loaded when initially visible was set to true by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2862>
-- fix(utils): delete the renderless/common directory and adjust all reference paths. by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2849>
-- fix(vue-directive): unify the functions in vue-hooks into double-layer functions and optimize the infinite-scroll function by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2864>
-- fix(vue): modify the correct package dependency by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2865>
-- fix(fluent-editor): [fluent-editor] Fixed the bug where the cursor was out of focus when entering line breaks after modifying the font style of the rich text box by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/2880>
-- fix(select):[select] fix the focus event is triggered and prevent the panel from failing to collapse by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2876>
-- fix(grid): [grid] fix setActiveRow scroll to error position when set visual scroll by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/2878>
-- fix(renderless): restore the removed InfiniteScroll variable by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2882>
-- fix(nav-menu): [nav-menu] fix the e2e error in the nav-menu component by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/2883>
-- fix(radio): [radio] resolve the issue of text wrapping not being centered in radio components by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/2884>
-- fix(huicharts): fix the script error of Huicharts saas theme by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2887>
-- fix(fluent-editor): fix the error problem of vue-fluent-editor introduced in ssr environment by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2888>
-- fix(renderless): fix wrong path of useEventListener by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2894>
-- fix(calendar-view):[calendar-view] Verifying SaaS Theme Modification by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/2886>
-- fix(input): [input] fix textarea word wrap style by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/2896>
-- fix(input): [input] fix textarea word wrap style by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/2899>
-- fix(date-picker):[date-picker] In the disabled state, can click the icon to activate the panel. by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/2900>
-- fix(select): [select] fix state.selected.state is empty object, and can't get the right displayText by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2902>
-- fix(site): add the correct responsive position for .search-box by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2893>
-- fix(tabs): [tabs] Fixed the bug where the use of separators in tabs resulted in misaligned buttons at both ends and separators not being centered by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/2912>
-- fix(card): [card] Style pollution caused by modifying the card component by @Youyou-smiles in <https://github.com/opentiny/tiny-vue/pull/2910>
-- fix: 编译入口名称调整 by @hashiqi12138 in <https://github.com/opentiny/tiny-vue/pull/2914>
-- fix(upload-list):progress props width type issue in upload-list(#2915) by @Darkingtail in <https://github.com/opentiny/tiny-vue/pull/2916>
-- fix(file-upload): [file-upload] Adjust the style of the mobile-first button for uploading components by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/2918>
-- fix(charts): [charts]Pack and remove huicharts files by @Davont in <https://github.com/opentiny/tiny-vue/pull/2897>
-- fix: fix the error when loading chart component by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2921>
-- fix(grid): [grid] Fix bug where dragging and dropping in the expanded state of the table cannot render correctly by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/2901>
-- fix: fix form item not align when set display-only by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/2927>
-- fix(button): [button,tag] fix the display problem of the button and tag components in dark mode by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2928>
-- fix(cascader): [cascader,select] add the changeCompat attribute to the component by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2934>
-- fix(icon): [icon] Fix bug where loading shadow icon size and margin do not comply with specifications by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/2935>
-- fix(button): [select] add button's cssvar and fix select reference slot's problem by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2941>
-- fix(pager): [pager] add Pager component internationalization by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/2939>
-- fix(calendar-view): [calendar-view] modify the configuration of calendar view hours, minutes, and seconds, and adding an attribute by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/2932>
-- fix(cascader): [cascader] fix cascader dont emit change by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2944>
-- fix(dialog-box): [dialog-box] modify the full screen content height of the dialog box component not being fully supported by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/2947>
-- fix: fix form item not align when set display-only by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/2950>
-- fix(grid): [grid] fix gird header tip error show by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/2949>
-- fix(date-picker):[date-picker]Formatted MMMs are displayed as abbreviations, and MMMMs are displayed as full spellings. by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/2945>
-- fix(renderless): [base-select] designConfig 未配置 spacingHeight时高度无法自动计算 by @hashiqi12138 in <https://github.com/opentiny/tiny-vue/pull/2926>
-- fix(site): official website adapts to the dark mode. by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2956>
-- fix: fix grid header style and tabs style in dark mode by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2957>
-- fix: fix tabs background color style in dark mode by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2960>
-- fix: fix mobile first input prepend content wrap by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/2958>
-- fix: fixed the background color of the official website API table expansion by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2962>
-- fix(guide): [guide] resolve the situation where data cannot be bound when editing pop ups in tables by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/2961>
-- fix(site): official website adapts to the dark mode. by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2963>
-- fix(grid): [grid] resolve incomplete display of table icons by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/2966>
-- fix(site): fix source code's highlight color by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2968>
-- fix(datetime-picker): fix datetime-picker's display to flex in mobilefirst by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2969>
-- fix(grid): [grid ] fix grid show overflow tip error when navigator scale by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/2971>
-- fix(renderless): fix renderless publish error and fix button-group apis by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2983>
-- fix(vuerenderless/grid): 支持designConfig中配置tooltip by @hashiqi12138 in <https://github.com/opentiny/tiny-vue/pull/2977>
-- fix(grid): [grid] fix error of grid component and fix huicharts being packaged and excluded by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2994>
-- fix(e2e): [tag-group,skeleton] fix e2e by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/3000>
-- fix(badge): [badge] fixed the incorrect dot badge style for values by @gweesin in <https://github.com/opentiny/tiny-vue/pull/3009>
-- fix(docs):Fixed an issue where plus will display header search and description by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3002>
-- fix(carousel): [carousel] modify color theme variables by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/2999>
-- fix(site): refactor the implementation mode of switch dark theme by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2995>
-- fix(site): remove css nests by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3011>
-- fix(form): fix form array type message by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3017>
-- fix(site): fix header's background color on dark theme by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3019>
-- fix(docs):Modified the TinyVuePlus description. by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3021>
-- fix(calendar-view): [calendar-view] change month type from string to number by @gweesin in <https://github.com/opentiny/tiny-vue/pull/3041>
-- fix(button-group): [button-group] update size prop type and add validator by @gweesin in <https://github.com/opentiny/tiny-vue/pull/3038>
-- fix(docs): modify the path in the chart document by @Davont in <https://github.com/opentiny/tiny-vue/pull/3042>
-- fix(color-select-panel): [color-select-panel] change theme by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/3043>
-- fix(docs): [file-upload] Fix the issue of uploading component documents by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3047>
-- fix(site): document search box adapts to the dark theme. by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3046>
-- fix(utils): add nanoid.ts to utils by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3050>
-- fix(crop): [crop] change theme by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/3015>
-- fix(breadcrumb): [breadcrumb] update size prop type and add validator by @gweesin in <https://github.com/opentiny/tiny-vue/pull/3037>
-- fix(form): [form] modifying form validation sorting issues in asynchronous situations by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/2982>
-- fix(grid): [grid] fix scrollLeft error after header drag resize by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3087>
-- fix: make design parameter optional in getAlias function by @gweesin in <https://github.com/opentiny/tiny-vue/pull/3090>
-- fix(fluent-editor): [fluent-editor] change theme by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/3051>
-- fix(numeric): [numeric] update controls-position prop type and add validator by @gweesin in <https://github.com/opentiny/tiny-vue/pull/3065>
-- fix(input): [input] fix prop types for cols, rows, and input-box-type by @gweesin in <https://github.com/opentiny/tiny-vue/pull/3066>
-- fix(tree-menu): [tree-menu] resolve input box style issues during folding and hover status issues in dark mode by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/3049>
-- fix(site):Fixed the plus official website interface and type document display by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3062>
-- fix(image): [image] fix 'appendToBody' definition placement error by @gweesin in <https://github.com/opentiny/tiny-vue/pull/3067>
-- fix(card): [card] fix card type definition error by @gweesin in <https://github.com/opentiny/tiny-vue/pull/3088>
-- fix(pager): [pager] fix align responsive cannot work and size docs by @gweesin in <https://github.com/opentiny/tiny-vue/pull/3091>
-- fix(file-upload): [file-upload] Fix the issue of incomplete prompts for uploading components by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3095>
-- fix(datePicker):[date-picker]Fix the display of datePicker deletion icon in dark themes. by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3094>
-- fix(input): [input] fixed the abnormal display of the input box back icon in read-only mode by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3096>
-- fix(select): [select] fix the issue where the `dropStyle` attribute of the `select` component is not passed through to the internal `scrollBar` component by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3100>
-- fix(date-picker,steps):[date-picker,steps]Fix the width of the datePicker panel and the background of the step bar under the dark theme by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3110>
-- fix(form): [form] Fix the popper-options page demo style issue by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/3114>
-- fix(docs): fixed the issue that the drop-down panel on the official website does not follow the scrolling by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3113>
-- fix(input): [input] fix size attr with opposite description by @gweesin in <https://github.com/opentiny/tiny-vue/pull/3064>
-- fix(popover): [popover] make popover placement reactive by @gweesin in <https://github.com/opentiny/tiny-vue/pull/3093>
-- fix(nav-menu): [nav-menu] add parent-key prop description by @gweesin in <https://github.com/opentiny/tiny-vue/pull/3101>
-- fix: fix unit test cases cannot be scanned by @gweesin in <https://github.com/opentiny/tiny-vue/pull/3102>
-- fix(grid): [grid] fix grid drag error when set visual scroll by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3112>
-- fix(datepicker):[date-picker]Fix the panel width is abnormal. by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3115>
-- fix(ip-address): [ip-address] fix IPv6 display error when ipValidator not true by @gweesin in <https://github.com/opentiny/tiny-vue/pull/3063>
-- fix(datepicker):[date-picker]year panel disabling does not take effect by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3124>
-- fix(tree): [tree] fix tree node slot radio cannot be displayed by @gweesin in <https://github.com/opentiny/tiny-vue/pull/3117>
-- fix(popper): [tooltip,popover] fix popper doms in custom element, cant get zindex by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3126>
-- fix(transfer): [transfer] add is-filterable className to transfer-panel's root dom by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3127>
-- fix:[icon]Lightning icon hovers the whole blackening by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3132>
-- fix(utils): fix the `crypt` function for missing `await` by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3139>
-- fix(grid): [grid] fix mobile first empty slot by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3140>
-- fix(base-select): [base-select,select] modify test cases by @MomoPoppy in <https://github.com/opentiny/tiny-vue/pull/3141>
-- fix(carousel): [carousel] change demo of theme by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/3149>
-- fix(checkbox-group): sync theme-saas by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3156>
-- fix(tag): [tag,select] tag add maxWidth prop, and select add maxTagWidth prop by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3158>
-- fix: fix features page style by @kagol in <https://github.com/opentiny/tiny-vue/pull/3161>
-- fix(utils): modify the date formatting function, remove redundant parameters and optimize the logic by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3169>
-- fix(popconfirm): add handleDocumentClick to IPopconfirmApi interface by @betavs in <https://github.com/opentiny/tiny-vue/pull/3170>
-- fix(cascader): [cascader] fix component theme by @lcy0620 in <https://github.com/opentiny/tiny-vue/pull/3184>
-- fix(select): [select,base-select,tree-select,slider] fix component style issue by @MomoPoppy in <https://github.com/opentiny/tiny-vue/pull/3177>
-- fix(tooltip): [tooltip] add a default value for the contentMaxHeight property by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3192>
-- fix(calendar-view): [calendar-view] increase the maximum height and overflow handling of calendar-view tooltip content to optimize display effect by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3196>
-- fix(theme-saas): fix theme-saas build error by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3197>
-- fix(grid): [grid] fix grid custom saas tree check event by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3210>
-- fix(grid): [grid] fix duplicate empty when set is-center-empty by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3217>
-- fix(calendar-view): [calendar-view] fix popper cant mouse enter by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3218>
-- fix(tree-select): [tree-select] fix e2e test by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3224>
-- fix:[checkbox,time-line,steps] fix e2e test and icon modification by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3226>
-- fix(calendar-view): [calendar-view] fix e2e erros by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3229>
-- fix(alert): [alert] add variables to icons by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/3236>
-- fix(modal): [modal] modify icon by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/3244>
-- fix: [file-upload,input] Fix the icon color by @discreted66 in <https://github.com/opentiny/tiny-vue/pull/3243>
-- fix(svgs): [select] modify Icon by @MomoPoppy in <https://github.com/opentiny/tiny-vue/pull/3246>
-- fix(query-builder): fix query builder style not align by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3227>
-- fix: fix mobile-first long word bug by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3228>
-- fix(grid): fix grid textarea editor hidden bug by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3230>
-- fix: change mobile-first input suffix and prefix svg color by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3225>
-- fix: [file-upload] Fix the display issue of uploading files without suffixes by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3233>
-- fix(button): fix the issue where the loading attribute of the button's multi-terminal template does not take effect by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/3232>
-- fix(installation): update Vue import path and add TinyVue component example by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3248>
-- fix: Fix SaaS theme packaging error issue by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3250>
-- fix(grid): [grid] add grid no-data icon by @wuyiping0628 in <https://github.com/opentiny/tiny-vue/pull/3257>
-- fix: [search] Fix the problem of the search icon not being centered on MobileFirst by @chenxi-20 in <https://github.com/opentiny/tiny-vue/pull/3259>
-- fix(checkbox): [checkbox,select,base-select] change the checkbox icon and synchronously modify the checkbox style by @MomoPoppy in <https://github.com/opentiny/tiny-vue/pull/3258>
-- fix: fix the error in building the official website and add the default value of the theme by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3262>
-- fix: fix build:runtime script by @kagol in <https://github.com/opentiny/tiny-vue/pull/3263>
-
-### Other Changes
-
-- refactor(mobile): remove @opentiny/mobile-utils package, and add alias path by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2767>
-- refactor(mobile): add d.ts export files for mobile build by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2781>
-- docs: added Vitepress packaging to FAQ section by @James-9696 in <https://github.com/opentiny/tiny-vue/pull/2776>
-- docs: add mobile demo preview by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/2807>
-- refactor(utils): [grid,tree] rename log to logger by @shenjunjian in <https://github.com/opentiny/tiny-vue/pull/2826>
-- docs(tiny-editor): fix TinyEditor website link by @kagol in <https://github.com/opentiny/tiny-vue/pull/2861>
-- docs: convert the mobile demo to the composition-api format by @zzcr in <https://github.com/opentiny/tiny-vue/pull/2873>
-- refactor: refactor mobile site by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/2808>
-- docs: fix plus doc load error by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3016>
-- docs(site): add webpack to parse vue-fluent-editor related dependencies FAQ by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3130>
-- docs: add feature list by @kagol in <https://github.com/opentiny/tiny-vue/pull/3135>
-- docs: optimize feature list page by @kagol in <https://github.com/opentiny/tiny-vue/pull/3137>
-- docs: optimize features of action-menu/alert/anchor and so on by @kagol in <https://github.com/opentiny/tiny-vue/pull/3142>
-- docs: add features of carousel/cascader/checkout and so on by @kagol in <https://github.com/opentiny/tiny-vue/pull/3144>
-- docs: optimize features of dialog-select/divider/drawer and so on by @kagol in <https://github.com/opentiny/tiny-vue/pull/3145>
-- docs: optimize features of guide/image/link and so on by @kagol in <https://github.com/opentiny/tiny-vue/pull/3147>
-- docs: optimize features of popconfirm/popeditor/rate and so on by @kagol in <https://github.com/opentiny/tiny-vue/pull/3150>
-- docs: optimize features of date-picker/dialog-box/dropdown and so on by @kagol in <https://github.com/opentiny/tiny-vue/pull/3151>
-- docs: add XSS whitelist configuration FAQ by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3148>
-- docs(select): [select] add dropdown menu top slot official website documen by @zzcr in <https://github.com/opentiny/tiny-vue/pull/3186>
-- docs(api): [popeditor] update type for popselector by @betavs in <https://github.com/opentiny/tiny-vue/pull/3179>
-- docs(api): [popupload] update type for size by @betavs in <https://github.com/opentiny/tiny-vue/pull/3180>
-- docs(api): [popupload] update description for size by @betavs in <https://github.com/opentiny/tiny-vue/pull/3188>
-- docs(guide): [guide] add show-step property and etc. by @hu-qi in <https://github.com/opentiny/tiny-vue/pull/3189>
-- docs: optimize grid docs by @gimmyhehe in <https://github.com/opentiny/tiny-vue/pull/3215>
-- docs: optimize cloud in the features page by @kagol in <https://github.com/opentiny/tiny-vue/pull/3254>
-- docs: update checkbox icons by @kagol in <https://github.com/opentiny/tiny-vue/pull/3256>
-- docs: add test in the features page by @kagol in <https://github.com/opentiny/tiny-vue/pull/3255>
-- docs: update playground by @kagol in <https://github.com/opentiny/tiny-vue/pull/3264>
-
-## New Contributors
-
-- @hashiqi12138 made their first contribution in <https://github.com/opentiny/tiny-vue/pull/2914>
-- @Darkingtail made their first contribution in <https://github.com/opentiny/tiny-vue/pull/2916>
-- @lcy0620 made their first contribution in <https://github.com/opentiny/tiny-vue/pull/2964>
-- @tsinghua-lau made their first contribution in <https://github.com/opentiny/tiny-vue/pull/2992>
-- @hu-qi made their first contribution in <https://github.com/opentiny/tiny-vue/pull/3189>

--- a/examples/sites/playground/App.vue
+++ b/examples/sites/playground/App.vue
@@ -11,7 +11,7 @@ import logoUrl from './assets/opentiny-logo.svg?url'
 import GitHub from './icons/Github.vue'
 import Share from './icons/Share.vue'
 
-const VERSION = 'tiny-vue-version-3.24'
+const VERSION = 'tiny-vue-version-3.26'
 const NOTIFY_KEY = 'tiny-vue-playground-notify'
 const LAYOUT = 'playground-layout'
 const LAYOUT_REVERSE = 'playground-layout-reverse'
@@ -23,7 +23,7 @@ const isMobileFirst = tinyMode === 'mobile-first'
 const isSaas = tinyTheme === 'saas'
 const isPreview = searchObj.get('openMode') === 'preview' // 是否多端弹窗预览
 
-const versions = ['3.24', '3.23', '3.22']
+const versions = ['3.26', '3.25', '3.24']
 const getVersion = () => {
   if (isPreview) {
     return versions[0]


### PR DESCRIPTION
# PR
推送更新日志和升级playground版本号到release3.26分支上
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Replaced the old Update Log with a new Changelog page showing the latest three releases and a Full Changelog link.
  - Added structured entries for v3.26.0/v2.26.0 and v3.25.0/v2.25.0 with “What’s Changed,” “Exciting New Features,” “Bug Fixes,” “Other Changes,” and “New Contributors.”
  - Standardized English formatting and removed the older v2.23.0/v3.23.0 section.

- Chores
  - Updated the Playground version selector to default to 3.26 and include 3.26, 3.25, and 3.24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->