### PR TITLE
fix(select): only when in the mf template, check the screen's breakpoint

### DIFF
--- a/packages/renderless/src/select/index.ts
+++ b/packages/renderless/src/select/index.ts
@@ -250,9 +250,9 @@ export const handleMenuEnter =
   }
 
 export const emitChange =
-  ({ emit, props, state, constants }) =>
+  ({ emit, props, state, constants, isMobileFirstMode }) =>
   (value, changed) => {
-    if (state.device === 'mb' && props.multiple && !changed) return
+    if (isMobileFirstMode && state.device === 'mb' && props.multiple && !changed) return
 
     const seekItem = (val, arr, items, flag) => {
       if (constants.TYPE.Tree === flag) {
@@ -304,9 +304,9 @@ export const emitChange =
   }
 
 export const directEmitChange =
-  ({ emit, props, state }) =>
+  ({ emit, props, state, isMobileFirstMode }) =>
   (value, key) => {
-    if (state.device === 'mb' && props.multiple) return
+    if (isMobileFirstMode && state.device === 'mb' && props.multiple) return
 
     emit('change', value, key)
   }
@@ -1539,7 +1539,7 @@ export const toHide =
   }
 
 export const watchVisible =
-  ({ api, constants, emit, state, vm, props }) =>
+  ({ api, constants, emit, state, vm, props, isMobileFirstMode }) =>
   (value) => {
     if ((props.filterable || props.searchable || props.remote) && !value) {
       vm.$refs.reference?.blur()
@@ -1549,7 +1549,7 @@ export const watchVisible =
       return
     }
 
-    if (value && props.multiple && state.device === 'mb') {
+    if (value && props.multiple && isMobileFirstMode && state.device === 'mb') {
       state.selectedCopy = state.selected.slice()
     }
 
@@ -2245,11 +2245,11 @@ export const computeMultipleLimit =
   }
 
 export const updateModelValue =
-  ({ props, emit, state }) =>
+  ({ props, emit, state, isMobileFirstMode }) =>
   (value, needUpdate) => {
     state.isClickChoose = true
 
-    if (state.device === 'mb' && props.multiple && !needUpdate) {
+    if (isMobileFirstMode && state.device === 'mb' && props.multiple && !needUpdate) {
       state.modelValue = value
     } else {
       emit('update:modelValue', value)
@@ -2302,13 +2302,13 @@ export const computedTagsStyle =
   }
 
 export const computedReadonly =
-  ({ props, state }) =>
+  ({ props, state, isMobileFirstMode }) =>
   () => {
     if (state.isIOS && props.filterable) {
       return false
     } else {
       return (
-        state.device === 'mb' ||
+        (isMobileFirstMode && state.device === 'mb') ||
         props.readonly ||
         !(props.filterable || props.searchable) ||
         props.multiple ||
@@ -2331,9 +2331,9 @@ export const computedShowClose =
 export const computedCollapseTagSize = (state) => () => state.selectSize
 
 export const computedShowNewOption =
-  ({ props, state }) =>
+  ({ props, state, isMobileFirstMode }) =>
   () => {
-    const query = state.device === 'mb' ? state.queryValue : state.query
+    const query = isMobileFirstMode && state.device === 'mb' ? state.queryValue : state.query
     return (
       (props.filterable || props.searchable) &&
       props.allowCreate &&

--- a/packages/renderless/src/select/vue.ts
+++ b/packages/renderless/src/select/vue.ts
@@ -183,7 +183,19 @@ export const api = [
   'isTagClosable'
 ]
 
-const initState = ({ reactive, computed, props, api, emitter, parent, constants, useBreakpoint, vm, designConfig }) => {
+const initState = ({
+  reactive,
+  computed,
+  props,
+  api,
+  emitter,
+  parent,
+  constants,
+  isMobileFirstMode,
+  useBreakpoint,
+  vm,
+  designConfig
+}) => {
   const stateAdd = initStateAdd({ computed, props, api, parent })
   const state = reactive({
     ...stateAdd,
@@ -225,7 +237,9 @@ const initState = ({ reactive, computed, props, api, emitter, parent, constants,
     selectedCopy: [],
     compareValue: null,
     selectedVal: computed(() =>
-      state.device === 'mb' && props.multiple && state.visible ? state.selectedCopy : state.selected
+      isMobileFirstMode && state.device === 'mb' && props.multiple && state.visible
+        ? state.selectedCopy
+        : state.selected
     ),
     displayOnlyContent: computed(() => {
       if (props.multiple) {
@@ -378,8 +392,8 @@ const initApi = ({
     getChildValue: getChildValue(),
     getOption: getOption({ props, state, api }),
     getSelectedOption: getSelectedOption({ props, state }),
-    emitChange: emitChange({ emit, props, state, constants }),
-    directEmitChange: directEmitChange({ emit, props, state, constants }),
+    emitChange: emitChange({ emit, props, state, constants, isMobileFirstMode }),
+    directEmitChange: directEmitChange({ emit, props, state, constants, isMobileFirstMode }),
     toggleMenu: toggleMenu({ vm, state, props, api, isMobileFirstMode }),
     showTip: showTip({ props, state, vm }),
     onOptionDestroy: onOptionDestroy(state),
@@ -421,12 +435,12 @@ const initApi = ({
     computeMultipleLimit: computeMultipleLimit({ props, state }),
     watchInputHover: watchInputHover({ vm }),
     initQuery: initQuery({ props, state, constants, vm }),
-    updateModelValue: updateModelValue({ props, emit, state }),
+    updateModelValue: updateModelValue({ props, emit, state, isMobileFirstMode }),
     computedTagsStyle: computedTagsStyle({ props, parent, state, vm }),
-    computedReadonly: computedReadonly({ props, state }),
+    computedReadonly: computedReadonly({ props, state, isMobileFirstMode }),
     computedShowClose: computedShowClose({ props, state }),
     computedCollapseTagSize: computedCollapseTagSize(state),
-    computedShowNewOption: computedShowNewOption({ props, state }),
+    computedShowNewOption: computedShowNewOption({ props, state, isMobileFirstMode }),
     computedShowCopy: computedShowCopy({ props, state }),
     computedOptionsAllDisabled: computedOptionsAllDisabled(state),
     computedDisabledTooltipContent: computedDisabledTooltipContent({ props, state }),
@@ -641,6 +655,7 @@ export const renderless = (
     emitter,
     parent,
     constants,
+    isMobileFirstMode,
     useBreakpoint,
     vm,
     designConfig


### PR DESCRIPTION
# PR

修改select的renderless, 增加： 只有在mf模板时，才判断屏幕尺寸。  

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Select component behavior in mobile-first mode for a smoother experience.
  * Improved selection synchronization and visibility toggling on mobile.
  * Better handling of placeholders and displayed values in mobile contexts.
  * Mobile-aware logic for creating new options and showing tags, aligning UI states with mobile usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->