### PR TITLE
fix(grid): fix grid loading-component error

### DIFF
--- a/examples/sites/demos/apis/grid.js
+++ b/examples/sites/demos/apis/grid.js
@@ -1999,8 +1999,13 @@ export default {
           type: '() => IRow[]',
           defaultValue: '',
           desc: {
-            'zh-CN':
-              '获取当前表格的数据（完整的全量表体数据、处理条件之后的全量表体数据、当前渲染中的表体数据、当前渲染中的表尾数据）',
+            'zh-CN': `
+            获取当前表格的数据（完整的全量表体数据、处理条件之后的全量表体数据、当前渲染中的表体数据、当前渲染中的表尾数据） <br/>
+            footerData: 表尾数据。 <br/>
+            fullData: 表格全量数据。  <br/>
+            visibleData: 经过筛选处理后，表格可视数据。 <br/>
+            tableData: 经过虚拟滚动剪切处理和筛选处理，表格实际用于渲染的数据。<br/>
+            `,
             'en-US':
               'Get the data of the current table (complete full body data, full body data after processing conditions, currently rendered body data, currently rendered footer data)'
           },

--- a/packages/vue/src/grid/src/table/src/table.ts
+++ b/packages/vue/src/grid/src/table/src/table.ts
@@ -896,7 +896,7 @@ export default defineComponent({
             })
           : null,
         // 加载中
-        h(loadingComponent || GridLoading, { props: { visible: loading }, class: this.viewCls('gridLoading') }),
+        h(GridLoading, { props: { visible: loading, loadingComponent }, class: this.viewCls('gridLoading') }),
         // 筛选、快捷菜单、Tip提示、校验提示
         h(
           'div',


### PR DESCRIPTION
# PR
修复loading-component在vue2下报错，vue3下样式错乱问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Refactor
  - Standardized loading rendering to always use a unified loader while still honoring custom loader configuration via props, improving consistency without changing the public API.

- Documentation
  - Expanded the Chinese description for getTableData to clearly list and explain returned data segments (footerData, fullData, visibleData, tableData).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->