### PR TITLE
fix(select): remove displayOnlyContent in slot-reference

### DIFF
--- a/packages/renderless/src/select/vue.ts
+++ b/packages/renderless/src/select/vue.ts
@@ -242,6 +242,9 @@ const initState = ({
         : state.selected
     ),
     displayOnlyContent: computed(() => {
+      if (vm.$slots.reference) {
+        return ''
+      }
       if (props.multiple) {
         if (Array.isArray(state.selected)) {
           // 如果已经displayOnly 且传入了options,从这里找label, 否则从state.selected （displayOnly时不渲染options)


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
When using <code>reference</code> slot, hovering over the trigger source causes displayOnlyContent to appear.

## What is the new behavior?
When using <code>reference</code> slot, hovering over the trigger source will no longer show displayforContent.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
[slot-reference playground](https://opentiny.design/vue-playground?cmpId=select&fileName=slot-reference.vue&apiMode=Composition&mode=pc&theme=os)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved display behavior in select components when using reference slots, preventing unintended content conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->