### PR TITLE
fix(saas-api): hide some props in saas mode

### DIFF
--- a/examples/sites/demos/apis/select.js
+++ b/examples/sites/demos/apis/select.js
@@ -16,7 +16,8 @@ export default {
           },
           mode: ['pc', 'mobile-first'],
           pcDemo: 'all-text',
-          mfDemo: 'all-text'
+          mfDemo: 'all-text',
+          hideSaas: true
         },
         {
           name: 'show-all-text-tag',
@@ -29,7 +30,8 @@ export default {
               'Specifies whether only the tag specified by all-text is displayed in the text box after the multi-select mode is specified. The default value is <code>false</code>. All options are displayed in the text box cyclically.'
           },
           mode: ['pc'],
-          pcDemo: 'all-text'
+          pcDemo: 'all-text',
+          hideSaas: true
         },
         {
           name: 'allow-copy',
@@ -93,7 +95,8 @@ export default {
           },
           mode: ['pc', 'mobile-first'],
           pcDemo: 'clear-no-match-value',
-          mfDemo: 'clear-no-match-value'
+          mfDemo: 'clear-no-match-value',
+          hideSaas: true
         },
         {
           name: 'clearable',
@@ -236,7 +239,8 @@ export default {
           },
           mode: ['pc', 'mobile-first'],
           pcDemo: 'input-box-type',
-          mfDemo: 'input-box-type'
+          mfDemo: 'input-box-type',
+          hideSaas: true
         },
         {
           name: 'is-drop-inherit-width',
@@ -285,7 +289,8 @@ export default {
               'Default maximum display lines for multiple lines, with automatic hiding option for exceeding lines'
           },
           mode: ['pc'],
-          pcDemo: 'collapse-tags'
+          pcDemo: 'collapse-tags',
+          hideSaas: true
         },
         {
           name: 'modelValue / v-model',
@@ -507,7 +512,8 @@ export default {
           },
           mode: ['pc', 'mobile-first'],
           pcDemo: 'searchable',
-          mfDemo: 'searchable'
+          mfDemo: 'searchable',
+          hideSaas: true
         },
         {
           name: 'show-alloption',
@@ -531,7 +537,8 @@ export default {
           },
           mode: ['pc', 'mobile-first'],
           pcDemo: 'no-data-text',
-          mfDemo: 'no-data-text'
+          mfDemo: 'no-data-text',
+          hideSaas: true
         },
         {
           name: 'size',
@@ -568,7 +575,8 @@ export default {
           },
           mode: ['pc', 'mobile-first'],
           pcDemo: 'tag-type',
-          mfDemo: 'tag-type'
+          mfDemo: 'tag-type',
+          hideSaas: true
         },
         {
           name: 'max-tag-width',
@@ -582,7 +590,8 @@ export default {
           pcDemo: '',
           meta: {
             stable: '3.22.0'
-          }
+          },
+          hideSaas: true
         },
         {
           name: 'text-field',
@@ -670,7 +679,8 @@ export default {
           },
           mode: ['pc', 'mobile-first'],
           pcDemo: 'collapse-tags',
-          mfDemo: 'collapse-tags'
+          mfDemo: 'collapse-tags',
+          hideSaas: true
         },
         {
           name: 'show-limit-text',
@@ -683,7 +693,8 @@ export default {
               'Display the proportion of the number of selected items and the total number of items in the multiple-choice box'
           },
           mode: ['pc'],
-          pcDemo: 'multiple'
+          pcDemo: 'multiple',
+          hideSaas: true
         },
         {
           name: 'init-label',
@@ -905,7 +916,8 @@ export default {
           },
           mode: ['pc', 'mobile-first'],
           pcDemo: 'slot-reference',
-          mfDemo: 'slot-reference'
+          mfDemo: 'slot-reference',
+          hideSaas: true
         }
       ]
     },

--- a/examples/sites/demos/pc/app/select/webdoc/select.js
+++ b/examples/sites/demos/pc/app/select/webdoc/select.js
@@ -28,7 +28,7 @@ export default {
         'zh-CN': `
             通过 <code>multiple</code> 属性启用多选功能，此时 <code>v-model</code> 的值为当前选中值所组成的数组。默认选中值会以标签（Tag 组件）展示。<br>
             通过 <code>multiple-limit</code> 属性限制最多可选择的个数，默认为 0 不限制。<br>
-            通过 <code>show-limit-text</code> 属性限制最多可选择的个数，默认为 0 不限制。<br>
+            通过 <code>show-limit-text</code> 属性限制最多可选择的个数，默认为 flase 不限制，非saas属性<br>
             多选时，通过给 option 标签配置 <code>required</code> 或者在 options 配置项中添加 <code>required</code> 属性，来设置必选选项。<br>
             通过 <code>dropdown-icon</code> 属性可自定义下拉图标，<code>drop-style</code> 属性可自定义下拉选项样式。<br>
         `,
@@ -50,7 +50,7 @@ export default {
       },
       desc: {
         'zh-CN':
-          '<p>通过 <code>collapse-tags</code> 属性设置选中多个选项时，多个标签缩略展示。设置 <code>show-proportion</code> 可展示当前选中条数和总条数占比，默认值为 <code>false</code> 。设置 <code>hover-expand</code> 为 <code>true</code> ，默认折叠标签，<code>hover</code> 时展示所有标签。标签内容超长时超出省略，<code>hover</code> 标签时展示 <code>tooltip</code> 。</p>\n',
+          '<p>通过 <code>collapse-tags</code> 属性设置选中多个选项时，多个标签缩略展示。设置 <code>show-proportion</code> 可展示当前选中条数和总条数占比，默认值为 <code>false</code>，非saas属性 。设置 <code>hover-expand</code> 为 <code>true</code> ，默认折叠标签，<code>hover</code> 时展示所有标签。标签内容超长时超出省略，<code>hover</code> 标签时展示 <code>tooltip</code> 。</p>\n',
         'en-US':
           '<p>When multiple options are selected through the <code>collapse-tags</code> attribute settings, multiple tags are displayed in a thumbnail. Set <code>show-proportion</code> to display the current number of selected items and the proportion of total items, with a default value of <code>false</code> . By setting <code>hover-expand</code> to <code>true</code> , the tags are collapsed by default, and all tags are displayed when hovering. If the content of the tag is too long, it should be omitted. When hovering the tag, a <code>tooltip</code> should be displayed</p>'
       },
@@ -86,7 +86,8 @@ export default {
         'en-US':
           '<p>Set the label type through the <code>tag-type</code> attribute, which is the same as the type attribute of the Tag component. Optional values: success/info/warning/danger.</p>\n'
       },
-      codeFiles: ['tag-type.vue']
+      codeFiles: ['tag-type.vue'],
+      hideSaas: true
     },
     {
       demoId: 'size',
@@ -178,7 +179,8 @@ export default {
         'en-US':
           '<p>The search box is displayed through the <code>searchable</code> attribute setting drop-down panel, which is not displayed by default. </p>\n'
       },
-      codeFiles: ['searchable.vue']
+      codeFiles: ['searchable.vue'],
+      hideSaas: true
     },
     {
       demoId: 'allow-create',
@@ -232,7 +234,8 @@ export default {
         'en-US':
           'The <p>Set the input box type through the <code>input-box-type</code> attribute. Optional values: input / underline. </p>\n'
       },
-      codeFiles: ['input-box-type.vue']
+      codeFiles: ['input-box-type.vue'],
+      hideSaas: true
     },
     {
       demoId: 'show-alloption',
@@ -259,7 +262,8 @@ export default {
         'en-US':
           '<p>By setting the value of the v-model through the <code>clear-no-match-value</code>attribute, if a matching value cannot be found in the options, it will be automatically cleared and will not be cleared by default.</p>\n'
       },
-      codeFiles: ['clear-no-match-value.vue']
+      codeFiles: ['clear-no-match-value.vue'],
+      hideSaas: true
     },
     {
       demoId: 'optimization',
@@ -351,7 +355,7 @@ export default {
       },
       desc: {
         'zh-CN':
-          '<p>通过 <code>no-data-text</code> 属性设置选项为空时显示的文本，<code>show-empty-image</code> 属性设置是否显示空数据图片，默认不显示。</p>\n',
+          '<p>通过 <code>no-data-text</code> 属性设置选项为空时显示的文本，<code>show-empty-image</code> 属性设置是否显示空数据图片，默认不显示，非saas属性。</p>\n',
         'en-US':
           '<p>By setting the<code>no-data-text</code> attribute to display text when the option is empty, and by setting the <code>show-empty-image</code> attribute to display empty data images, it is not displayed by default.</p>\n'
       },
@@ -616,7 +620,8 @@ export default {
         'zh-CN': '<p>通过 <code>reference</code> 插槽自定义触发源的 HTML 模板。</p>\n',
         'en-US': '<p>Customize the HTML template of the trigger source through the <code>reference</code> slot.</p>'
       },
-      codeFiles: ['slot-reference.vue']
+      codeFiles: ['slot-reference.vue'],
+      hideSaas: true
     },
     {
       demoId: 'slot-label',
@@ -647,7 +652,8 @@ export default {
           If <code>show-all-text-tag</code> is set to <code>true</code> and all is selected, only the tag specified by <code>all-text</code> is displayed in the text box. The default value is <code>false</code>.
         `
       },
-      codeFiles: ['all-text.vue']
+      codeFiles: ['all-text.vue'],
+      hideSaas: true
     },
     {
       demoId: 'events',

--- a/examples/sites/demos/saas/menus.js
+++ b/examples/sites/demos/saas/menus.js
@@ -6,13 +6,21 @@ const noSaasComponents = [
   'ActionMenu',
   'ColorPicker',
   'ColorSelectPanel',
+  'DatePanel',
   'DatePickerMobileFirst',
   'MindMap',
   'QrCode',
   'RichTextEditor',
   'TimelineItem',
   'Watermark',
-  'Statistic'
+  'Statistic',
+  'Space',
+  'BaseSelect',
+  'FluentEditor',
+  'TreeSelect',
+  'GridSelect',
+  'ConfigProvider',
+  'Skeleton'
 ]
 
 // mobile-first上所有分类，pc上都有，因此可以用pc端menu分类进行合并

--- a/packages/vue/src/select/src/index.ts
+++ b/packages/vue/src/select/src/index.ts
@@ -368,6 +368,7 @@ export default defineComponent({
       type: [String, Number],
       default: null
     },
+    // 专门为saas增加，只有一个项时，自动选中
     autoSelect: {
       type: Boolean,
       default: false


### PR DESCRIPTION
# PR
1、从saas官网的菜单中，隐藏某些组件
2、为select的部分属性，添加 hideSaas:true
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added autoSelect property to Select component for automatic selection when only one item is available.

* **Chores**
  * Updated Select component documentation metadata to control visibility in different environments.
  * Adjusted component availability configuration for SaaS platform.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->