### PR TITLE
fix(grid): fix body height error after change pager size

### DIFF
--- a/packages/vue/src/grid/src/body/src/body.tsx
+++ b/packages/vue/src/grid/src/body/src/body.tsx
@@ -846,7 +846,6 @@ export default defineComponent({
     const { bodyWrapperHeight, bodyWrapperMinHeight, bodyWrapperMaxHeight } = $table
     const $slots = $grid.slots
     const _vm = this
-
     return (
       <div
         ref="body"

--- a/packages/vue/src/grid/src/table/src/table.ts
+++ b/packages/vue/src/grid/src/table/src/table.ts
@@ -659,6 +659,10 @@ export default defineComponent({
     const bodyWrapperMinHeight = hooks.ref()
     // 外部设置的表体容器最大高度
     const bodyWrapperMaxHeight = hooks.ref()
+    // 表格滚动宽度
+    const containerScrollWidth = hooks.ref(0)
+    // 表格滚动高度
+    const containerScrollHeight = hooks.ref(0)
     // 表体表格元素宽度
     const bodyTableWidth = hooks.ref()
     // 滚动加载滚动高度
@@ -826,6 +830,8 @@ export default defineComponent({
       bodyWrapperHeight,
       bodyWrapperMinHeight,
       bodyWrapperMaxHeight,
+      containerScrollWidth,
+      containerScrollHeight,
       bodyTableWidth,
       scrollLoadScrollHeight,
       columnStore,


### PR DESCRIPTION
# PR
修复切换分页大小后，表格高度不正确问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Table now exposes live container scroll width and height values, enabling visibility into horizontal and vertical scroll dimensions.

- Style
  - Minor formatting cleanup in the grid body component (no behavioral changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->