### PR TITLE
[WIP]fix(modal): 修复 modal 组件在 alert, confirm 的弹窗场景下 top 属性不生效的问题

### DIFF
--- a/examples/sites/demos/apis/modal.js
+++ b/examples/sites/demos/apis/modal.js
@@ -379,10 +379,10 @@ export default {
         {
           name: 'top',
           type: 'number | string',
-          defaultValue: '80',
+          defaultValue: '80px',
           desc: {
-            'zh-CN': "消息距离顶部的位置，仅当 type 为 'message' 时有效",
-            'en-US': "The position of the message from the top, only valid when type is 'message'"
+            'zh-CN': '模态框距离顶部的位置',
+            'en-US': 'The position of the modal from the top'
           },
           mode: ['pc', 'mobile-first'],
           pcDemo: 'message-top',

--- a/examples/sites/demos/pc/app/modal/message-top.vue
+++ b/examples/sites/demos/pc/app/modal/message-top.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
     <div class="content">
-      <tiny-button @click="btnClick">消息距离顶部 500px</tiny-button>
+      <tiny-button @click="btnClick1">提示弹窗距离顶部 300px</tiny-button>
+      <tiny-button @click="btnClick2">确认弹窗距离顶部 50vh</tiny-button>
+      <tiny-button @click="btnClick3">消息距离顶部 500px</tiny-button>
     </div>
   </div>
 </template>
@@ -14,7 +16,21 @@ export default {
     TinyButton: Button
   },
   methods: {
-    btnClick() {
+    btnClick1() {
+      Modal.alert({
+        status: 'info',
+        message: '提示弹窗距离顶部 300px',
+        top: 300
+      })
+    },
+    btnClick2() {
+      Modal.confirm({
+        status: 'info',
+        message: '确认弹窗距离顶部 50vh',
+        top: '50vh'
+      })
+    },
+    btnClick3() {
       Modal.message({
         status: 'info',
         message: '自定义消息的内容距离顶部 500px',

--- a/examples/sites/demos/pc/app/modal/webdoc/modal.js
+++ b/examples/sites/demos/pc/app/modal/webdoc/modal.js
@@ -301,12 +301,12 @@ export default {
     {
       demoId: 'message-top',
       name: {
-        'zh-CN': '消息距离顶部位置',
+        'zh-CN': '模态框距离顶部位置',
         'en-US': 'Position from top'
       },
       desc: {
-        'zh-CN': '通过<code>top</code>属性设置消息距离顶部的位置，单位为 px',
-        'en-US': `Use the <code>top</code> property to set the distance from the top of the message in units of px. `
+        'zh-CN': '通过<code>top</code>属性设置模态框距离顶部的位置',
+        'en-US': 'Use the <code>top</code> property to set the distance from the top of the modal.'
       },
       codeFiles: ['message-top.vue']
     },

--- a/packages/renderless/src/modal/index.ts
+++ b/packages/renderless/src/modal/index.ts
@@ -61,8 +61,13 @@ export const computedBoxStyle =
       return {}
     }
 
+    let top = ''
     let width: string | number = ''
     let height: string | number = ''
+
+    if (props.type === 'alert' || props.type === 'confirm') {
+      top = typeof props.top === 'number' ? `${props.top}px` : props.top
+    }
 
     if (props.width) {
       width = isNaN(props.width as number) ? props.width : `${props.width}px`
@@ -72,7 +77,7 @@ export const computedBoxStyle =
       height = isNaN(props.height as number) ? props.height : `${props.height}px`
     }
 
-    return { width, height }
+    return { top, width, height }
   }
 
 export const watchValue =


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

modal 组件在 alert, confirm 的弹窗场景下 top 属性不生效

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

modal 组件在 alert, confirm 的弹窗场景下 top 属性生效

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

此改动会影响初始值从 15vh 变为 80px

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `top` positioning now applies to alert and confirm modal types and is supported with unit-aware values.

* **Bug Fixes**
  * Default `top` value formatted to include units (e.g., "80px") to ensure consistent positioning.

* **Documentation**
  * Updated modal docs and demo labels/descriptions to clarify modal top-position behavior and examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->