### PR TITLE
fix(site): the remoter entry on release326 is temporarily shielded.

### DIFF
--- a/examples/sites/src/App.vue
+++ b/examples/sites/src/App.vue
@@ -17,11 +17,11 @@ import { TinyConfigProvider, TinyModal } from '@opentiny/vue'
 import { iconClose } from '@opentiny/vue-icon'
 import { TinyRemoter } from '@opentiny/next-remoter'
 import '@opentiny/next-remoter/dist/style.css'
-import { useTinyRemoter, webMcpSessionId } from './composable/useTinyRemoter'
+import { webMcpSessionId } from './composable/useTinyRemoter'
 
 import useTheme from './tools/useTheme'
 
-useTinyRemoter()
+// useTinyRemoter()
 
 const modalSHow = ref(false)
 const previewUrl = ref(import.meta.env.VITE_PLAYGROUND_URL)


### PR DESCRIPTION
# PR
 暂时屏蔽release326上的remoter入口


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused Tiny Remoter initialization logic to simplify the app’s setup while keeping existing behavior intact.

* **Chores**
  * Cleaned up imports to remove an unused composition function.

No user-facing changes are expected. TinyRemoter continues to render when a session ID is present, and existing functionality remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->