### PR TITLE
fix(space): [space]default spacing for overlay button components

### DIFF
--- a/examples/sites/demos/mobile-first/app/space/space-size.vue
+++ b/examples/sites/demos/mobile-first/app/space/space-size.vue
@@ -15,7 +15,7 @@
 
     <!-- 使用 dynamic direction 值 -->
     <tiny-space class="tiny-space" :size="[rowValue, columnValue]" :wrap="true">
-      <tiny-button style="margin: 0" v-for="n in 15" :key="n">按钮 {{ n }}</tiny-button>
+      <tiny-button v-for="n in 15" :key="n">按钮 {{ n }}</tiny-button>
     </tiny-space>
   </div>
 </template>

--- a/examples/sites/demos/pc/app/space/space-size.vue
+++ b/examples/sites/demos/pc/app/space/space-size.vue
@@ -15,7 +15,7 @@
 
     <!-- 使用 dynamic direction 值 -->
     <tiny-space class="tiny-space" :size="[rowValue, columnValue]" :wrap="true">
-      <tiny-button style="margin: 0" v-for="n in 15" :key="n">按钮 {{ n }}</tiny-button>
+      <tiny-button v-for="n in 15" :key="n">按钮 {{ n }}</tiny-button>
     </tiny-space>
   </div>
 </template>

--- a/packages/theme/src/index.less
+++ b/packages/theme/src/index.less
@@ -123,6 +123,7 @@
 @import './skeleton-item/index.less';
 @import './slide-img/index.less';
 @import './slider/index.less';
+@import './space/index.less';
 @import './split/index.less';
 @import './statistic/index.less';
 @import './steps/index.less';

--- a/packages/theme/src/space/index.less
+++ b/packages/theme/src/space/index.less
@@ -1,0 +1,24 @@
+/**
+* Copyright (c) 2022 - present TinyVue Authors.
+* Copyright (c) 2022 - present Huawei Cloud Computing Technologies Co., Ltd.
+*
+* Use of this source code is governed by an MIT-style license.
+*
+* THE OPEN SOURCE SOFTWARE IN THIS PRODUCT IS DISTRIBUTED IN THE HOPE THAT IT WILL BE USEFUL,
+* BUT WITHOUT ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS FOR
+* A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
+*
+*/
+
+@import '../custom.less';
+@import './vars.less';
+
+@space-prefix-cls: ~'@{css-prefix}space';
+
+.@{space-prefix-cls} {
+  .inject-Space-vars();
+  // TODO: 需要和 button 组件的间距变量统一(button组件后续大版本变更,需要去除默认间距8px),变更后，再将此代码删除
+  && .tiny-button + .tiny-button {
+    margin-left: var(--tv-Space-margin);
+  }
+}

--- a/packages/theme/src/space/vars.less
+++ b/packages/theme/src/space/vars.less
@@ -1,0 +1,15 @@
+/**
+* Copyright (c) 2022 - present TinyVue Authors.
+* Copyright (c) 2022 - present Huawei Cloud Computing Technologies Co., Ltd.
+*
+* Use of this source code is governed by an MIT-style license.
+*
+* THE OPEN SOURCE SOFTWARE IN THIS PRODUCT IS DISTRIBUTED IN THE HOPE THAT IT WILL BE USEFUL,
+* BUT WITHOUT ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS FOR
+* A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
+*
+*/
+
+.inject-Space-vars() {
+  --tv-Space-margin: 0px;
+}

--- a/packages/theme/src/vars.less
+++ b/packages/theme/src/vars.less
@@ -52,6 +52,7 @@
 @import './slide-bar/vars.less';
 @import './tooltip/vars.less';
 @import './split/vars.less';
+@import './space/vars.less';
 @import './steps/vars.less';
 @import './switch/vars.less';
 @import './tabs/vars.less';

--- a/packages/vue/src/space/index.ts
+++ b/packages/vue/src/space/index.ts
@@ -11,6 +11,7 @@
  */
 
 import Space from './src/index'
+import '@opentiny/vue-theme/space/index.less'
 import { version } from './package.json'
 
 /* istanbul ignore next */


### PR DESCRIPTION
# PR
<img width="1718" height="822" alt="image" src="https://github.com/user-attachments/assets/d4ae88b6-beb9-44f9-bff6-0312a19c0adc" />

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:
--覆盖默认的button组件样式
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized Space spacing into theme-based styles and ensured the Space component loads those styles.
* **Style**
  * Removed per-button inline margin; adjacent buttons now receive left spacing from a theme variable (default 0px), standardizing spacing across instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->