### PR TITLE
feat(calendar-view): The date can be specified to a day.

### DIFF
--- a/examples/sites/demos/apis/calendar-view.js
+++ b/examples/sites/demos/apis/calendar-view.js
@@ -6,6 +6,18 @@ export default {
       type: 'component',
       props: [
         {
+          name: 'day',
+          type: 'number',
+          defaultValue: '',
+          desc: {
+            'zh-CN': '指定日期，配合 year、month 使用',
+            'en-US': 'Specify the date, used with year and month'
+          },
+          mode: ['pc', 'mobile-first'],
+          pcDemo: 'basic-usage',
+          mfDemo: 'basic-usage'
+        },
+        {
           name: 'day-times',
           type: 'Array',
           defaultValue: '',

--- a/examples/sites/demos/mobile-first/app/calendar-view/basic-usage.vue
+++ b/examples/sites/demos/mobile-first/app/calendar-view/basic-usage.vue
@@ -1,5 +1,5 @@
 <template>
-  <tiny-calendar-view :events="eventslist" :year="2023" :month="5"> </tiny-calendar-view>
+  <tiny-calendar-view :events="eventslist" :year="2023" :month="5" :day="15"> </tiny-calendar-view>
 </template>
 
 <script>

--- a/examples/sites/demos/pc/app/calendar-view/basic-usage-composition-api.vue
+++ b/examples/sites/demos/pc/app/calendar-view/basic-usage-composition-api.vue
@@ -1,5 +1,5 @@
 <template>
-  <tiny-calendar-view :events="eventslist" :year="2023" :month="5"></tiny-calendar-view>
+  <tiny-calendar-view :events="eventslist" :year="2023" :month="5" :day="15"></tiny-calendar-view>
 </template>
 
 <script setup lang="ts">

--- a/examples/sites/demos/pc/app/calendar-view/basic-usage.vue
+++ b/examples/sites/demos/pc/app/calendar-view/basic-usage.vue
@@ -1,5 +1,5 @@
 <template>
-  <tiny-calendar-view :events="eventslist" :year="2023" :month="5"> </tiny-calendar-view>
+  <tiny-calendar-view :events="eventslist" :year="2023" :month="5" :day="15"> </tiny-calendar-view>
 </template>
 
 <script>

--- a/packages/renderless/src/calendar-view/index.ts
+++ b/packages/renderless/src/calendar-view/index.ts
@@ -307,16 +307,17 @@ function splitEvent(props, event) {
   return result
 }
 
-export const computedSelectDay = ({ state }) =>
-(day) => {
-  if (!day || !day.value || day.disabled) return false
+export const computedSelectDay =
+  ({ state }) =>
+  (day) => {
+    if (!day || !day.value || day.disabled) return false
 
-  if (state.multiSelect) { 
-    return state.selectedDates.includes(day.value)
-  } else{
-    return state.selectedDate === day.value
+    if (state.multiSelect) {
+      return state.selectedDates.includes(day.value)
+    } else {
+      return state.selectedDate === day.value
+    }
   }
-}
 
 export const selectDay =
   ({ props, state, emit, api }) =>
@@ -355,7 +356,7 @@ export const selectDay =
       state.selectedDate =
         day.value.toString().length > 2 ? day.value : `${state.activeYear}-${state.activeMonth}-${day.value}`
       state.showSelectedDateEvents = true
-      
+
       const dateEvent = dealEvents(props, api, [state.selectedDate])
 
       emit('update:modelValue', state.selectedDate)
@@ -364,15 +365,14 @@ export const selectDay =
   }
 
 const dealEvents = (props, api, date) => {
-  return date.map(item => {
+  return date.map((item) => {
     let event = api.getEventByTime(item, props._constants.DAY_START_TIME, props._constants.DAY_END_TIME)
-    event.forEach(e => {
-      delete e.dayArr;
-      delete e.dayNumber;
-    });
+    event.forEach((e) => {
+      delete e.dayArr
+      delete e.dayNumber
+    })
     return event
   })
-  
 }
 
 export const getEventByMonth =
@@ -563,17 +563,24 @@ export const toToday =
   }
 
 export const currentDateChange =
-  ({ state, api }) =>
+  ({ state, api, nextTick }) =>
   (date) => {
     const currentDate = new Date(date)
     const year = currentDate.getFullYear()
     const month = currentDate.getMonth() + 1
+    const day = currentDate.getDate()
 
     state.activeMonth = month
     state.activeYear = year
+
+    // 更新当前日期状态
+    state.currentDate = `${year}-${month}-${day}`
+
     if (state.mode !== 'month') {
-      api.getAllWednesdaysInMonth(currentDate)
-      api.getAllDatesOfCurrWeek(state.monthWednesdays[0])
+      // 对于非月份模式，直接使用传入的日期初始化周历
+      nextTick(() => {
+        api.initWeeklyCalendar(currentDate)
+      })
     }
   }
 

--- a/packages/renderless/src/calendar-view/vue.ts
+++ b/packages/renderless/src/calendar-view/vue.ts
@@ -124,11 +124,17 @@ const initState = ({ reactive, props, computed, api, images, modesIcon }) => {
     multiSelect: computed(() => props.multiSelect),
     cascaderVisible: false,
     eventTipContent: {},
-    activeYear: props.year,
+    activeYear: props.year || new Date().getFullYear(),
     displayMode: props.mode,
-    activeMonth: props.month,
-    currentDate: props.year + '-' + props.month,
-    cascaderCurrent: [props.year || new Date().getFullYear(), props.month || new Date().getMonth + 1],
+    activeMonth: props.month || new Date().getMonth() + 1,
+    dateType: computed(() => (!props.day ? 'month' : 'date')),
+    currentDate:
+      props.year && props.month && props.day
+        ? `${props.year}-${props.month}-${props.day}`
+        : props.year && props.month
+          ? `${props.year}-${props.month}`
+          : `${new Date().getFullYear()}-${new Date().getMonth() + 1}-${new Date().getDate()}`,
+    cascaderCurrent: [props.year || new Date().getFullYear(), props.month || new Date().getMonth() + 1],
     cascaderOptions: computed(() => api.computeCascaderOptions()),
     calendar: computed(() => api.computedCalendar('cur')),
     prevCalendar: computed(() => api.computedCalendar('prev')),
@@ -157,6 +163,10 @@ const initWatch = ({ watch, props, state, emit, api, nextTick }) => {
     () => state.mode,
     (val) => {
       emit('mode-change', val)
+      // 切换到周视图时，主动跳转到currentDate对应的周
+      if (val !== 'month') {
+        api.getAllDatesOfCurrWeek(state.currentDate)
+      }
       if (val === 'schedule') {
         api.getCurWeekEvent()
       }
@@ -282,7 +292,7 @@ const initApi = ({ vm, api, state, t, props, emit, nextTick }) => {
     initWeeklyCalendar: initWeeklyCalendar({ api, state }),
     getDatesOfPreviousWeek: getDatesOfPreviousWeek({ api, state }),
     getDatesOfNextWeek: getDatesOfNextWeek({ api, state }),
-    currentDateChange: currentDateChange({ api, state }),
+    currentDateChange: currentDateChange({ api, state, nextTick }),
     newSchedule: newSchedule({ emit }),
     getPrevWeek: throttle(50, true, getPrevWeek({ api, state, emit })),
     getNextWeek: throttle(50, true, getNextWeek({ api, state, emit })),

--- a/packages/vue-locale/src/lang/en.ts
+++ b/packages/vue-locale/src/lang/en.ts
@@ -776,7 +776,8 @@ export default {
       noSchedule: 'No Schedule',
       year: '',
       month: '',
-      dateFormat: 'yyyy-MM'
+      dateFormat: 'yyyy-MM-dd',
+      monthFormat: 'yyyy-MM'
     },
     selectedBox: {
       select: 'Selected (%s)',

--- a/packages/vue-locale/src/lang/es-LA.ts
+++ b/packages/vue-locale/src/lang/es-LA.ts
@@ -780,7 +780,8 @@ export default {
       noSchedule: 'Sin programación',
       year: '',
       month: '',
-      dateFormat: 'yyyy-MM'
+      dateFormat: 'yyyy-MM-dd',
+      monthFormat: 'yyyy-MM'
     },
     selectedBox: {
       select: 'Seleccionados (%s)',

--- a/packages/vue-locale/src/lang/pt-BR.ts
+++ b/packages/vue-locale/src/lang/pt-BR.ts
@@ -780,7 +780,8 @@ export default {
       noSchedule: 'Sem agendamento',
       year: '',
       month: '',
-      dateFormat: 'yyyy-MM'
+      dateFormat: 'yyyy-MM-dd',
+      monthFormat: 'yyyy-MM'
     },
     selectedBox: {
       select: 'Selecionado (%s)',

--- a/packages/vue-locale/src/lang/zh-CN.ts
+++ b/packages/vue-locale/src/lang/zh-CN.ts
@@ -747,7 +747,8 @@ export default {
       noSchedule: '暂无日程',
       year: '年',
       month: '月',
-      dateFormat: 'yyyy 年 MM 月'
+      dateFormat: 'yyyy 年 MM 月 dd 日',
+      monthFormat: 'yyyy 年 MM 月'
     },
     selectedBox: {
       select: '已选（%s）',

--- a/packages/vue/src/calendar-view/src/mobile-first.vue
+++ b/packages/vue/src/calendar-view/src/mobile-first.vue
@@ -22,10 +22,10 @@
         v-model="state.currentDate"
         :class="[showBackToday ? 'ml-5' : '', 'shrink-0']"
         shape="filter"
-        type="month"
+        :type="state.dateType"
         :clearable="false"
         @change="currentDateChange"
-        :format="t('ui.calendarView.dateFormat')"
+        :format="day ? t('ui.calendarView.dateFormat') : t('ui.calendarView.monthFormat')"
       ></tiny-date-picker>
       <div class="flex-1 mx-5" data-tag="tiny-calendar-view-tool">
         <slot name="tool"></slot>
@@ -382,6 +382,7 @@ export default defineComponent({
     'modes',
     'year',
     'month',
+    'day',
     'dayTimes',
     'events',
     'height',

--- a/packages/vue/src/calendar-view/src/pc.vue
+++ b/packages/vue/src/calendar-view/src/pc.vue
@@ -7,10 +7,10 @@
       <tiny-date-picker
         v-model="state.currentDate"
         class="tiny-calendar-view__picker"
-        type="month"
+        :type="state.dateType"
         :clearable="false"
         @change="currentDateChange"
-        :format="t('ui.calendarView.dateFormat')"
+        :format="day ? t('ui.calendarView.dateFormat') : t('ui.calendarView.monthFormat')"
       ></tiny-date-picker>
       <div class="tiny-calendar-view__tool">
         <slot name="tool"></slot>
@@ -285,6 +285,7 @@ export default defineComponent({
     'mode',
     'modes',
     'year',
+    'day',
     'month',
     'dayTimes',
     'events',


### PR DESCRIPTION
# PR
feat:支持日期指定到天

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - CalendarView accepts an optional day input to target a specific date, enabling day-level display on PC and mobile.

- Enhancements
  - Date picker switches between month and date modes when day is provided.
  - Current date (year/month/day) defaults to today when not specified.
  - Locale formats updated to include day-level formats and a separate month format.

- Documentation
  - Demos and API docs updated to show the new day option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->