### PR TITLE
fix(numeric): numeric modelValue type should not include underfined

### DIFF
--- a/examples/sites/demos/pc/app/numeric/allow-empty.spec.ts
+++ b/examples/sites/demos/pc/app/numeric/allow-empty.spec.ts
@@ -10,5 +10,5 @@ test('可清空特性', async ({ page }) => {
   await demo.getByRole('spinbutton').blur()
 
   const inputValue = await demo.locator('.tiny-numeric__input-inner').inputValue()
-  expect(inputValue).toEqual('0')
+  expect(inputValue).toEqual('')
 })

--- a/examples/sites/demos/pc/app/numeric/allow-empty.spec.ts
+++ b/examples/sites/demos/pc/app/numeric/allow-empty.spec.ts
@@ -10,5 +10,5 @@ test('可清空特性', async ({ page }) => {
   await demo.getByRole('spinbutton').blur()
 
   const inputValue = await demo.locator('.tiny-numeric__input-inner').inputValue()
-  expect(inputValue).toEqual('')
+  expect(inputValue).toEqual('0')
 })

--- a/packages/vue/src/numeric/src/index.ts
+++ b/packages/vue/src/numeric/src/index.ts
@@ -82,7 +82,10 @@ export const numericProps = {
     type: Boolean,
     default: true
   },
-  modelValue: [Number, String, undefined],
+  modelValue: {
+    type: [Number, String],
+    default: 0
+  },
   mouseWheel: Boolean,
   name: String,
   placeholder: String,

--- a/packages/vue/src/numeric/src/index.ts
+++ b/packages/vue/src/numeric/src/index.ts
@@ -82,10 +82,7 @@ export const numericProps = {
     type: Boolean,
     default: true
   },
-  modelValue: {
-    type: [Number, String],
-    default: 0
-  },
+  modelValue: [Number, String],
   mouseWheel: Boolean,
   name: String,
   placeholder: String,


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3789 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * The numeric component now strictly validates the `modelValue` prop, accepting only `Number` or `String` types. Undefined values are no longer permitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->