### PR TITLE
fix(select): fix the dropdown panel width cannot follow the input width

### DIFF
--- a/packages/renderless/src/select-dropdown/vue.ts
+++ b/packages/renderless/src/select-dropdown/vue.ts
@@ -94,12 +94,17 @@ const initApi = ({ api, popper, state, selectEmitter, constants, selectVm, paren
   })
 }
 
-const initWatch = ({ watch, selectVm, state, nextTick }) => {
+const initWatch = ({ watch, selectVm, state, nextTick, props }) => {
   watch(
     () => (!isServer ? selectVm.state.inputWidth : undefined),
     (val) => {
       nextTick(() => {
         state.minWidth = ((selectVm && selectVm.$el && selectVm.$el.getBoundingClientRect().width) || val) + 'px'
+        if (props.isDropInheritWidth) {
+          setTimeout(() => {
+            state.minWidth = ((selectVm && selectVm.$el && selectVm.$el.getBoundingClientRect().width) || val) + 'px'
+          }, 210)
+        }
       })
     },
     { immediate: true }
@@ -161,10 +166,10 @@ export const renderless = (
     watch
   })
 
-  const state = initState({ reactive, computed, popper, props, selectVm })
+  const state = initState({ reactive, computed, popper, selectVm })
 
   initApi({ api, popper, state, selectEmitter, constants, selectVm, parent, nextTick, props, isMobileFirstMode })
-  initWatch({ watch, selectVm, state, nextTick, api })
+  initWatch({ watch, selectVm, state, nextTick, props })
 
   onBeforeUnmount(() => {
     popper.destroyPopper('remove')

--- a/packages/renderless/src/select-dropdown/vue.ts
+++ b/packages/renderless/src/select-dropdown/vue.ts
@@ -100,6 +100,8 @@ const initWatch = ({ watch, selectVm, state, nextTick, props }) => {
     (val) => {
       nextTick(() => {
         state.minWidth = ((selectVm && selectVm.$el && selectVm.$el.getBoundingClientRect().width) || val) + 'px'
+
+        // 由于select的父容器可能有动画，所以延迟再计算一次最小宽度
         if (props.isDropInheritWidth) {
           setTimeout(() => {
             state.minWidth = ((selectVm && selectVm.$el && selectVm.$el.getBoundingClientRect().width) || val) + 'px'


### PR DESCRIPTION
…th，when the parent container of select has an animation, the dropdown panel width cannot follow the input width

# PR
修复select的父容器有动画时，下拉面板的宽度不能跟随input宽度     runtime: 6.7.24

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
