### PR TITLE
fix: [tree-menu] fix the issue of icons not being referenced

### DIFF
--- a/examples/sites/demos/pc/app/tree-menu/with-icon.vue
+++ b/examples/sites/demos/pc/app/tree-menu/with-icon.vue
@@ -6,6 +6,7 @@
 
 <script>
 import { TinyTreeMenu } from '@opentiny/vue'
+import { IconPlusCircle, IconPlusSquare, IconPreChecked, IconNode, IconNew } from '@opentiny/vue-icon'
 
 export default {
   components: {


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced Tree Menu demo to showcase icon usage, improving visual clarity and discoverability.
  - Integrated icons (e.g., plus, checked, node, new) into tree nodes to illustrate common patterns.
  - Provides a reference for applying icons within tree data in similar implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->