### PR TITLE
fix(grid): remove last visible row border

### DIFF
--- a/packages/theme-saas/src/grid/table.less
+++ b/packages/theme-saas/src/grid/table.less
@@ -268,25 +268,6 @@
     }
   }
 
-  // tiny新增滚动条放置表格内
-  tbody tr.row__last-visible {
-    &::after {
-      @apply content-[''];
-      @apply absolute;
-      @apply left-0;
-      @apply right-0;
-      @apply h-px;
-      top: calc(var(--body-container-scroll-height) - 1px);
-      width: var(--body-container-scroll-width);
-      @apply bg-color-border-separator;
-      @apply ~'z-[3]';
-    }
-  }
-
-  &:has(.@{grid-prefix-cls}__footer-wrapper) tbody tr.row__last-visible::after {
-    display: none;
-  }
-
   &&__border,
   &&__border-saas {
     // 启用 border 只有表头生效，默认不建议启用 border 属性，另外如果内嵌列，则表头会自动启用 border 属性

--- a/packages/vue/src/grid/src/body/src/body.tsx
+++ b/packages/vue/src/grid/src/body/src/body.tsx
@@ -346,8 +346,6 @@ function renderRows(_vm) {
   const seqCount = { value: 0 }
   const $seq = ''
 
-  const lastVisibleIndex = rowPool.findLastIndex(({ used }) => Boolean(used))
-
   rowPool.forEach(({ id, item: { payload: row, level: rowLevel }, used }, $rowIndex) => {
     const rowActived = editConfig && actived.row === row
     const virtualRow = isVirtualRow(row)
@@ -382,8 +380,7 @@ function renderRows(_vm) {
       isSkipRowRender,
       row,
       rowActived,
-      rowClassName,
-      lastVisibleIndex
+      rowClassName
     }
 
     Object.assign(args, { rowIndex, rowLevel, rowid, rows, selection, seq, treeConfig, used, selectRow })
@@ -441,7 +438,7 @@ function renderRowAfter({ $table, _vm, row, rowIndex, rows, id, used }) {
 
 function renderRow(args) {
   const { $rowIndex, $seq, $table, _vm, editStore, id, isSkipRowRender, row, rowActived, rowClassName } = args
-  const { rowIndex, rowLevel, rowid, rows, selection, selectRow, seq, treeConfig, used, lastVisibleIndex } = args
+  const { rowIndex, rowLevel, rowid, rows, selection, selectRow, seq, treeConfig, used } = args
 
   if (isSkipRowRender) {
     return
@@ -474,8 +471,7 @@ function renderRow(args) {
           'row__new': editStore.insertList.includes(row),
           'row__selected': selection.includes(row),
           'row__radio': selectRow === row,
-          'row__actived': rowActived,
-          'row__last-visible': lastVisibleIndex === $rowIndex
+          'row__actived': rowActived
         },
         rowClassName
           ? isFunction(rowClassName)
@@ -862,8 +858,6 @@ export default defineComponent({
           'no-data': isNoData && $table.isShapeTable
         }}
         style={{
-          '--body-container-scroll-height': `${containerScrollHeight}px`,
-          '--body-container-scroll-width': `${containerScrollWidth}px`,
           height: bodyWrapperHeight ? `${bodyWrapperHeight}px` : undefined,
           minHeight: bodyWrapperMinHeight ? `${bodyWrapperMinHeight}px` : undefined,
           maxHeight: bodyWrapperMaxHeight ? `${bodyWrapperMaxHeight}px` : undefined


### PR DESCRIPTION
# PR
移除最后一个可视行的下边框。

此处的边框为修复老版本合并列下边框消失问题。
<img width="562" height="356" alt="image" src="https://github.com/user-attachments/assets/ec7a62d3-a22c-46ca-a76e-ed18e0ea611d" />
表格重构后版本不存在此问题，因此移除相关逻辑。
<img width="537" height="563" alt="image" src="https://github.com/user-attachments/assets/f8faf814-10d6-4377-a15a-d24de356acee" />

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified table scrollbar positioning and last visible row styling behavior in grid components, removing special overlay logic and conditional row styling rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->