### PR TITLE
fix(theme): fix input show 2 eye icons when focus in password mode

### DIFF
--- a/packages/theme-saas/src/input/index.less
+++ b/packages/theme-saas/src/input/index.less
@@ -13,7 +13,7 @@
   @apply w-full;
 
   /* 解决 ms-edge浏览器下，出现一个多余的eye*/
-  &[type='password']::-ms-reveal {
+  &__inner[type='password']::-ms-reveal {
     display: none;
   }
 

--- a/packages/theme-saas/src/input/index.less
+++ b/packages/theme-saas/src/input/index.less
@@ -12,6 +12,11 @@
   @apply inline-table;
   @apply w-full;
 
+  /* 解决 ms-edge浏览器下，出现一个多余的eye*/
+  &[type='password']::-ms-reveal {
+    display: none;
+  }
+
   &::-webkit-scrollbar {
     @apply ~'z-[11]';
     @apply ~'w-1.5';

--- a/packages/theme/src/input/index.less
+++ b/packages/theme/src/input/index.less
@@ -27,6 +27,11 @@
   display: inline-table;
   width: 100%;
 
+  /* 解决 ms-edge浏览器下，出现一个多余的eye*/
+  &[type='password']::-ms-reveal {
+    display: none;
+  }
+
   &.is-exceed &__suffix &__count {
     color: var(--tv-Input-exceed-text-color);
 

--- a/packages/theme/src/input/index.less
+++ b/packages/theme/src/input/index.less
@@ -28,7 +28,7 @@
   width: 100%;
 
   /* 解决 ms-edge浏览器下，出现一个多余的eye*/
-  &[type='password']::-ms-reveal {
+  &__inner[type='password']::-ms-reveal {
     display: none;
   }
 


### PR DESCRIPTION
# PR
修复在ms-edge浏览器下，显示2个eye 图标 
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  #3938 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated password input styling across theme packages to hide the default password-reveal icon in Microsoft Edge, improving visual consistency across browsers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->