### PR TITLE
feat(color-select): `color-mode` prop support

### DIFF
--- a/examples/sites/demos/apis/color-picker.js
+++ b/examples/sites/demos/apis/color-picker.js
@@ -103,6 +103,22 @@ export default {
           meta: {
             stable: '3.19.0'
           }
+        },
+        {
+          name: 'colorMode',
+          type: 'monochrome | linear-gradient',
+          defaultValue: 'monochrome',
+          desc: {
+            'zh-CN':
+              '设定颜色模式, 如果为linear-gradient则为线性渐变. 如果为线性渐变, modelValue必须为一个合法的线性渐变表达式',
+            'en-US':
+              'Set the color mode. If it is linear-gradient, it is a linear gradient. If it is a linear gradient, modelValue must be a valid linear gradient expression'
+          },
+          mode: ['pc'],
+          pcDemo: 'color-mode',
+          meta: {
+            stable: '3.27.0'
+          }
         }
       ],
       events: [

--- a/examples/sites/demos/pc/app/color-picker/linear-gradient-composition-api.vue
+++ b/examples/sites/demos/pc/app/color-picker/linear-gradient-composition-api.vue
@@ -1,0 +1,20 @@
+<template>
+  <div>
+    <tiny-color-picker v-model="color" color-mode="linear-gradient" @confirm="onConfirm" />
+  </div>
+</template>
+
+<script setup>
+import { TinyColorPicker, TinyNotify } from '@opentiny/vue'
+import { ref } from 'vue'
+
+const color = ref('linear-gradient(90deg, #66ADFF 21%,#00FEF1 100%)')
+const onConfirm = () => {
+  TinyNotify({
+    type: 'success',
+    position: 'top-right',
+    title: '用户点击了选择',
+    message: color.value
+  })
+}
+</script>

--- a/examples/sites/demos/pc/app/color-picker/linear-gradient.spec.ts
+++ b/examples/sites/demos/pc/app/color-picker/linear-gradient.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test'
+
+test('测试历史记录', async ({ page }) => {
+  page.on('pageerror', (exception) => expect(exception).toBeNull())
+  await page.goto('color-picker#color-mode')
+  await page.locator('.tiny-color-picker > .tiny-color-picker__inner').click()
+  await page.getByRole('button', { name: '确定' }).click()
+  await expect(page.locator('body')).toContainText('linear-gradient(90deg, #66ADFF 21%,#00FEF1 100%)')
+  await page.locator('.tiny-notify__icon-close > .tiny-svg').click()
+})

--- a/examples/sites/demos/pc/app/color-picker/linear-gradient.spec.ts
+++ b/examples/sites/demos/pc/app/color-picker/linear-gradient.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-test('测试历史记录', async ({ page }) => {
+test('渐变', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
   await page.goto('color-picker#color-mode')
   await page.locator('.tiny-color-picker > .tiny-color-picker__inner').click()

--- a/examples/sites/demos/pc/app/color-picker/linear-gradient.vue
+++ b/examples/sites/demos/pc/app/color-picker/linear-gradient.vue
@@ -1,0 +1,27 @@
+<template>
+  <div>
+    <tiny-color-picker v-model="color" color-mode="linear-gradient" @confirm="onConfirm" />
+  </div>
+</template>
+
+<script>
+import { TinyColorPicker, TinyNotify } from '@opentiny/vue'
+
+export default {
+  components: {
+    TinyColorPicker
+  },
+  setup() {
+    const color = ref('linear-gradient(90deg, #66ADFF 21%,#00FEF1 100%)')
+    const onConfirm = () => {
+      TinyNotify({
+        type: 'success',
+        position: 'top-right',
+        title: '用户点击了选择',
+        message: color.value
+      })
+    }
+    return { onConfirm, color }
+  }
+}
+</script>

--- a/examples/sites/demos/pc/app/color-picker/linear-gradient.vue
+++ b/examples/sites/demos/pc/app/color-picker/linear-gradient.vue
@@ -6,6 +6,7 @@
 
 <script>
 import { TinyColorPicker, TinyNotify } from '@opentiny/vue'
+import { ref } from 'vue'
 
 export default {
   components: {

--- a/examples/sites/demos/pc/app/color-picker/webdoc/color-picker.js
+++ b/examples/sites/demos/pc/app/color-picker/webdoc/color-picker.js
@@ -130,8 +130,9 @@ export default {
       },
       desc: {
         'zh-CN':
-          '通过设置 <code>format</code> 属性，用于设置点击确定后颜色的格式。目前支持<code>hex</code>, <code>hsl</code>, <code>hsv</code>, <code>rgb</code>',
-        'en-US': ''
+          '通过设置 <code>color-mode</code> 属性切换颜色模式。支持 <code>monochrome</code>(单色) 和 <code>linear-gradient</code>(线性渐变) 两种模式。',
+        'en-US':
+          'Set the <code>color-mode</code> attribute to switch color modes. Supports <code>monochrome</code> and <code>linear-gradient</code> modes.'
       },
       codeFiles: ['linear-gradient.vue']
     }

--- a/examples/sites/demos/pc/app/color-picker/webdoc/color-picker.js
+++ b/examples/sites/demos/pc/app/color-picker/webdoc/color-picker.js
@@ -121,6 +121,19 @@ export default {
         'en-US': ''
       },
       codeFiles: ['format.vue']
+    },
+    {
+      demoId: 'color-mode',
+      name: {
+        'zh-CN': '颜色模式',
+        'en-US': 'color mode'
+      },
+      desc: {
+        'zh-CN':
+          '通过设置 <code>format</code> 属性，用于设置点击确定后颜色的格式。目前支持<code>hex</code>, <code>hsl</code>, <code>hsv</code>, <code>rgb</code>',
+        'en-US': ''
+      },
+      codeFiles: ['linear-gradient.vue']
     }
   ],
   features: [

--- a/examples/sites/demos/pc/app/color-picker/webdoc/color-picker.js
+++ b/examples/sites/demos/pc/app/color-picker/webdoc/color-picker.js
@@ -227,6 +227,19 @@ export default {
       },
       apis: ['change'],
       demos: ['events']
+    },
+    {
+      id: 'color-mode',
+      name: '颜色模式',
+      support: {
+        value: true
+      },
+      description: '通过 color-mode 属性来定义是否启用线性渐变',
+      cloud: {
+        value: false
+      },
+      apis: ['color-mode'],
+      demos: ['color-mode']
     }
   ]
 }

--- a/packages/renderless/src/color-picker/vue.ts
+++ b/packages/renderless/src/color-picker/vue.ts
@@ -52,9 +52,14 @@ export const renderless = (props, ctx: ISharedRenderlessParamHooks, { emit }: IS
   ctx.watch(
     () => props.modelValue,
     () => {
-      color.fromString(props.modelValue)
-      const { r, g, b, a } = color.toRgba()
-      state.hex = `rgba(${r}, ${g}, ${b}, ${a})`
+      state.hex = props.modelValue
+      // if (props.colorMode === 'linear-gradient') {
+      //   state.hex = props.modelValue
+      //   return
+      // }
+      // color.fromString(props.modelValue)
+      // const { r, g, b, a } = color.toRgba()
+      // state.hex = `rgba(${r}, ${g}, ${b}, ${a})`
     }
   )
   const changeVisible = toggleVisible(isShow)

--- a/packages/renderless/src/color-picker/vue.ts
+++ b/packages/renderless/src/color-picker/vue.ts
@@ -52,14 +52,13 @@ export const renderless = (props, ctx: ISharedRenderlessParamHooks, { emit }: IS
   ctx.watch(
     () => props.modelValue,
     () => {
-      state.hex = props.modelValue
-      // if (props.colorMode === 'linear-gradient') {
-      //   state.hex = props.modelValue
-      //   return
-      // }
-      // color.fromString(props.modelValue)
-      // const { r, g, b, a } = color.toRgba()
-      // state.hex = `rgba(${r}, ${g}, ${b}, ${a})`
+      if (props.colorMode === 'linear-gradient') {
+        state.hex = props.modelValue
+        return
+      }
+      color.fromString(props.modelValue)
+      const { r, g, b, a } = color.toRgba()
+      state.hex = `rgba(${r}, ${g}, ${b}, ${a})`
     }
   )
   const changeVisible = toggleVisible(isShow)

--- a/packages/renderless/src/color-select-panel/index.ts
+++ b/packages/renderless/src/color-select-panel/index.ts
@@ -206,8 +206,7 @@ export const initApi = (
   hooks: ISharedRenderlessParamHooks,
   ext: ColorSelectPanelExtends
 ) => {
-  const { emit, nextTick, vm } = utils
-  const { ref } = hooks
+  const { emit, nextTick } = utils
   const setShowPicker = (value: boolean) => (state.showPicker = value)
   const resetColor = () => {
     nextTick(() => {

--- a/packages/vue/src/color-picker/src/index.ts
+++ b/packages/vue/src/color-picker/src/index.ts
@@ -45,6 +45,13 @@ export default defineComponent({
     enablePredefineColor: {
       type: Boolean,
       default: false
+    },
+    colorMode: {
+      type: String,
+      default: 'monochrome',
+      validator(val: string) {
+        return ['monochrome', 'linear-gradient'].includes(val)
+      }
     }
   },
   setup(props, context) {

--- a/packages/vue/src/color-picker/src/index.ts
+++ b/packages/vue/src/color-picker/src/index.ts
@@ -35,7 +35,7 @@ export default defineComponent({
         if (val[val.length - 1] === 'a') {
           console.warn('If you want enable alpha, You should set `alpha` prop to true')
         }
-        return ['hsv', 'hsl', 'rgb', 'hex'].includes(val)
+        return ['hsv', 'hsl', 'rgb', 'hex'].includes(val[0])
       }
     },
     enableHistory: {

--- a/packages/vue/src/color-picker/src/pc.vue
+++ b/packages/vue/src/color-picker/src/pc.vue
@@ -29,6 +29,7 @@
         :style="{
           'min-width': '330px'
         }"
+        :color-mode="$props.colorMode"
         :enable-history="state.enableHistory"
         :enable-predefine-color="state.enablePredefineColor"
       />
@@ -55,7 +56,8 @@ export default defineComponent({
     'size',
     'format',
     'enableHistory',
-    'enablePredefineColor'
+    'enablePredefineColor',
+    'colorMode'
   ],
   components: {
     IconChevronDown: IconChevronDown(),


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Incompatible `color-mode` props

Issue Number: N/A

## What is the new behavior?

compatible `color-mode` props

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

preview (vvv)

![1](https://github.com/user-attachments/assets/1551335c-7265-470b-9fa8-91dbadccc5cb)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Color Picker adds a colorMode option with "monochrome" (default) and "linear-gradient"; users can choose gradient mode and confirm a selection.

- **Documentation**
  - New demos and web docs demonstrating linear-gradient mode and usage with confirmation feedback.

- **Tests**
  - Added end-to-end test validating gradient selection, confirmation flow, notification display, and expected gradient output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->