### PR TITLE
fix(select): add max-height:50% for select-dropdown

### DIFF
--- a/packages/renderless/src/select/vue.ts
+++ b/packages/renderless/src/select/vue.ts
@@ -295,11 +295,11 @@ const initState = ({
     rootAutoTipConfig: computed(() => ({
       content: state.displayOnlyContent,
       always: !!state.displayOnlyContent,
+      popperClass: 'tiny-select__popper-maxh-50',
       ...props.tooltipConfig
     })),
     ariaListId: 'tiny-select-' + crypto.randomUUID().slice(-8)
   })
-
   return state
 }
 

--- a/packages/theme-saas/src/select-dropdown/index.less
+++ b/packages/theme-saas/src/select-dropdown/index.less
@@ -41,7 +41,7 @@
     list-style: none;
 
     .@{select-dropdown__item-prefix-cls} {
-      margin-right: 0
+      margin-right: 0;
     }
 
     &__slot {
@@ -89,8 +89,8 @@
     @apply m-1;
     @apply rounded;
 
-    >.tiny-svg,
-    >span>.tiny-svg {
+    > .tiny-svg,
+    > span > .tiny-svg {
       @apply ~'-mt-0.5';
     }
   }
@@ -99,7 +99,7 @@
     @apply text-center;
     @apply ~'py-2.5 px-0';
 
-    >.circular {
+    > .circular {
       @apply fill-color-brand;
       @apply h-4;
       @apply w-4;
@@ -142,6 +142,10 @@
       @apply hidden;
     }
   }
+}
+
+.@{select-prefix-cls}__popper-maxh-50 {
+  max-height: 50%;
 }
 
 @keyframes loading-rotate {

--- a/packages/theme-saas/src/select-dropdown/index.less
+++ b/packages/theme-saas/src/select-dropdown/index.less
@@ -1,6 +1,7 @@
 @import '../custom.less';
 
 @select-dropdown-prefix-cls: ~'@{css-prefix}select-dropdown';
+@select-prefix-cls: ~'@{css-prefix}select';
 @input-prefix-cls: ~'@{css-prefix}input';
 @tree-prefix-cls: ~'@{css-prefix}tree';
 @popper-prefix-cls: ~'@{css-prefix}popper';

--- a/packages/theme/src/select-dropdown/index.less
+++ b/packages/theme/src/select-dropdown/index.less
@@ -195,3 +195,7 @@
     background: var(--tv-SelectDropdown-empty-img) 50% no-repeat;
   }
 }
+
+.@{select-prefix-cls}__popper-maxh-50 {
+  max-height: 50%;
+}


### PR DESCRIPTION
# PR
select 的多选提示框，增加 max-height:50% 的限制。 用户可以通过属性传入，覆盖掉这个默认值。
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select dropdowns now enforce a maximum height of 50% of available vertical space, preventing overflow and improving usability on small or constrained screens.

* **Style**
  * Added a theming utility to enable the new max-height behavior and allow customization of select popper sizing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->