### PR TITLE
fix(grid): fix grid scroll will rerender all table

### DIFF
--- a/packages/vue/src/grid/src/table/src/methods.ts
+++ b/packages/vue/src/grid/src/table/src/methods.ts
@@ -309,6 +309,12 @@ const Methods = {
           return this.attemptRestoreScroll({ lastScrollLeft, lastScrollTop })
         }
       })
+      .then(() => {
+        if (this.resolveMap.loadDataResolve) {
+          this.resolveMap.loadDataResolve()
+          this.resolveMap.loadDataResolve = null
+        }
+      })
   },
   // 重新加载数据
   reloadData(datas) {
@@ -318,7 +324,7 @@ const Methods = {
   loadData(datas) {
     return new Promise((resolve) => {
       this.updateRawData(datas)
-      resolve()
+      this.resolveMap.loadDataResolve = resolve
     })
   },
   updateRawData(datas) {

--- a/packages/vue/src/grid/src/table/src/table.ts
+++ b/packages/vue/src/grid/src/table/src/table.ts
@@ -775,6 +775,8 @@ export default defineComponent({
       }
     }
 
+    const resolveMap = {}
+
     hooks.watch(
       () => [horizonScroll.value?.isLeft, horizonScroll.value?.isRight],
       ([newIsLeft, newIsRight]) => {
@@ -893,7 +895,8 @@ export default defineComponent({
       rawData,
       markColumnIndex,
       rowidCacheMap,
-      horizonScroll
+      horizonScroll,
+      resolveMap
     }
   },
   render() {

--- a/packages/vue/src/grid/src/table/src/table.ts
+++ b/packages/vue/src/grid/src/table/src/table.ts
@@ -411,9 +411,7 @@ export default defineComponent({
       // 在编辑模式下 单元格在失去焦点验证的状态
       validatedMap: {},
       // 表格父容器的高度
-      parentHeight: 0,
-      // 水平滚动条的状态
-      horizonScroll: { fixed: false, threshold: 2, max: 0, isLeft: true, isRight: false }
+      parentHeight: 0
     }
   },
   computed: {
@@ -688,6 +686,8 @@ export default defineComponent({
       scaleMinList: []
     })
 
+    const horizonScroll = hooks.ref({ fixed: false, threshold: 2, max: 0, isLeft: true, isRight: false })
+
     // body组件参数
     const bodyProps = hooks.computed(() => ({
       collectColumn: collectColumn.value,
@@ -746,6 +746,42 @@ export default defineComponent({
 
     const { tiledLength } = useData(props)
 
+    // 监听 horizonScroll.isLeft 和 isRight 的变化，直接操作 DOM 更新 class，避免触发重渲染
+    // 注意：tiny-grid-fixed__left 和 tiny-grid-fixed__right 通过 watch 直接操作 DOM 更新，避免触发重渲染
+    const updateFixedClasses = (isLeft, isRight) => {
+      if (!$table.$el) return
+
+      const el = $table.$el as HTMLElement
+      const hasLeftClass = el.classList.contains('tiny-grid-fixed__left')
+      const hasRightClass = el.classList.contains('tiny-grid-fixed__right')
+      const shouldHaveLeft = !isLeft
+      const shouldHaveRight = !isRight
+
+      // 只在状态真正变化时更新 DOM
+      if (hasLeftClass !== shouldHaveLeft) {
+        if (shouldHaveLeft) {
+          el.classList.add('tiny-grid-fixed__left')
+        } else {
+          el.classList.remove('tiny-grid-fixed__left')
+        }
+      }
+
+      if (hasRightClass !== shouldHaveRight) {
+        if (shouldHaveRight) {
+          el.classList.add('tiny-grid-fixed__right')
+        } else {
+          el.classList.remove('tiny-grid-fixed__right')
+        }
+      }
+    }
+
+    hooks.watch(
+      () => [horizonScroll.value?.isLeft, horizonScroll.value?.isRight],
+      ([newIsLeft, newIsRight]) => {
+        hooks.nextTick(() => updateFixedClasses(newIsLeft, newIsRight))
+      }
+    )
+
     hooks.onMounted(() => {
       $table.addIntersectionObserver()
 
@@ -756,7 +792,18 @@ export default defineComponent({
 
       hooks.nextTick(() => {
         $table.afterMounted = true
-
+        // 初始化时设置一次 class
+        setTimeout(() => {
+          if ($table.$el && $table.horizonScroll) {
+            const el = $table.$el as HTMLElement
+            if (!horizonScroll.value?.isLeft) {
+              el.classList.add('tiny-grid-fixed__left')
+            }
+            if (!horizonScroll.value?.isRight) {
+              el.classList.add('tiny-grid-fixed__right')
+            }
+          }
+        })
         if (props.autoResize && TINYGrid._resize) {
           $table.bindResize()
         }
@@ -845,7 +892,8 @@ export default defineComponent({
       rawDataVersion,
       rawData,
       markColumnIndex,
-      rowidCacheMap
+      rowidCacheMap,
+      horizonScroll
     }
   },
   render() {
@@ -892,9 +940,7 @@ export default defineComponent({
           'column__highlight': highlightHoverColumn,
           'is__row-span': (rowSpan && rowSpan.length > 0) || typeof spanMethod === 'function',
           'row__drop-handle--index': dropConfig.rowHandle === 'index',
-          'fixed__sticky': horizonScroll.fixed,
-          'tiny-grid-fixed__left': !horizonScroll.isLeft,
-          'tiny-grid-fixed__right': !horizonScroll.isRight
+          'fixed__sticky': horizonScroll.fixed
         }
       },
       [


### PR DESCRIPTION
# PR
修复非虚拟滚动场景，滚动到最右侧会引起表格一次重渲染
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed data loading to properly resolve after all internal updates complete, ensuring external callers are notified of full completion.

* **Performance**
  * Optimized horizontal scrolling and fixed column indicator updates to reduce unnecessary render cycles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->