### PR TITLE
fix(timeline): add description prop for configuration mode display Fixes #3070

### DIFF
--- a/examples/sites/demos/apis/time-line.js
+++ b/examples/sites/demos/apis/time-line.js
@@ -244,6 +244,17 @@ export default {
           mode: ['pc', 'mobile-first'],
           pcDemo: 'vertical-timeline',
           mfDemo: ''
+        },
+        {
+          name: 'description',
+          type: 'string',
+          defaultValue: '',
+          desc: {
+            'zh-CN': '时间线描述',
+            'en-US': 'Timeline description'
+          },
+          mode: ['pc', 'mobile-first'],
+          mfDemo: ''
         }
       ],
       events: [

--- a/examples/sites/demos/apis/time-line.js
+++ b/examples/sites/demos/apis/time-line.js
@@ -254,7 +254,10 @@ export default {
             'en-US': 'Timeline description'
           },
           mode: ['pc', 'mobile-first'],
-          mfDemo: ''
+          mfDemo: '',
+          meta: {
+            stable: '3.28.0'
+          }
         }
       ],
       events: [

--- a/packages/vue/src/timeline-item/src/pc.vue
+++ b/packages/vue/src/timeline-item/src/pc.vue
@@ -51,7 +51,12 @@
 
           <div class="tiny-timeline-item__description" ref="description">
             <slot name="description" :slot-scope="node">
-              {{ node.description }}
+              <span v-if="description !== undefined && description !== null">
+                {{ description }}
+              </span>
+              <span v-else-if="node.description !== undefined && node.description !== null">
+                {{ node.description }}
+              </span>
             </slot>
             <div v-show="nodeIndex === rootProps.active">
               <slot name="active-node-desc" :slot-scope="node"></slot>
@@ -168,7 +173,7 @@ import type { ITimelineItemApi } from '@opentiny/vue-renderless/types/timeline-i
 
 export default defineComponent({
   emits: ['click'],
-  props: [...props, 'node', 'space', 'lineWidth', 'shape', 'autoColorField', 'nodeIndex'],
+  props: [...props, 'node', 'space', 'lineWidth', 'shape', 'autoColorField', 'nodeIndex', 'description'],
   components: {
     IconWarn: iconWarn(),
     IconClose: iconClose(),


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public `description` property to the timeline component, enabling customizable item descriptions across PC and mobile-first views.
  * Timeline items now display the `description` property when provided, falling back to existing item content otherwise.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->