### PR TITLE
feat(guide): [guide] whether to display the mask layer when adding the guide component

### DIFF
--- a/examples/sites/demos/apis/guide.js
+++ b/examples/sites/demos/apis/guide.js
@@ -148,7 +148,10 @@ export default {
             'en-US': ''
           },
           mode: ['pc'],
-          pcDemo: 'mask'
+          pcDemo: 'mask',
+          meta: {
+            stable: '3.27.0'
+          }
         }
       ],
       events: [],

--- a/examples/sites/demos/apis/guide.js
+++ b/examples/sites/demos/apis/guide.js
@@ -138,6 +138,17 @@ export default {
           },
           mode: ['pc'],
           pcDemo: 'size'
+        },
+        {
+          name: 'mask',
+          type: 'boolean',
+          defaultValue: 'false',
+          desc: {
+            'zh-CN': '是否显示遮罩层',
+            'en-US': ''
+          },
+          mode: ['pc'],
+          pcDemo: 'mask'
         }
       ],
       events: [],

--- a/examples/sites/demos/pc/app/guide/mask-composition-api.vue
+++ b/examples/sites/demos/pc/app/guide/mask-composition-api.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    <tiny-button plain class="guide-box" @click="stepStart">新手引导</tiny-button>
+    <tiny-guide :mask="mask" :show-step="showStep" :dom-data="domData"></tiny-guide>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { TinyGuide, TinyButton } from '@opentiny/vue'
+
+const showStep = ref(false)
+const mask = ref(true)
+const domData = ref([
+  {
+    title: '新手引导标题',
+    text: '这里是新手引导文案这里是新手引导文案这里是新手引导文案这里是新手引导文案这里是新手引导文案这里是是新手引导文案',
+    domElement: '.guide-box',
+    button: [
+      {
+        text: '完成',
+        action: 'complete'
+      }
+    ]
+  }
+])
+
+function stepStart() {
+  showStep.value = !showStep.value
+}
+</script>

--- a/examples/sites/demos/pc/app/guide/mask.spec.ts
+++ b/examples/sites/demos/pc/app/guide/mask.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test'
+
+test('弹窗的遮罩层', async ({ page }) => {
+  page.on('pageerror', (exception) => expect(exception).toBeNull())
+  await page.goto('guide#mask')
+
+  const guideVisible = page.locator('.shepherd-modal-is-visible')
+  const showBtn = page.getByRole('button', { name: '新手引导' })
+
+  await showBtn.click()
+  await expect(guideVisible).toBeVisible()
+  await expect(guideVisible).toHaveCSS('opacity', '0.2')
+})

--- a/examples/sites/demos/pc/app/guide/mask.vue
+++ b/examples/sites/demos/pc/app/guide/mask.vue
@@ -1,0 +1,41 @@
+<template>
+  <div>
+    <tiny-button plain class="guide-box" @click="stepStart">新手引导</tiny-button>
+    <tiny-guide :mask="mask" :show-step="showStep" :dom-data="domData"></tiny-guide>
+  </div>
+</template>
+
+<script>
+import { TinyGuide, TinyButton } from '@opentiny/vue'
+
+export default {
+  components: {
+    TinyGuide,
+    TinyButton
+  },
+  data() {
+    return {
+      showStep: false,
+      mask: true,
+      domData: [
+        {
+          title: '新手引导标题',
+          text: '这里是新手引导文案这里是新手引导文案这里是新手引导文案这里是新手引导文案这里是新手引导文案这里是是新手引导文案',
+          domElement: '.guide-box',
+          button: [
+            {
+              text: '完成',
+              action: 'complete'
+            }
+          ]
+        }
+      ]
+    }
+  },
+  methods: {
+    stepStart() {
+      this.showStep = !this.showStep
+    }
+  }
+}
+</script>

--- a/examples/sites/demos/pc/app/guide/webdoc/guide.js
+++ b/examples/sites/demos/pc/app/guide/webdoc/guide.js
@@ -93,6 +93,18 @@ export default {
       codeFiles: ['size.vue']
     },
     {
+      demoId: 'mask',
+      name: {
+        'zh-CN': '弹窗的遮罩层',
+        'en-US': ''
+      },
+      desc: {
+        'zh-CN': '<p>通过添加 <code>mask</code> 来自定义是否显示遮罩层。默认值为 <code>false</code> </p>',
+        'en-US': ''
+      },
+      codeFiles: ['mask.vue']
+    },
+    {
       demoId: 'modal-overlay-opening',
       name: {
         'zh-CN': '模态叠加层开口',

--- a/packages/renderless/src/guide/index.ts
+++ b/packages/renderless/src/guide/index.ts
@@ -3,7 +3,7 @@ import { xss } from '@opentiny/utils'
 export const createShepherd =
   ({ state, props, Shepherd, offset, designConfig }) =>
   () => {
-    const tour = newTour(state, Shepherd, offset, designConfig)
+    const tour = newTour(state, Shepherd, offset, designConfig, props)
 
     state.tour = tour
 
@@ -83,9 +83,9 @@ const getItemCopy = (props, tour, result) => {
   return result
 }
 
-const newTour = (state, Shepherd, offset, designConfig) => {
+const newTour = (state, Shepherd, offset, designConfig, props) => {
   const tour = new Shepherd.Tour({
-    useModalOverlay: designConfig?.state?.isUseModalOverlay ?? false,
+    useModalOverlay: props.mask ?? designConfig?.state?.isUseModalOverlay,
     defaultStepOptions: {
       modalOverlayOpeningPadding: state.modalOverlayOpeningPadding,
       modalOverlayOpeningRadius: state.modalOverlayOpeningRadius,

--- a/packages/theme/src/guide/index.less
+++ b/packages/theme/src/guide/index.less
@@ -269,7 +269,7 @@
     opacity 0.3s 0ms;
 
   &.shepherd-modal-is-visible {
-    opacity: 0.5;
+    opacity: 0.2;
     transform: translateZ(0);
     transition:
       all 0.3s ease-out,

--- a/packages/vue/src/guide/src/index.ts
+++ b/packages/vue/src/guide/src/index.ts
@@ -50,6 +50,10 @@ export default defineComponent({
     height: {
       type: String,
       default: ''
+    },
+    mask: {
+      type: Boolean,
+      default: false
     }
   },
   setup(props, context) {

--- a/packages/vue/src/guide/src/pc.vue
+++ b/packages/vue/src/guide/src/pc.vue
@@ -25,6 +25,7 @@ export default defineComponent({
     'arrow',
     'lightClass',
     'width',
+    'mask',
     'height'
   ],
   setup(props, context) {


### PR DESCRIPTION
… the mask layer API

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Guide component adds a mask option to toggle an overlay during tours (default: off).
  - New demo components, including a Composition API example, demonstrate mask usage.

- Style
  - Guide overlay opacity reduced to 0.2 for a lighter visual effect.

- Documentation
  - Added demo entry explaining the mask option and usage.

- Tests
  - Automated test added to verify mask overlay visibility and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->