### PR TITLE
feat(from): mobile-first mode tag text increases the number of displayed lines

### DIFF
--- a/examples/sites/demos/apis/form.js
+++ b/examples/sites/demos/apis/form.js
@@ -581,6 +581,17 @@ export default {
           pcDemo: 'slot-label'
         },
         {
+          name: 'label-line',
+          defaultValue: 2,
+          type: 'number',
+          desc: {
+            'zh-CN': '标签文本显示的行数',
+            'en-US': 'The number of lines displayed in the label text'
+          },
+          mode: ['mobile-first'],
+          pcDemo: 'slot-label'
+        },
+        {
           name: 'error',
           defaultValue: '',
           desc: {

--- a/packages/vue/src/form-item/src/index.ts
+++ b/packages/vue/src/form-item/src/index.ts
@@ -27,6 +27,10 @@ export const formItemProps = {
   },
   messageType: String,
   label: String,
+  labelLine: {
+    type: Number,
+    default: 2
+  },
   labelWidth: String,
   manual: Boolean,
   popperOptions: {

--- a/packages/vue/src/form-item/src/mobile-first.vue
+++ b/packages/vue/src/form-item/src/mobile-first.vue
@@ -49,7 +49,7 @@
         <span
           :class="
             m(
-              'max-h-[theme(spacing.10)] line-clamp-2 inline-block relative top-px leading-normal',
+              `max-h-[theme(spacing.${labelLine * 5})] line-clamp-${labelLine} inline-block relative top-px leading-normal`,
               (state.isRequired || required) && !state.hideRequiredAsterisk
                 ? `before:content-['*'] before:text-color-error before:relative before:mr-1`
                 : '',
@@ -173,6 +173,10 @@ export default defineComponent({
       default: ''
     },
     label: String,
+    labelLine: {
+      type: Number,
+      default: 2
+    },
     labelWidth: String,
     manual: Boolean,
     popperOptions: {


### PR DESCRIPTION
…yed lines

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `labelLine` property to Form component, enabling configurable label text line wrapping. Labels now dynamically adapt their height and line clamping based on the specified line count (default: 2 lines), providing greater flexibility for displaying label text in different scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->