### PR TITLE
fix(button): in theme-saas package, remove the button's max-width

### DIFF
--- a/packages/theme-saas/src/button/index.less
+++ b/packages/theme-saas/src/button/index.less
@@ -10,7 +10,7 @@
   @apply text-center;
   @apply box-border;
   @apply ~"min-w-[theme(spacing.18)]";
-  @apply ~"max-w-[theme(spacing.36)]";
+  // @apply ~"max-w-[theme(spacing.36)]"; 屏蔽最大宽度
   @apply h-7;
   @apply ~"leading-[calc(theme(spacing.7)-2*theme(borderWidth.DEFAULT))]";
   @apply text-color-text-primary;

--- a/packages/vue/src/button/src/mobile-first.vue
+++ b/packages/vue/src/button/src/mobile-first.vue
@@ -8,7 +8,7 @@
     :class="
       m(
         gcls('button'),
-        gcls(banner ? 'button-banner' : 'button-base-width'),
+        gcls(banner ? 'button-banner' : ''),
         gcls(`size-${size || 'default'}`),
         gcls(
           `type-${type || 'default'}${icon ? '-icon' : state.plain ? '-plain' : ''}${

--- a/packages/vue/src/button/src/token.ts
+++ b/packages/vue/src/button/src/token.ts
@@ -1,7 +1,7 @@
 export const classes = {
   'button':
     'inline-block text-center overflow-hidden overflow-ellipsis whitespace-nowrap transition-button duration-300 delay-[0ms] active:transition-all active:scale-[0.95] active:ease-[cubic-bezier(0.33,0,0.67,1)]',
-  'button-base-width': 'sm:max-w-[theme(spacing.36)]',
+  // 'button-base-width': 'sm:max-w-[theme(spacing.36)]',
   'size-default': 'h-10 text-sm sm:h-7',
   'size-medium': 'h-10 text-sm sm:h-8',
   'size-small': 'h-8 text-sm sm:h-7',


### PR DESCRIPTION
# PR
删除saas主题时，button的最大宽度。
删除mf模板中的button的最大宽度。


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Removed the fixed max-width and default fixed-width styling for buttons so they now size according to content and container.
  * Banner variant renders only its banner styling; non-banner buttons no longer receive the previous fixed-width fallback.
  * Result: improved responsiveness and fewer truncated labels, with potential layout shifts where fixed widths were previously relied upon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->