### PR TITLE
feat(tag): [tag] add round prop to support circular border radius

### DIFF
--- a/examples/sites/demos/apis/tag.js
+++ b/examples/sites/demos/apis/tag.js
@@ -175,6 +175,18 @@ export default {
           mode: ['pc', 'mobile-first'],
           pcDemo: 'basic-usage',
           mfDemo: ''
+        },
+        {
+          name: 'round',
+          type: 'boolean',
+          defaultValue: 'false',
+          desc: {
+            'zh-CN': '是否为圆角的模式',
+            'en-US': 'Whether it is a circular mode'
+          },
+          mode: ['pc'],
+          pcDemo: 'round',
+          mfDemo: ''
         }
       ],
       events: [

--- a/examples/sites/demos/apis/tag.js
+++ b/examples/sites/demos/apis/tag.js
@@ -186,7 +186,10 @@ export default {
           },
           mode: ['pc'],
           pcDemo: 'round',
-          mfDemo: ''
+          mfDemo: '',
+          meta: {
+            stable: '3.28.0'
+          }
         }
       ],
       events: [

--- a/examples/sites/demos/pc/app/tag/round-composition-api.vue
+++ b/examples/sites/demos/pc/app/tag/round-composition-api.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="tag-round-demo">
+    <h4>Round 属性示例</h4>
+
+    <tiny-tag type="primary" round>圆角标签</tiny-tag>
+    <tiny-tag type="success" round>成功标签</tiny-tag>
+    <tiny-tag type="warning" round>警告标签</tiny-tag>
+    <tiny-tag type="danger" round>危险标签</tiny-tag>
+
+    <tiny-tag type="info" round only-icon>
+      <tiny-icon-heartempty />
+    </tiny-tag>
+  </div>
+</template>
+
+<script setup>
+import { TinyTag } from '@opentiny/vue'
+import { IconHeartempty } from '@opentiny/vue-icon'
+
+const tinyIconHeartempty = IconHeartempty()
+</script>
+
+<style scoped>
+.tiny-tag {
+  margin-right: 12px;
+  margin-bottom: 12px;
+}
+
+h4 {
+  margin-bottom: 16px;
+  color: #333;
+}
+</style>

--- a/examples/sites/demos/pc/app/tag/round.spec.ts
+++ b/examples/sites/demos/pc/app/tag/round.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test'
+
+test('round 属性基础测试', async ({ page }) => {
+  page.on('pageerror', (exception) => expect(exception).not.toBeNull())
+  await page.goto('tag#round-usage')
+
+  // 测试圆角标签是否存在
+  const roundTag = page.locator('.tiny-tag').filter({ hasText: '圆角标签' }).first()
+  await expect(roundTag).toHaveCount(1)
+
+  // 验证圆角标签具有圆角样式
+  await expect(roundTag).toHaveCSS('border-radius', '9999px')
+
+  // 测试成功标签的圆角
+  const successTag = page.locator('.tiny-tag').filter({ hasText: '成功标签' }).first()
+  await expect(successTag).toHaveCSS('border-radius', '9999px')
+
+  // 测试警告标签的圆角
+  const warningTag = page.locator('.tiny-tag').filter({ hasText: '警告标签' }).first()
+  await expect(warningTag).toHaveCSS('border-radius', '9999px')
+
+  // 测试危险标签的圆角
+  const dangerTag = page.locator('.tiny-tag').filter({ hasText: '危险标签' }).first()
+  await expect(dangerTag).toHaveCSS('border-radius', '9999px')
+})
+
+test('round 属性特殊标签测试', async ({ page }) => {
+  page.on('pageerror', (exception) => expect(exception).not.toBeNull())
+  await page.goto('tag#round-usage')
+
+  // 测试圆角图标标签
+  const iconTag = page.locator('.tiny-tag--only-icon').first()
+  await expect(iconTag).toHaveCSS('border-radius', '9999px')
+
+  // 测试圆角配置式标签
+  const valueTag = page.locator('.tiny-tag').filter({ hasText: '圆角配置标签' })
+  await expect(valueTag).toHaveCount(1)
+  await expect(valueTag).toHaveCSS('border-radius', '9999px')
+})
+
+test('round 属性样式验证', async ({ page }) => {
+  page.on('pageerror', (exception) => expect(exception).not.toBeNull())
+  await page.goto('tag#round-usage')
+
+  // 验证所有具有round属性的标签都具有正确的圆角样式
+  const roundTags = page.locator('.tiny-tag')
+  const count = await roundTags.count()
+
+  for (let i = 0; i < count; i++) {
+    const tag = roundTags.nth(i)
+    await expect(tag).toHaveCSS('border-radius', '9999px')
+  }
+
+  // 验证标签数量是否正确
+  expect(count).toBe(6) // 4个基础标签 + 1个图标标签 + 1个配置标签
+})
+
+test('round 属性视觉呈现测试', async ({ page }) => {
+  page.on('pageerror', (exception) => expect(exception).not.toBeNull())
+  await page.goto('tag#round-usage')
+
+  // 测试不同类型的标签视觉呈现
+  const typeClasses = [
+    'tiny-tag--primary',
+    'tiny-tag--success',
+    'tiny-tag--warning',
+    'tiny-tag--danger',
+    'tiny-tag--info'
+  ]
+
+  for (const typeClass of typeClasses) {
+    const tag = page.locator(`.tiny-tag.${typeClass}`).first()
+    await expect(tag).toBeVisible()
+
+    // 验证圆角样式
+    const borderRadius = await tag.evaluate((el) => {
+      return window.getComputedStyle(el).borderRadius
+    })
+    expect(borderRadius).toBe('9999px')
+
+    // 验证标签可见且具有内容
+    const isVisible = await tag.isVisible()
+    expect(isVisible).toBe(true)
+  }
+})

--- a/examples/sites/demos/pc/app/tag/round.spec.ts
+++ b/examples/sites/demos/pc/app/tag/round.spec.ts
@@ -1,85 +1,12 @@
 import { test, expect } from '@playwright/test'
 
-test('round 属性基础测试', async ({ page }) => {
-  page.on('pageerror', (exception) => expect(exception).not.toBeNull())
-  await page.goto('tag#round-usage')
+test('圆角', async ({ page }) => {
+  page.on('pageerror', (exception) => expect(exception).toBeNull())
+  await page.goto('tag#round')
 
-  // 测试圆角标签是否存在
-  const roundTag = page.locator('.tiny-tag').filter({ hasText: '圆角标签' }).first()
-  await expect(roundTag).toHaveCount(1)
+  const tags = page.locator('.all-demos-container').locator('.tiny-tag')
+  const count = await tags.count()
 
-  // 验证圆角标签具有圆角样式
-  await expect(roundTag).toHaveCSS('border-radius', '9999px')
-
-  // 测试成功标签的圆角
-  const successTag = page.locator('.tiny-tag').filter({ hasText: '成功标签' }).first()
-  await expect(successTag).toHaveCSS('border-radius', '9999px')
-
-  // 测试警告标签的圆角
-  const warningTag = page.locator('.tiny-tag').filter({ hasText: '警告标签' }).first()
-  await expect(warningTag).toHaveCSS('border-radius', '9999px')
-
-  // 测试危险标签的圆角
-  const dangerTag = page.locator('.tiny-tag').filter({ hasText: '危险标签' }).first()
-  await expect(dangerTag).toHaveCSS('border-radius', '9999px')
-})
-
-test('round 属性特殊标签测试', async ({ page }) => {
-  page.on('pageerror', (exception) => expect(exception).not.toBeNull())
-  await page.goto('tag#round-usage')
-
-  // 测试圆角图标标签
-  const iconTag = page.locator('.tiny-tag--only-icon').first()
-  await expect(iconTag).toHaveCSS('border-radius', '9999px')
-
-  // 测试圆角配置式标签
-  const valueTag = page.locator('.tiny-tag').filter({ hasText: '圆角配置标签' })
-  await expect(valueTag).toHaveCount(1)
-  await expect(valueTag).toHaveCSS('border-radius', '9999px')
-})
-
-test('round 属性样式验证', async ({ page }) => {
-  page.on('pageerror', (exception) => expect(exception).not.toBeNull())
-  await page.goto('tag#round-usage')
-
-  // 验证所有具有round属性的标签都具有正确的圆角样式
-  const roundTags = page.locator('.tiny-tag')
-  const count = await roundTags.count()
-
-  for (let i = 0; i < count; i++) {
-    const tag = roundTags.nth(i)
-    await expect(tag).toHaveCSS('border-radius', '9999px')
-  }
-
-  // 验证标签数量是否正确
-  expect(count).toBe(6) // 4个基础标签 + 1个图标标签 + 1个配置标签
-})
-
-test('round 属性视觉呈现测试', async ({ page }) => {
-  page.on('pageerror', (exception) => expect(exception).not.toBeNull())
-  await page.goto('tag#round-usage')
-
-  // 测试不同类型的标签视觉呈现
-  const typeClasses = [
-    'tiny-tag--primary',
-    'tiny-tag--success',
-    'tiny-tag--warning',
-    'tiny-tag--danger',
-    'tiny-tag--info'
-  ]
-
-  for (const typeClass of typeClasses) {
-    const tag = page.locator(`.tiny-tag.${typeClass}`).first()
-    await expect(tag).toBeVisible()
-
-    // 验证圆角样式
-    const borderRadius = await tag.evaluate((el) => {
-      return window.getComputedStyle(el).borderRadius
-    })
-    expect(borderRadius).toBe('9999px')
-
-    // 验证标签可见且具有内容
-    const isVisible = await tag.isVisible()
-    expect(isVisible).toBe(true)
-  }
+  // 动态创建与元素数量相同的期望数组
+  await expect(tags).toHaveClass(Array(count).fill(/tiny-tag--round/))
 })

--- a/examples/sites/demos/pc/app/tag/round.vue
+++ b/examples/sites/demos/pc/app/tag/round.vue
@@ -8,20 +8,19 @@
     <tiny-tag type="danger" :round="true">危险标签</tiny-tag>
 
     <tiny-tag type="info" :round="true" :only-icon="true">
-      <template #default>
-        <icon-heartempty />
-      </template>
+      <tiny-icon-heartempty />
     </tiny-tag>
   </div>
 </template>
 
 <script>
-import { Tag, Icon } from '@opentiny/vue'
+import { TinyTag } from '@opentiny/vue'
+import { IconHeartempty } from '@opentiny/vue-icon'
 
 export default {
   components: {
-    TinyTag: Tag,
-    IconHeartempty: Icon.IconHeartempty
+    TinyTag,
+    TinyIconHeartempty: IconHeartempty()
   }
 }
 </script>

--- a/examples/sites/demos/pc/app/tag/round.vue
+++ b/examples/sites/demos/pc/app/tag/round.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="tag-round-demo">
+    <h4>Round 属性示例</h4>
+
+    <tiny-tag type="primary" :round="true">圆角标签</tiny-tag>
+    <tiny-tag type="success" :round="true">成功标签</tiny-tag>
+    <tiny-tag type="warning" :round="true">警告标签</tiny-tag>
+    <tiny-tag type="danger" :round="true">危险标签</tiny-tag>
+
+    <tiny-tag type="info" :round="true" :only-icon="true">
+      <template #default>
+        <icon-heartempty />
+      </template>
+    </tiny-tag>
+  </div>
+</template>
+
+<script>
+import { Tag, Icon } from '@opentiny/vue'
+
+export default {
+  components: {
+    TinyTag: Tag,
+    IconHeartempty: Icon.IconHeartempty
+  }
+}
+</script>
+
+<style scoped>
+.tiny-tag {
+  margin-right: 12px;
+  margin-bottom: 12px;
+}
+
+h4 {
+  margin-bottom: 16px;
+  color: #333;
+}
+</style>

--- a/examples/sites/demos/pc/app/tag/webdoc/tag.js
+++ b/examples/sites/demos/pc/app/tag/webdoc/tag.js
@@ -115,6 +115,30 @@ export default {
       codeFiles: ['delete.vue']
     },
     {
+      demoId: 'round',
+      name: {
+        'zh-CN': '圆角',
+        'en-US': 'Round'
+      },
+      desc: {
+        'zh-CN': '通过 <code>round</code> 设置圆角。',
+        'en-US': 'Set the round through <code>round</code> .'
+      },
+      codeFiles: ['round.vue'],
+      api: {
+        props: {
+          round: {
+            type: 'boolean',
+            defaultValue: 'false',
+            desc: {
+              'zh-CN': '是否为圆角的模式',
+              'en-US': 'Whether it is a round mode'
+            }
+          }
+        }
+      }
+    },
+    {
       demoId: 'slot-default',
       name: {
         'zh-CN': '默认插槽',

--- a/packages/vue/src/tag/src/index.ts
+++ b/packages/vue/src/tag/src/index.ts
@@ -43,6 +43,10 @@ export const tagProps = {
     type: [String, Number],
     default: null
   },
+  round: {
+    type: Boolean,
+    default: false
+  },
   // mobile
   mini: {
     type: Boolean,

--- a/packages/vue/src/tag/src/pc.vue
+++ b/packages/vue/src/tag/src/pc.vue
@@ -33,7 +33,8 @@ export default defineComponent({
     'value',
     'beforeDelete',
     'onlyIcon',
-    'maxWidth'
+    'maxWidth',
+    'round'
   ],
   setup(props, context) {
     return setup({ props, context, renderless, api, h }) as unknown as ITagApi
@@ -53,7 +54,8 @@ export default defineComponent({
       state,
       value,
       onlyIcon,
-      maxWidth
+      maxWidth,
+      round
     } = this
 
     let styles = {}
@@ -65,7 +67,8 @@ export default defineComponent({
       effect ? `tiny-tag--${effect}` : '',
       hit && 'is-hit',
       disabled ? 'is-disabled' : '',
-      onlyIcon ? 'tiny-tag--only-icon' : ''
+      onlyIcon ? 'tiny-tag--only-icon' : '',
+      round ? 'tiny-tag--round' : ''
     ]
 
     if (color) {
@@ -80,6 +83,10 @@ export default defineComponent({
 
     if (maxWidth) {
       styles.maxWidth = maxWidth
+    }
+
+    if (round) {
+      styles.borderRadius = '9999px'
     }
 
     const tagElement =


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a round-corner option for the Tag component, enabling rounded borders and an icon-only rounded tag.

* **Documentation / Demos**
  * Added a new demo showcasing round-styled tags with examples and bilingual (zh/en) descriptions.

* **Tests**
  * Added end-to-end tests verifying the round styling is applied and visible across tag variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->