### PR TITLE
feat(vue-renderless/drawer): add close-on-press-escape api

### DIFF
--- a/examples/sites/demos/apis/drawer.js
+++ b/examples/sites/demos/apis/drawer.js
@@ -207,6 +207,20 @@ export default {
           mode: ['pc'],
           pcDemo: 'tips-props',
           hideSaas: true
+        },
+        {
+          name: 'close-on-press-escape',
+          type: 'boolean',
+          defaultValue: 'false',
+          desc: {
+            'zh-CN': 'ESC 键关闭抽屉',
+            'en-US': 'ESC key to close drawer'
+          },
+          mode: ['pc'],
+          pcDemo: 'closeOnPressEscape',
+          meta: {
+            stable: '3.28.0'
+          }
         }
       ],
       events: [

--- a/examples/sites/demos/pc/app/drawer/close-on-press-escape-composition-api.vue
+++ b/examples/sites/demos/pc/app/drawer/close-on-press-escape-composition-api.vue
@@ -1,0 +1,29 @@
+<template>
+  <div>
+    <tiny-button @click="openDrawer" type="primary"> 抽屉组件 </tiny-button>
+    <tiny-drawer
+      title="标题"
+      :visible="visible"
+      @update:visible="visible = $event"
+      @confirm="confirm"
+      :close-on-press-escape="true"
+    >
+      <div>内容区域</div>
+    </tiny-drawer>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { TinyDrawer, TinyButton } from '@opentiny/vue'
+
+const visible = ref(false)
+
+function openDrawer() {
+  visible.value = true
+}
+
+function confirm() {
+  visible.value = false
+}
+</script>

--- a/examples/sites/demos/pc/app/drawer/close-on-press-escape.spec.ts
+++ b/examples/sites/demos/pc/app/drawer/close-on-press-escape.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test'
+
+test('按 Esc 键关闭 Drawer（close-on-press-escape）', async ({ page }) => {
+  page.on('pageerror', (exception) => expect(exception).toBeNull())
+
+  await page.goto('drawer#close-on-press-escape')
+
+  const drawer = page.locator('.tiny-drawer__main')
+
+  // 打开 Drawer（用文本更稳定）
+  await page.getByText('抽屉组件').click()
+  await expect(drawer).toBeVisible()
+
+  // 按 Esc
+  await page.keyboard.press('Escape')
+
+  // Drawer 关闭
+  await expect(drawer).toBeHidden()
+})

--- a/examples/sites/demos/pc/app/drawer/close-on-press-escape.vue
+++ b/examples/sites/demos/pc/app/drawer/close-on-press-escape.vue
@@ -1,0 +1,38 @@
+<template>
+  <div>
+    <tiny-button @click="openDrawer" type="primary"> 抽屉组件 </tiny-button>
+    <tiny-drawer
+      title="标题"
+      :visible="visible"
+      @update:visible="visible = $event"
+      @confirm="confirm"
+      :close-on-press-escape="true"
+    >
+      <div>内容区域</div>
+    </tiny-drawer>
+  </div>
+</template>
+
+<script>
+import { TinyDrawer, TinyButton } from '@opentiny/vue'
+
+export default {
+  components: {
+    TinyDrawer,
+    TinyButton
+  },
+  data() {
+    return {
+      visible: false
+    }
+  },
+  methods: {
+    openDrawer() {
+      this.visible = true
+    },
+    confirm() {
+      this.visible = false
+    }
+  }
+}
+</script>

--- a/examples/sites/demos/pc/app/drawer/webdoc/drawer.js
+++ b/examples/sites/demos/pc/app/drawer/webdoc/drawer.js
@@ -17,6 +17,18 @@ export default {
       codeFiles: ['basic-usage.vue']
     },
     {
+      demoId: 'close-on-press-escape',
+      name: {
+        'zh-CN': '按下 ESC 关闭抽屉',
+        'en-US': ''
+      },
+      desc: {
+        'zh-CN': '<p>添加 <code>close-on-press-escape</code> 属性可以控制是否可以通过 ESC 关闭抽屉。</p>',
+        'en-US': ''
+      },
+      codeFiles: ['close-on-press-escape.vue']
+    },
+    {
       demoId: 'use-through-method',
       name: { 'zh-CN': '通过方法调用', 'en-US': 'Use through method' },
       desc: {

--- a/packages/renderless/src/drawer/index.ts
+++ b/packages/renderless/src/drawer/index.ts
@@ -80,6 +80,36 @@ export const handleClose =
     }
   }
 
+/* ================= Esc 关闭（受控） ================= */
+export const keydown =
+  ({ api, state, props }: Pick<IDrawerRenderlessParams, 'api' | 'state' | 'props'>) =>
+  (event: KeyboardEvent) => {
+    if (!state.visible) {
+      return
+    }
+
+    if (!props.closeOnPressEscape) {
+      return
+    }
+
+    if (event.key === 'Escape' || event.key === 'Esc') {
+      api.handleClose('esc', true)
+    }
+  }
+
+export const addKeydownEvent =
+  ({ api }: { api: IDrawerApi }) =>
+  () => {
+    document.addEventListener('keydown', api.keydown)
+  }
+
+export const removeKeydownEvent =
+  ({ api }: { api: IDrawerApi }) =>
+  () => {
+    document.removeEventListener('keydown', api.keydown)
+  }
+/* ================================================== */
+
 export const mousedown =
   ({ state, vm }: { vm: ISharedRenderlessParamUtils<IDrawerCT>['vm']; state: IDrawerState }) =>
   (event) => {

--- a/packages/renderless/src/drawer/vue.ts
+++ b/packages/renderless/src/drawer/vue.ts
@@ -12,7 +12,10 @@ import {
   handleClose,
   computedWidth,
   computedHeight,
-  open
+  open,
+  keydown,
+  addKeydownEvent,
+  removeKeydownEvent
 } from './index'
 import type {
   IDrawerProps,
@@ -50,8 +53,11 @@ export const renderless = (
     mousedown: mousedown({ state, vm }),
     mousemove: mousemove({ state, props, emit }),
     mouseup: mouseup({ state }),
-    addDragEvent: addDragEvent({ api: api as IDrawerApi, vm }),
-    removeDragEvent: removeDragEvent({ api: api as IDrawerApi, vm }),
+    keydown: keydown({ api, state, props }),
+    addKeydownEvent: addKeydownEvent({ api }),
+    removeKeydownEvent: removeKeydownEvent({ api }),
+    addDragEvent: addDragEvent({ api, vm }),
+    removeDragEvent: removeDragEvent({ api, vm }),
     watchVisible: watchVisible({ state, api }),
     showScrollbar: showScrollbar(lockScrollClass),
     hideScrollbar: hideScrollbar(lockScrollClass),
@@ -61,6 +67,7 @@ export const renderless = (
 
   onMounted(() => {
     props.dragable && api.addDragEvent()
+    api.addKeydownEvent()
     if (props.lockScroll && props.visible) {
       api.showScrollbar()
     }
@@ -68,6 +75,7 @@ export const renderless = (
 
   onBeforeUnmount(() => {
     props.dragable && api.removeDragEvent()
+    api.removeKeydownEvent()
     props.lockScroll && api.hideScrollbar()
   })
 

--- a/packages/vue/src/drawer/src/pc.vue
+++ b/packages/vue/src/drawer/src/pc.vue
@@ -161,7 +161,8 @@ export default defineComponent({
     'zIndex',
     'beforeClose',
     'tipsProps',
-    'customSlots'
+    'customSlots',
+    'closeOnPressEscape'
   ],
   emits: ['update:visible', 'open', 'close', 'confirm', 'drag'],
   setup(props, context) {


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Drawer component now includes a new `close-on-press-escape` prop that enables automatic drawer closure when the ESC key is pressed. This property is disabled by default and can be individually configured per drawer instance. Users can now leverage this keyboard-based interaction pattern as a familiar way to close drawers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->