### PR TITLE
feat(steps): Add a single chain circular node icon slot API

### DIFF
--- a/examples/sites/demos/apis/steps.js
+++ b/examples/sites/demos/apis/steps.js
@@ -253,6 +253,21 @@ export default {
           mfDemo: ''
         },
         {
+          name: 'icon',
+          type: '',
+          defaultValue: '',
+          meta: {
+            stable: '3.27.0'
+          },
+          desc: {
+            'zh-CN': '单链型圆形节点插槽',
+            'en-US': 'Single chain circular node slot'
+          },
+          mode: ['pc'],
+          pcDemo: 'slot-icon',
+          mfDemo: ''
+        },
+        {
           name: 'item',
           type: '',
           defaultValue: '',

--- a/examples/sites/demos/pc/app/steps/slot-icon-composition-api.vue
+++ b/examples/sites/demos/pc/app/steps/slot-icon-composition-api.vue
@@ -1,0 +1,46 @@
+<template>
+  <tiny-steps line :data="data" :active="active">
+    <template #icon="{ node, index }">
+      <div v-if="index === 1" class="tiny-steps-icon active">
+        <TinyIconPagelink class="link-svg"></TinyIconPagelink>
+      </div>
+      <div v-else-if="index === 3" class="tiny-steps-icon">
+        <TinyIconVersiontree></TinyIconVersiontree>
+      </div>
+      <div v-else-if="index === 4" class="tiny-steps-icon">
+        <TinyIconCheckedTrue></TinyIconCheckedTrue>
+      </div>
+      <div v-else-if="node.name === '网站备案'" class="tiny-steps-icon">
+        <TinyIconFileupload></TinyIconFileupload>
+      </div>
+    </template>
+  </tiny-steps>
+</template>
+
+<script setup>
+import { reactive, ref } from 'vue'
+import { TinySteps } from '@opentiny/vue'
+import { iconPagelink, iconFileupload, iconVersiontree, iconCheckedTrue } from '@opentiny/vue-icon'
+
+const TinyIconPagelink = iconPagelink()
+const TinyIconFileupload = iconFileupload()
+const TinyIconVersiontree = iconVersiontree()
+const TinyIconCheckedTrue = iconCheckedTrue()
+const active = ref(1)
+const data = reactive([
+  {
+    name: '网站搭建',
+    status: 'done'
+  },
+  { name: '域名注册', status: 'doing' },
+  { name: '网站备案', status: 'doing' },
+  { name: '域名解析（可选填）', status: 'doing' },
+  { name: 'SSL证书', status: 'disabled' }
+])
+</script>
+
+<style scoped>
+.link-svg {
+  fill: #fff;
+}
+</style>

--- a/examples/sites/demos/pc/app/steps/slot-icon.vue
+++ b/examples/sites/demos/pc/app/steps/slot-icon.vue
@@ -1,0 +1,54 @@
+<template>
+  <tiny-steps line :data="data" :active="active">
+    <template #icon="{ node, index }">
+      <div v-if="index === 1" class="tiny-steps-icon active">
+        <TinyIconPagelink class="link-svg"></TinyIconPagelink>
+      </div>
+      <div v-else-if="index === 3" class="tiny-steps-icon">
+        <TinyIconVersiontree></TinyIconVersiontree>
+      </div>
+      <div v-else-if="index === 4" class="tiny-steps-icon">
+        <TinyIconCheckedTrue></TinyIconCheckedTrue>
+      </div>
+      <div v-else-if="node.name === '网站备案'" class="tiny-steps-icon">
+        <TinyIconFileupload></TinyIconFileupload>
+      </div>
+    </template>
+  </tiny-steps>
+</template>
+
+<script>
+import { TinySteps } from '@opentiny/vue'
+import { iconPagelink, iconFileupload, iconVersiontree, iconCheckedTrue } from '@opentiny/vue-icon'
+
+export default {
+  components: {
+    TinySteps,
+    TinyIconPagelink: iconPagelink(),
+    TinyIconFileupload: iconFileupload(),
+    TinyIconVersiontree: iconVersiontree(),
+    TinyIconCheckedTrue: iconCheckedTrue()
+  },
+  data() {
+    return {
+      active: 1,
+      data: [
+        {
+          name: '网站搭建',
+          status: 'done'
+        },
+        { name: '域名注册', status: 'doing' },
+        { name: '网站备案', status: 'doing' },
+        { name: '域名解析（可选填）', status: 'doing' },
+        { name: 'SSL证书', status: 'disabled' }
+      ]
+    }
+  }
+}
+</script>
+
+<style scoped>
+.link-svg {
+  fill: #fff;
+}
+</style>

--- a/examples/sites/demos/pc/app/steps/webdoc/steps.js
+++ b/examples/sites/demos/pc/app/steps/webdoc/steps.js
@@ -124,6 +124,18 @@ export default {
       codeFiles: ['custom-steps-item.vue']
     },
     {
+      demoId: 'slot-icon',
+      name: {
+        'zh-CN': '图标插槽',
+        'en-US': 'Icon slot'
+      },
+      desc: {
+        'zh-CN': '<p>通过插槽 <code>icon</code> 自定义单链型节点图标。</p>\n',
+        'en-US': 'Customize a single chain node icon through the slot<code>icon</code>.'
+      },
+      codeFiles: ['slot-icon.vue']
+    },
+    {
       demoId: 'slot-item',
       name: {
         'zh-CN': 'item 插槽',

--- a/packages/vue/src/steps/src/pc/pc-line.vue
+++ b/packages/vue/src/steps/src/pc/pc-line.vue
@@ -54,25 +54,27 @@
             { 'not-vertical': !vertical }
           ]"
         ></div>
-        <div
-          :class="[
-            'tiny-steps-icon',
-            node[statusField] === 'error' ? 'fault' : node[statusField],
-            { 'active': index === active }
-          ]"
-        >
-          <template v-if="size !== 'mini'">
-            <template v-if="node[statusField] === 'done'">
-              <icon-finish :class="['icon icon-finish', { 'active': index === active }]"></icon-finish>
+        <slot name="icon" :node="node" :index="index">
+          <div
+            :class="[
+              'tiny-steps-icon',
+              node[statusField] === 'error' ? 'fault' : node[statusField],
+              { 'active': index === active }
+            ]"
+          >
+            <template v-if="size !== 'mini'">
+              <template v-if="node[statusField] === 'done'">
+                <icon-finish :class="['icon icon-finish', { 'active': index === active }]"></icon-finish>
+              </template>
+              <template v-else-if="node[statusField] === 'error'">
+                <icon-warn :class="['icon icon-warn', { 'active': index === active }]"></icon-warn>
+              </template>
+              <template v-else>
+                {{ index + 1 }}
+              </template>
             </template>
-            <template v-else-if="node[statusField] === 'error'">
-              <icon-warn :class="['icon icon-warn', { 'active': index === active }]"></icon-warn>
-            </template>
-            <template v-else>
-              {{ index + 1 }}
-            </template>
-          </template>
-        </div>
+          </div>
+        </slot>
         <!-- title1 -->
         <div v-if="!vertical" v-auto-tip="{ placement: 'bottom' }" class="title">
           {{ node[nameField] }}


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Steps component now supports a customizable icon slot, enabling per-step icon rendering while preserving default behavior (PC mode).

- Documentation
  - Updated API docs to include the new icon slot with multilingual descriptions and versioning.

- Demos
  - Added PC demos demonstrating custom icon usage in Steps (including a Composition API example) and updated demo listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->