### PR TITLE
feat: add the hideSaas attribute to hide the demo and related properties

### DIFF
--- a/examples/sites/demos/apis/config-provider.js
+++ b/examples/sites/demos/apis/config-provider.js
@@ -51,7 +51,8 @@ export default {
             'en-US': 'Customized theme color, in {data:"tv-base-color-brand":"#595959",....} format.'
           },
           mode: ['pc'],
-          pcDemo: 'theme'
+          pcDemo: 'theme',
+          hideSaas: true // 当环境变量为tiny-vue-saas时隐藏该属性
         }
       ],
       events: [],

--- a/examples/sites/demos/pc/app/carousel/webdoc/carousel.js
+++ b/examples/sites/demos/pc/app/carousel/webdoc/carousel.js
@@ -97,7 +97,8 @@ export default {
         'zh-CN': '<p>通过配置 <code>type</code> 属性为<code>vertical</code>即可实现纵向轮播。</p>\n',
         'en-US': '<p>Set <code>type</code> to vertical to implement <code>vertical</code> rotation. </p>\n'
       },
-      codeFiles: ['up-down-carousel.vue']
+      codeFiles: ['up-down-carousel.vue'],
+      hideSaas: true
     },
     {
       demoId: 'show-title',

--- a/examples/sites/demos/pc/app/config-provider/webdoc/config-provider.js
+++ b/examples/sites/demos/pc/app/config-provider/webdoc/config-provider.js
@@ -54,7 +54,8 @@ export default {
         'zh-CN': '可通过<code>theme</code>属性设置自定义主题色常量。',
         'en-US': 'You can use the <code>theme</code> property to set a custom theme color constant.'
       },
-      codeFiles: ['theme.vue']
+      codeFiles: ['theme.vue'],
+      hideSaas: true // 当环境变量为tiny-vue-saas时隐藏该属性
     }
   ],
   features: [

--- a/examples/sites/src/components/anchor.vue
+++ b/examples/sites/src/components/anchor.vue
@@ -16,7 +16,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { TinyAnchor } from '@opentiny/vue'
-import { isSaas, isTinyVueSaas } from '../const'
+import { isSaas } from '../const'
 
 const props = defineProps({ anchorAffix: {}, currentJson: {}, activeTab: {}, langKey: {}, apiTypes: {} })
 
@@ -25,7 +25,7 @@ const emit = defineEmits(['link-click'])
 // 实例锚点
 const demoAnchorLinks = computed(() =>
   (props.currentJson?.demos || [])
-    .filter((demo) => (isTinyVueSaas ? !demo.hideSaas : true))
+    .filter((demo) => (isSaas ? !demo.hideSaas : true))
     .map((demo) => ({
       key: demo.demoId,
       title: demo.name[props.langKey],

--- a/examples/sites/src/components/anchor.vue
+++ b/examples/sites/src/components/anchor.vue
@@ -16,22 +16,22 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { TinyAnchor } from '@opentiny/vue'
-import { isSaas } from '../const'
+import { isSaas, isTinyVueSaas } from '../const'
 
 const props = defineProps({ anchorAffix: {}, currentJson: {}, activeTab: {}, langKey: {}, apiTypes: {} })
 
 const emit = defineEmits(['link-click'])
 
 // 实例锚点
-const demoAnchorLinks = computed(() => {
-  const links =
-    props.currentJson?.demos?.map((demo) => ({
+const demoAnchorLinks = computed(() =>
+  (props.currentJson?.demos || [])
+    .filter((demo) => (isTinyVueSaas ? !demo.hideSaas : true))
+    .map((demo) => ({
       key: demo.demoId,
       title: demo.name[props.langKey],
       link: `#${demo.demoId}`
-    })) || []
-  return links
-})
+    }))
+)
 
 // 组件API锚点
 const apiAnchorLinks = computed(() => {

--- a/examples/sites/src/const.ts
+++ b/examples/sites/src/const.ts
@@ -1,6 +1,7 @@
 import { tinyOldTheme, tinyAuroraTheme, tinyDarkTheme } from '@opentiny/vue-theme/theme-tool'
 
 export const isSaas = import.meta.env.VITE_TINY_THEME === 'saas'
+export const isTinyVueSaas = import.meta.env.VITE_CONTEXT === '/tiny-vue-saas/'
 
 // localStorage中保存语言的key
 export const LANG_KEY = '_lang'

--- a/examples/sites/src/const.ts
+++ b/examples/sites/src/const.ts
@@ -1,7 +1,6 @@
 import { tinyOldTheme, tinyAuroraTheme, tinyDarkTheme } from '@opentiny/vue-theme/theme-tool'
 
 export const isSaas = import.meta.env.VITE_TINY_THEME === 'saas'
-export const isTinyVueSaas = import.meta.env.VITE_CONTEXT === '/tiny-vue-saas/'
 
 // localStorage中保存语言的key
 export const LANG_KEY = '_lang'

--- a/examples/sites/src/views/components-doc/common.vue
+++ b/examples/sites/src/views/components-doc/common.vue
@@ -114,7 +114,7 @@ import DesignToken from '../../components/design-token.vue'
 import McpDocs from '../../components/mcp-docs.vue'
 import useTasksFinish from '../../composable/useTasksFinish'
 import list from '@opentiny/vue-theme/token'
-import { isTinyVueSaas } from '../../const'
+import { isSaas } from '../../const'
 import { getTinyVueMcpConfig } from '@opentiny/tiny-vue-mcp'
 import { camelize, capitalize } from '@vue/shared'
 
@@ -237,7 +237,7 @@ const parseApiData = () => {
   }
 
   // 当环境变量为tiny-vue-saas时
-  if (isTinyVueSaas) {
+  if (isSaas) {
     for (const group of Object.keys(tableData)) {
       for (const apiType of Object.keys(tableData[group])) {
         tableData[group][apiType] = tableData[group][apiType].filter((item) => !item.hideSaas)

--- a/examples/sites/src/views/components-doc/common.vue
+++ b/examples/sites/src/views/components-doc/common.vue
@@ -114,6 +114,7 @@ import DesignToken from '../../components/design-token.vue'
 import McpDocs from '../../components/mcp-docs.vue'
 import useTasksFinish from '../../composable/useTasksFinish'
 import list from '@opentiny/vue-theme/token'
+import { isTinyVueSaas } from '../../const'
 import { getTinyVueMcpConfig } from '@opentiny/tiny-vue-mcp'
 import { camelize, capitalize } from '@vue/shared'
 
@@ -207,7 +208,7 @@ const parseApiData = () => {
     for (const apiType of Object.keys(apiGroup)) {
       if (Array.isArray(apiGroup[apiType]) && apiGroup[apiType].length) {
         const apiArr = apiGroup[apiType].map((i) => {
-          const { name, type, defaultValue, desc, demoId, typeAnchorName, linkTo, meta, versionTipOption } = i
+          const { name, type, defaultValue, desc, demoId, typeAnchorName, linkTo, meta, versionTipOption, hideSaas } = i
           const item = {
             name,
             type,
@@ -217,7 +218,8 @@ const parseApiData = () => {
             meta,
             versionTipOption,
             typeAnchorName: '',
-            linkTo
+            linkTo,
+            hideSaas
           }
           if (typeAnchorName) {
             item.typeAnchorName = `${typeAnchorName?.includes('#') ? '' : '#'}${typeAnchorName}`
@@ -232,6 +234,15 @@ const parseApiData = () => {
     }
 
     tableData[apiGroup.name] = apiDisplay
+  }
+
+  // 当环境变量为tiny-vue-saas时
+  if (isTinyVueSaas) {
+    for (const group of Object.keys(tableData)) {
+      for (const apiType of Object.keys(tableData[group])) {
+        tableData[group][apiType] = tableData[group][apiType].filter((item) => !item.hideSaas)
+      }
+    }
   }
   state.tableData = tableData
 }


### PR DESCRIPTION
# PR
当在saas官网时，此组件无需theme属性配置，隐藏theme属性
<img width="1207" height="612" alt="image" src="https://github.com/user-attachments/assets/920df691-4471-4c70-881b-1f4de0c7305c" />

当在saas官网时，此组件无需展示属性相关的demo示例，隐藏此demo
<img width="1052" height="569" alt="image" src="https://github.com/user-attachments/assets/37b83368-5eae-4039-b17f-8ba5871c63c6" />



## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added visibility control flags to documentation and demo configuration items, enabling selective hiding of specific entries when running in SaaS mode.

* **Refactor**
  * Streamlined demo anchor link filtering implementation by replacing multi-line computed logic with direct expression-based evaluation for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->