### PR TITLE
fix(grid): fix insert row can't change to edit mode

### DIFF
--- a/examples/sites/demos/pc/app/grid/data-source/undefined-field-defalut-value-composition-api.vue
+++ b/examples/sites/demos/pc/app/grid/data-source/undefined-field-defalut-value-composition-api.vue
@@ -1,25 +1,28 @@
 <template>
-  <tiny-grid :data="tableData" :edit-config="editConfig">
-    <tiny-grid-column field="field1" title="所属区域" :editor="{}">
-      <template #edit="{ row }">
-        <tiny-input v-model="row.field1" />
-      </template>
-    </tiny-grid-column>
-    <tiny-grid-column field="field2" title="地址" :editor="{ defaultValue: '' }">
-      <template #edit="{ row }">
-        <tiny-input v-model="row.field2" />
-      </template>
-    </tiny-grid-column>
-    <tiny-grid-column field="field3" title="邮编" :editor="{ defaultValue: '' }">
-      <template #edit="{ row }">
-        <tiny-input v-model="row.field3" />
-      </template>
-    </tiny-grid-column>
-  </tiny-grid>
+  <div>
+    <tiny-button @click="addRow">新增行</tiny-button>
+    <tiny-grid ref="gridRef" :data="tableData" :edit-config="editConfig">
+      <tiny-grid-column field="field1" title="所属区域" :editor="{}">
+        <template #edit="{ row }">
+          <tiny-input v-model="row.field1" />
+        </template>
+      </tiny-grid-column>
+      <tiny-grid-column field="field2" title="地址" :editor="{ defaultValue: '' }">
+        <template #edit="{ row }">
+          <tiny-input v-model="row.field2" />
+        </template>
+      </tiny-grid-column>
+      <tiny-grid-column field="field3" title="邮编" :editor="{ defaultValue: '' }">
+        <template #edit="{ row }">
+          <tiny-input v-model="row.field3" />
+        </template>
+      </tiny-grid-column>
+    </tiny-grid>
+  </div>
 </template>
 
 <script setup>
-import { TinyGrid, TinyGridColumn, TinyInput } from '@opentiny/vue'
+import { TinyGrid, TinyGridColumn, TinyInput, TinyButton } from '@opentiny/vue'
 import { ref } from 'vue'
 
 const tableData = ref([
@@ -36,4 +39,10 @@ const editConfig = ref({
   mode: 'cell',
   autofocus: 'input'
 })
+
+const gridRef = ref(null)
+
+const addRow = () => {
+  gridRef.value.insert({})
+}
 </script>

--- a/examples/sites/demos/pc/app/grid/data-source/undefined-field-defalut-value.spec.js
+++ b/examples/sites/demos/pc/app/grid/data-source/undefined-field-defalut-value.spec.js
@@ -17,4 +17,11 @@ test('缺省数据默认值', async ({ page }) => {
   await firstRow.locator('.tiny-input__inner').fill('2')
   await firstRow.locator('td').nth(1).click()
   await expect(firstRow.locator('td').nth(2)).toHaveClass(/col__valid-success/)
+
+  // 新增行
+  await demo.locator('.tiny-button').click()
+  await firstRow.locator('td').nth(1).click()
+  await firstRow.locator('.tiny-input__inner').click()
+  await firstRow.locator('.tiny-input__inner').fill('1')
+  await expect(firstRow.locator('.tiny-input__inner')).toHaveText('1')
 })

--- a/examples/sites/demos/pc/app/grid/data-source/undefined-field-defalut-value.spec.js
+++ b/examples/sites/demos/pc/app/grid/data-source/undefined-field-defalut-value.spec.js
@@ -8,6 +8,7 @@ test('缺省数据默认值', async ({ page }) => {
 
   const firstRow = demo.locator('.tiny-grid-body__row:visible').nth(0)
 
+  // 缺省值的修改能够正常显示角标
   await firstRow.locator('td').nth(1).click()
   await firstRow.locator('.tiny-input__inner').click()
   await firstRow.locator('.tiny-input__inner').fill('1')
@@ -18,7 +19,7 @@ test('缺省数据默认值', async ({ page }) => {
   await firstRow.locator('td').nth(1).click()
   await expect(firstRow.locator('td').nth(2)).toHaveClass(/col__valid-success/)
 
-  // 新增行
+  // 新增行能成功进入编辑态
   await demo.locator('.tiny-button').click()
   await firstRow.locator('td').nth(1).click()
   await firstRow.locator('.tiny-input__inner').click()

--- a/examples/sites/demos/pc/app/grid/data-source/undefined-field-defalut-value.spec.js
+++ b/examples/sites/demos/pc/app/grid/data-source/undefined-field-defalut-value.spec.js
@@ -23,5 +23,5 @@ test('缺省数据默认值', async ({ page }) => {
   await firstRow.locator('td').nth(1).click()
   await firstRow.locator('.tiny-input__inner').click()
   await firstRow.locator('.tiny-input__inner').fill('1')
-  await expect(firstRow.locator('.tiny-input__inner')).toHaveText('1')
+  await expect(firstRow.locator('.tiny-input__inner')).toHaveValue('1')
 })

--- a/examples/sites/demos/pc/app/grid/data-source/undefined-field-defalut-value.vue
+++ b/examples/sites/demos/pc/app/grid/data-source/undefined-field-defalut-value.vue
@@ -1,31 +1,35 @@
 <template>
-  <tiny-grid :data="tableData" :edit-config="editConfig">
-    <tiny-grid-column field="field1" title="所属区域" :editor="{}">
-      <template #edit="{ row }">
-        <tiny-input v-model="row.field1" />
-      </template>
-    </tiny-grid-column>
-    <tiny-grid-column field="field2" title="地址" :editor="{ defaultValue: '' }">
-      <template #edit="{ row }">
-        <tiny-input v-model="row.field2" />
-      </template>
-    </tiny-grid-column>
-    <tiny-grid-column field="field3" title="邮编" :editor="{ defaultValue: '' }">
-      <template #edit="{ row }">
-        <tiny-input v-model="row.field3" />
-      </template>
-    </tiny-grid-column>
-  </tiny-grid>
+  <div>
+    <tiny-button @click="addRow">新增行</tiny-button>
+    <tiny-grid ref="grid" :data="tableData" :edit-config="editConfig">
+      <tiny-grid-column field="field1" title="所属区域" :editor="{}">
+        <template #edit="{ row }">
+          <tiny-input v-model="row.field1" />
+        </template>
+      </tiny-grid-column>
+      <tiny-grid-column field="field2" title="地址" :editor="{ defaultValue: '' }">
+        <template #edit="{ row }">
+          <tiny-input v-model="row.field2" />
+        </template>
+      </tiny-grid-column>
+      <tiny-grid-column field="field3" title="邮编" :editor="{ defaultValue: '' }">
+        <template #edit="{ row }">
+          <tiny-input v-model="row.field3" />
+        </template>
+      </tiny-grid-column>
+    </tiny-grid>
+  </div>
 </template>
 
 <script>
-import { TinyGrid, TinyGridColumn, TinyInput } from '@opentiny/vue'
+import { TinyGrid, TinyGridColumn, TinyInput, TinyButton } from '@opentiny/vue'
 
 export default {
   components: {
     TinyGrid,
     TinyGridColumn,
-    TinyInput
+    TinyInput,
+    TinyButton
   },
   data() {
     return {
@@ -42,6 +46,11 @@ export default {
         mode: 'cell',
         autofocus: 'input'
       }
+    }
+  },
+  methods: {
+    addRow() {
+      this.$refs.grid.insert({})
     }
   }
 }

--- a/packages/vue/src/grid/src/composable/useNormalData.ts
+++ b/packages/vue/src/grid/src/composable/useNormalData.ts
@@ -3,7 +3,7 @@ import { hooks } from '@opentiny/vue-common'
 export const useNormalData = ({ props, visibleColumn }) => {
   const $table = hooks.getCurrentInstance()?.proxy
   // 原始数据
-  const rawData = hooks.ref(null)
+  const rawData = hooks.ref([])
   // 原始数据版本
   const rawDataVersion = hooks.ref(0)
 

--- a/packages/vue/src/grid/src/edit/src/methods.ts
+++ b/packages/vue/src/grid/src/edit/src/methods.ts
@@ -48,11 +48,22 @@ import {
   handleActivedTryActive
 } from './utils/handleActived'
 
-function operArrs({ _vm, editStore, newRecords, newRecordsCopy, nowData, row, tableFullData, tableSourceData }) {
+function operArrs({
+  _vm,
+  editStore,
+  newRecords,
+  newRecordsCopy,
+  nowData,
+  row,
+  tableFullData,
+  tableSourceData,
+  rawData
+}) {
   if (row === -1) {
     Array.prototype.push.apply(nowData, newRecords)
     Array.prototype.push.apply(tableFullData, newRecords)
     Array.prototype.push.apply(tableSourceData, newRecordsCopy)
+    Array.prototype.push.apply(rawData, newRecords)
   }
 
   if (row && row !== -1) {
@@ -67,12 +78,19 @@ function operArrs({ _vm, editStore, newRecords, newRecordsCopy, nowData, row, ta
     Array.prototype.splice.apply(nowData, [targetIndex, 0].concat(newRecords))
     Array.prototype.splice.apply(tableFullData, [insertIndex, 0].concat(newRecords))
     Array.prototype.splice.apply(tableSourceData, [insertIndex, 0].concat(newRecordsCopy))
+
+    let rawInsertIndex = rawData.indexOf(row)
+
+    if (rawInsertIndex > -1) {
+      Array.prototype.splice.apply(rawData, [rawInsertIndex, 0].concat(newRecords))
+    }
   }
 
   if (!row) {
     Array.prototype.unshift.apply(nowData, newRecords)
     Array.prototype.unshift.apply(tableFullData, newRecords)
     Array.prototype.unshift.apply(tableSourceData, newRecordsCopy)
+    Array.prototype.unshift.apply(rawData, newRecords)
   }
 
   Array.prototype.unshift.apply(editStore.insertList, newRecords)
@@ -129,7 +147,16 @@ export default {
   },
   // 根据位置从指定行添加数据
   _insertAt(records, row) {
-    let { afterFullData, editStore, isAsyncColumn, scrollYLoad, tableFullData, tableSourceData = [], treeConfig } = this
+    let {
+      afterFullData,
+      editStore,
+      isAsyncColumn,
+      scrollYLoad,
+      tableFullData,
+      tableSourceData = [],
+      treeConfig,
+      rawData
+    } = this
 
     if (treeConfig) {
       throw new Error(error('ui.grid.error.treeInsert'))
@@ -154,7 +181,17 @@ export default {
     let newRecords = records.map((record) => hooks.reactive(this.defineField({ ...record })))
     let newRecordsCopy = clone(newRecords, true)
 
-    operArrs({ _vm: this, editStore, newRecords, newRecordsCopy, nowData, row, tableFullData, tableSourceData })
+    operArrs({
+      _vm: this,
+      editStore,
+      newRecords,
+      newRecordsCopy,
+      nowData,
+      row,
+      tableFullData,
+      tableSourceData,
+      rawData
+    })
 
     this.updateCache()
     this.handleTableData(true)
@@ -236,7 +273,6 @@ export default {
     // 修改缓存
     this.updateCache()
     this.handleTableData(true)
-
     this.checkSelectionStatus()
     this.updateFooter()
     if (scrollYLoad) {

--- a/packages/vue/src/grid/src/table/src/methods.ts
+++ b/packages/vue/src/grid/src/table/src/methods.ts
@@ -326,7 +326,7 @@ const Methods = {
     })
   },
   updateRawData(datas) {
-    this.rawData = datas
+    this.rawData = [...datas]
     this.rawDataVersion += 1
   },
   getOriginRow(row) {


### PR DESCRIPTION
# PR
修复insert方法插入的数据无法进入编辑态的问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a UI button and programmatic API to insert new rows into the grid.

* **Bug Fixes**
  * Initialized internal data as an array and made stored raw data immutable to prevent mutation-related issues.
  * Synchronized underlying data arrays during row insertions to avoid inconsistencies.

* **Tests**
  * Added a test scenario for adding a new row, editing a cell, and asserting the value.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->