### PR TITLE
fix(dialog-box): add before-close prop and event's doc

### DIFF
--- a/examples/sites/demos/apis/dialog-box.js
+++ b/examples/sites/demos/apis/dialog-box.js
@@ -289,19 +289,31 @@ export default {
           },
           mode: ['pc'],
           pcDemo: 'transition-effect'
+        },
+        {
+          name: 'before-close',
+          type: '(type) => boolean',
+          defaultValue: '',
+          desc: {
+            'zh-CN': '设置弹窗关闭前的回调函数，如果函数返回 `false`,可以拦截关闭弹窗',
+            'en-US':
+              'set the callback function before closing the pop-up. If the function returns `false`, the pop-up will not be closed'
+          },
+          mode: ['pc'],
+          pcDemo: 'before-close'
         }
       ],
       events: [
         {
           name: 'before-close',
-          type: '(arg:() => void) => void',
+          type: '(event, hideFn) => void',
           defaultValue: '',
           desc: {
-            'zh-CN': 'Dialog 关闭弹窗前，执行的事件',
-            'en-US': 'Event executed before a dialog window is closed.'
+            'zh-CN': 'Dialog 关闭弹窗前的事件，通过 event.preventDefault() 可以拦截关闭弹窗',
+            'en-US': 'Dialog event before closing the pop-up'
           },
           mode: ['pc'],
-          pcDemo: 'draggable'
+          pcDemo: 'before-close'
         },
         {
           name: 'close',

--- a/examples/sites/demos/pc/app/dialog-box/before-close-composition-api.vue
+++ b/examples/sites/demos/pc/app/dialog-box/before-close-composition-api.vue
@@ -31,24 +31,24 @@ const box1Ref = ref()
 const box2Ref = ref()
 
 function beforeCloseProp(type) {
-  // 模拟异步校验，是否需要关闭
+  // 模拟异步校验，是否需要手动关闭
   setTimeout(() => {
     if (Math.random() > 0.5) {
-      box1Ref.value.hide(type)
+      box1Ref.value.hide(type) // 手动关闭，使用 box1.value = false 同样效果
     } else {
-      Modal.alert('已拦截关闭')
+      Modal.alert('随机值过小，校验失败')
     }
   }, 1000)
 
   return false // 拦截关闭
 }
 function onBeforeClose(event, hideFn) {
-  // 模拟异步校验，是否需要关闭
+  // 模拟异步校验，是否需要手动关闭
   setTimeout(() => {
     if (Math.random() > 0.5) {
-      hideFn()
+      hideFn() // 手动关闭，使用 box2.value = false 同样效果
     } else {
-      Modal.alert('已拦截关闭')
+      Modal.alert('随机值过小，校验失败')
     }
   }, 1000)
 

--- a/examples/sites/demos/pc/app/dialog-box/before-close-composition-api.vue
+++ b/examples/sites/demos/pc/app/dialog-box/before-close-composition-api.vue
@@ -1,0 +1,65 @@
+<template>
+  <div>
+    <tiny-button @click="box1 = true" title="属性拦截 Dialog示例">属性拦截 Dialog</tiny-button>
+    <tiny-button @click="box2 = true" title="事件拦截 Dialog示例">事件拦截 Dialog</tiny-button>
+
+    <tiny-dialog-box ref="box1Ref" v-model:visible="box1" title="消息" width="30%" :before-close="beforeCloseProp">
+      <span>当前窗口有50%的概率关闭</span>
+      <template #footer>
+        <tiny-button @click="handleBox1Close">取 消</tiny-button>
+        <tiny-button type="primary" @click="handleBox1Close">确 定</tiny-button>
+      </template>
+    </tiny-dialog-box>
+
+    <tiny-dialog-box ref="box2Ref" v-model:visible="box2" title="消息" width="30%" @before-close="onBeforeClose">
+      <span>当前窗口有50%的概率关闭</span>
+      <template #footer>
+        <tiny-button @click="handleBox2Close">取 消</tiny-button>
+        <tiny-button type="primary" @click="handleBox2Close">确 定</tiny-button>
+      </template>
+    </tiny-dialog-box>
+  </div>
+</template>
+
+<script setup lang="jsx">
+import { ref } from 'vue'
+import { TinyButton, TinyDialogBox, Modal } from '@opentiny/vue'
+
+const box1 = ref(false)
+const box2 = ref(false)
+const box1Ref = ref()
+const box2Ref = ref()
+
+function beforeCloseProp(type) {
+  // 模拟异步校验，是否需要关闭
+  setTimeout(() => {
+    if (Math.random() > 0.5) {
+      box1Ref.value.hide(type)
+    } else {
+      Modal.alert('已拦截关闭')
+    }
+  }, 1000)
+
+  return false // 拦截关闭
+}
+function onBeforeClose(event, hideFn) {
+  // 模拟异步校验，是否需要关闭
+  setTimeout(() => {
+    if (Math.random() > 0.5) {
+      hideFn()
+    } else {
+      Modal.alert('已拦截关闭')
+    }
+  }, 1000)
+
+  event.preventDefault() // 拦截关闭
+}
+
+function handleBox1Close() {
+  box1Ref.value.handleClose()
+}
+
+function handleBox2Close() {
+  box2Ref.value.handleClose()
+}
+</script>

--- a/examples/sites/demos/pc/app/dialog-box/before-close.spec.ts
+++ b/examples/sites/demos/pc/app/dialog-box/before-close.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test'
+
+test('dialogBox 基础用法', async ({ page }) => {
+  page.on('pageerror', (exception) => expect(exception).toBeNull())
+  await page.goto('dialog-box#before-close')
+})

--- a/examples/sites/demos/pc/app/dialog-box/before-close.vue
+++ b/examples/sites/demos/pc/app/dialog-box/before-close.vue
@@ -37,24 +37,24 @@ export default {
   },
   methods: {
     beforeCloseProp(type) {
-      // 模拟异步校验，是否需要关闭
+      // 模拟异步校验，是否需要手动关闭
       setTimeout(() => {
         if (Math.random() > 0.5) {
-          this.$refs.box1Ref.hide(type)
+          this.$refs.box1Ref.hide(type) // 手动关闭，使用 box1.value = false 同样效果
         } else {
-          Modal.alert('已拦截关闭')
+          Modal.alert('随机值过小，校验失败')
         }
       }, 1000)
 
       return false // 拦截关闭
     },
     onBeforeClose(event, hideFn) {
-      // 模拟异步校验，是否需要关闭
+      // 模拟异步校验，是否需要手动关闭
       setTimeout(() => {
         if (Math.random() > 0.5) {
-          hideFn()
+          hideFn() // 手动关闭，使用 box2.value = false 同样效果
         } else {
-          Modal.alert('已拦截关闭')
+          Modal.alert('随机值过小，校验失败')
         }
       }, 1000)
 

--- a/examples/sites/demos/pc/app/dialog-box/before-close.vue
+++ b/examples/sites/demos/pc/app/dialog-box/before-close.vue
@@ -1,0 +1,71 @@
+<template>
+  <div>
+    <tiny-button @click="box1 = true" title="属性拦截 Dialog示例">属性拦截 Dialog</tiny-button>
+    <tiny-button @click="box2 = true" title="事件拦截 Dialog示例">事件拦截 Dialog</tiny-button>
+
+    <tiny-dialog-box ref="box1Ref" v-model:visible="box1" title="消息" width="30%" :before-close="beforeCloseProp">
+      <span>当前窗口有50%的概率关闭</span>
+      <template #footer>
+        <tiny-button @click="handleBox1Close">取 消</tiny-button>
+        <tiny-button type="primary" @click="handleBox1Close">确 定</tiny-button>
+      </template>
+    </tiny-dialog-box>
+
+    <tiny-dialog-box ref="box2Ref" v-model:visible="box2" title="消息" width="30%" @before-close="onBeforeClose">
+      <span>当前窗口有50%的概率关闭</span>
+      <template #footer>
+        <tiny-button @click="handleBox2Close">取 消</tiny-button>
+        <tiny-button type="primary" @click="handleBox2Close">确 定</tiny-button>
+      </template>
+    </tiny-dialog-box>
+  </div>
+</template>
+
+<script lang="jsx">
+import { TinyButton, TinyDialogBox, Modal } from '@opentiny/vue'
+
+export default {
+  components: {
+    TinyButton,
+    TinyDialogBox
+  },
+  data() {
+    return {
+      box1: false,
+      box2: false
+    }
+  },
+  methods: {
+    beforeCloseProp(type) {
+      // 模拟异步校验，是否需要关闭
+      setTimeout(() => {
+        if (Math.random() > 0.5) {
+          this.$refs.box1Ref.hide(type)
+        } else {
+          Modal.alert('已拦截关闭')
+        }
+      }, 1000)
+
+      return false // 拦截关闭
+    },
+    onBeforeClose(event, hideFn) {
+      // 模拟异步校验，是否需要关闭
+      setTimeout(() => {
+        if (Math.random() > 0.5) {
+          hideFn()
+        } else {
+          Modal.alert('已拦截关闭')
+        }
+      }, 1000)
+
+      event.preventDefault() // 拦截关闭
+    },
+    handleBox1Close() {
+      this.$refs.box1Ref.handleClose()
+    },
+    handleBox2Close() {
+      this.$refs.box2Ref.handleClose()
+    }
+  }
+}
+</script>

--- a/examples/sites/demos/pc/app/dialog-box/webdoc/dialog-box.js
+++ b/examples/sites/demos/pc/app/dialog-box/webdoc/dialog-box.js
@@ -298,7 +298,7 @@ export default {
       demoId: 'before-close',
       name: {
         'zh-CN': '关闭前拦截',
-        'en-US': 'bofore close blocking'
+        'en-US': 'before close blocking'
       },
       desc: {
         'zh-CN': `

--- a/examples/sites/demos/pc/app/dialog-box/webdoc/dialog-box.js
+++ b/examples/sites/demos/pc/app/dialog-box/webdoc/dialog-box.js
@@ -295,6 +295,22 @@ export default {
       codeFiles: ['open-close-events.vue']
     },
     {
+      demoId: 'before-close',
+      name: {
+        'zh-CN': '关闭前拦截',
+        'en-US': 'bofore close blocking'
+      },
+      desc: {
+        'zh-CN': `
+          可通过设置属性<code>before-close</code>,设置对话框关闭前时触发的拦截函数。
+          也可以通过绑定事件<code>before-close</code>,但它们的用法有细微差异，详见下面示例`,
+        'en-US': `
+          You can set the <code>before-close</code> property to define a function that triggers before the dialog box closes.
+          You can also bind the <code>before-close</code> event, but their usage differs slightly. See the example below.`
+      },
+      codeFiles: ['before-close.vue']
+    },
+    {
       demoId: 'transition-effect',
       name: {
         'zh-CN': '启用弹出动效',

--- a/packages/renderless/src/dialog-box/index.ts
+++ b/packages/renderless/src/dialog-box/index.ts
@@ -194,16 +194,15 @@ export const handleClose =
     if (typeof props.beforeClose === 'function' && props.beforeClose(type) === false) {
       return
     }
+    if (!emitEvent(emit, 'before-close', api.hide)) {
+      return
+    }
 
     const el = parent.$el
 
     if (props.rightSlide) {
       const dialogBoxDom = (el.querySelector(constants.DIALOG_BOX_CLASS) || el) as HTMLElement
       dialogBoxDom.style.left = ''
-    }
-
-    if (!emitEvent(emit, 'before-close', api.hide)) {
-      return
     }
 
     api.hide(type)

--- a/packages/renderless/src/dialog-box/vue.ts
+++ b/packages/renderless/src/dialog-box/vue.ts
@@ -48,6 +48,7 @@ export const api = [
   'afterEnter',
   'afterLeave',
   'handleClose',
+  'hide',
   'handleWrapperClick',
   'useMouseEventDown',
   'useMouseEventUp',


### PR DESCRIPTION
# PR
添加 before-close的属性的文档
添加before-close的综合示例
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a before-close prop and enhanced before-close event to allow intercepting dialog closure (can prevent close).

* **New Examples**
  * Added demos showing async before-close interception via prop and event, including a Composition API example.

* **Documentation**
  * Added a demo entry describing the before-close use case.

* **Tests**
  * Added an automated UI test covering the before-close demo.

* **New Public API**
  * Exposed a hide handler on the dialog public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->