### PR TITLE
fix(popover): fix the clickoutside bug in the pop-up component

### DIFF
--- a/packages/renderless/src/popover/index.ts
+++ b/packages/renderless/src/popover/index.ts
@@ -183,8 +183,10 @@ export const handleDocumentClick =
     const $el = vm.$refs.root
     let target = event.target as HTMLElement
 
-    // 解决组件在webcomponents中触发document的click事件，但是e.target始终是webcomponents自定义标签，从而引起的判断失效的bug
-    if (target?.shadowRoot && popperElm) {
+    // 点击在webcomponents上时，document监听事件的e.target始终是webcomponents自身，所以要判断处理：
+    // 1. 包含关系：popover使用在乾坤等场景时， popover包含在自定义组件内时， 需要替换target为 真实的 webComponent的内部dom, 再进行判断
+    // 2. 平级关系：比如页面上有popover 和一个平级关系的自定义dom元素，此时不需要替换target
+    if (target?.shadowRoot && target.shadowRoot.contains($el) && popperElm) {
       target = state.webCompEventTarget as HTMLElement
     }
 


### PR DESCRIPTION
# PR
点击 popover 组件外面的webcompont 不能关闭的bug

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined popover event handling to correctly manage interactions with nested custom elements, improving reliability when used with web components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->