### PR TITLE
fix(tabs): Fix the issue of using both overflow-title and with-close simultaneously

### DIFF
--- a/packages/renderless/src/tab-nav/index.ts
+++ b/packages/renderless/src/tab-nav/index.ts
@@ -429,14 +429,14 @@ export const watchCurrentName =
 export const handleTitleMouseenter =
   ({ state, vm, props }) =>
   (e, title) => {
-    const dom = e.target
-    // 以下逻辑与aui不同，tiny不能通过dom宽度判断是否超出隐藏
-    const el = title?.el
-
     // 如果用户配置了tooltipConfig属性，优先级最高
     if (props.tooltipConfig) {
       return
     }
+
+    const dom = e.target
+    // 以下逻辑与aui不同，tiny不能通过dom宽度判断是否超出隐藏
+    const el = title?.el
 
     if (dom && el && el.scrollWidth > el.offsetWidth) {
       const tooltip = vm.$refs.tooltip

--- a/packages/theme/src/tabs/index.less
+++ b/packages/theme/src/tabs/index.less
@@ -116,7 +116,7 @@
       // 实际页签栏盒子
       &__nav:not(.is-stretch) {
         .@{tabs-prefix-cls}__item__title {
-          display: inline-block;
+          display: block;
           width: 100%;
           white-space: nowrap;
           overflow: hidden;
@@ -1319,7 +1319,6 @@
 
   // 仅渲染头部
   &&--header-only {
-
     &:is(.@{tabs-prefix-cls}--left) {
       width: 120px;
     }
@@ -1343,7 +1342,6 @@
     &.@{tabs-prefix-cls}--bottom .@{tabs-prefix-cls}__header {
       margin-top: 0;
     }
-
   }
 
   // 动效


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted tab title in non-stretch headers to block-level with full width, improving alignment and overflow handling.
  * Minor cleanup in header-only styles (whitespace/brace adjustments).

* **Refactor**
  * Deferred DOM lookups for tooltip on tab title hover to run only when needed; no behavior or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->