### PR TITLE
fix(auto-tip): determine boundingValue.content whether it is incoming  and the priority of incoming is higher

### DIFF
--- a/packages/vue-directive/src/auto-tip.ts
+++ b/packages/vue-directive/src/auto-tip.ts
@@ -55,9 +55,10 @@ const mouseenterHandler = (e) => {
   if (isAlwaysShowTip(currentTarget) || isEllipsis(currentTarget)) {
     // 全局只创建一个tooltip实例，保证性能
     if (!globalTooltip.value) {
-      tooltipContent.value = Object.hasOwn(currentTarget.boundingValue, 'content') // 如果传入content, 哪怕是空格，也使用传入content
-        ? currentTarget.boundingValue.content
-        : currentTarget.textContent
+      tooltipContent.value =
+        'content' in currentTarget.boundingValue // 如果传入content, 哪怕是空格，也使用传入content
+          ? currentTarget.boundingValue.content
+          : currentTarget.textContent
 
       globalTooltip.value = createComponent({
         el: document.createElement('div'),

--- a/packages/vue-directive/src/auto-tip.ts
+++ b/packages/vue-directive/src/auto-tip.ts
@@ -55,7 +55,10 @@ const mouseenterHandler = (e) => {
   if (isAlwaysShowTip(currentTarget) || isEllipsis(currentTarget)) {
     // 全局只创建一个tooltip实例，保证性能
     if (!globalTooltip.value) {
-      tooltipContent.value = currentTarget.boundingValue?.content || currentTarget.textContent
+      tooltipContent.value = Object.hasOwn(currentTarget.boundingValue, 'content') // 如果传入content, 哪怕是空格，也使用传入content
+        ? currentTarget.boundingValue.content
+        : currentTarget.textContent
+
       globalTooltip.value = createComponent({
         el: document.createElement('div'),
         propsData: {

--- a/packages/vue-directive/src/auto-tip.ts
+++ b/packages/vue-directive/src/auto-tip.ts
@@ -33,10 +33,21 @@ const globalTooltip = {
 const tooltipContent = hooks.ref('')
 
 // 判断是否超出隐藏
-const isEllipsis = (currentTarget) =>
-  currentTarget?.textContent &&
-  (currentTarget.scrollWidth > currentTarget.clientWidth ||
-    currentTarget.scrollHeight - currentTarget.clientHeight > MISTAKE_VALUE)
+const isEllipsis = (currentTarget) => {
+  const content = getRealContent(currentTarget)
+  if (!content) return false
+
+  return (
+    currentTarget.scrollWidth > currentTarget.clientWidth ||
+    currentTarget.scrollHeight - currentTarget.clientHeight > MISTAKE_VALUE
+  )
+}
+
+// 查询显示内容
+const getRealContent = (currentTarget: HTMLElement) =>
+  'content' in currentTarget.boundingValue // 如果传入content, 哪怕是空格，也使用传入content
+    ? (currentTarget.boundingValue.content as string)
+    : currentTarget.textContent
 
 const isAlwaysShowTip = (currentTarget) => Boolean(currentTarget?.boundingValue?.always)
 
@@ -55,10 +66,7 @@ const mouseenterHandler = (e) => {
   if (isAlwaysShowTip(currentTarget) || isEllipsis(currentTarget)) {
     // 全局只创建一个tooltip实例，保证性能
     if (!globalTooltip.value) {
-      tooltipContent.value =
-        'content' in currentTarget.boundingValue // 如果传入content, 哪怕是空格，也使用传入content
-          ? currentTarget.boundingValue.content
-          : currentTarget.textContent
+      tooltipContent.value = getRealContent(currentTarget)
 
       globalTooltip.value = createComponent({
         el: document.createElement('div'),
@@ -74,7 +82,7 @@ const mouseenterHandler = (e) => {
     const tooltip = globalTooltip.value
     const popperElm = tooltip.state.popperElm
 
-    tooltipContent.value = currentTarget.boundingValue?.content || currentTarget.textContent
+    tooltipContent.value = getRealContent(currentTarget)
     tooltip.state.referenceElm = currentTarget
     tooltip.state.currentPlacement = getPlacement(currentTarget)
 


### PR DESCRIPTION
auto-tip中，判断boundingValue.content的优先级更高。 只要传入了，就使用。    ---- 发包

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tooltips now consistently prefer explicitly provided content on the target (including empty strings) over falling back to the element's text, avoiding unintended tooltip text.
  * Better handling with dynamic bindings and custom tooltip content so displayed tooltips match the intended source.
  * No changes to public APIs or visible UI beyond this corrected tooltip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->