### PR TITLE
fix(grid):  remove cache row at not scrollYLoad  sence 

### DIFF
--- a/packages/vue/src/grid/src/body/src/body.tsx
+++ b/packages/vue/src/grid/src/body/src/body.tsx
@@ -383,7 +383,7 @@ function renderRows(_vm) {
       rowClassName
     }
 
-    Object.assign(args, { rowIndex, rowLevel, rowid, rows, selection, seq, treeConfig, used, selectRow })
+    Object.assign(args, { rowIndex, rowLevel, rowid, rows, selection, seq, treeConfig, used, selectRow, scrollYLoad })
 
     renderRow(args)
 
@@ -438,7 +438,7 @@ function renderRowAfter({ $table, _vm, row, rowIndex, rows, id, used }) {
 
 function renderRow(args) {
   const { $rowIndex, $seq, $table, _vm, editStore, id, isSkipRowRender, row, rowActived, rowClassName } = args
-  const { rowIndex, rowLevel, rowid, rows, selection, selectRow, seq, treeConfig, used } = args
+  const { rowIndex, rowLevel, rowid, rows, selection, selectRow, seq, treeConfig, used, scrollYLoad } = args
 
   if (isSkipRowRender) {
     return
@@ -458,33 +458,35 @@ function renderRow(args) {
 
   const { columnPool } = _vm
 
-  rows.push(
-    <tr
-      key={key}
-      data-rowid={rowid}
-      data-rowindex={$rowIndex}
-      data-rowlevel={rowLevel}
-      style={{ display: used ? undefined : 'none' }}
-      class={[
-        'tiny-grid-body__row',
-        {
-          [`row__level-${rowLevel}`]: treeConfig,
-          'row__new': editStore.insertList.includes(row),
-          'row__selected': selection.includes(row),
-          'row__radio': selectRow === row,
-          'row__actived': rowActived
-        },
-        rowClassName
-          ? isFunction(rowClassName)
-            ? rowClassName({ $table, $seq, seq, fixedType: undefined, rowLevel, row, rowIndex, $rowIndex })
-            : rowClassName
-          : ''
-      ]}>
-      {columnPool.map(({ id, item: column, used }, $columnIndex) =>
-        renderColumn({ $columnIndex, $table, _vm, column, id, row, rowid, seq, used })
-      )}
-    </tr>
-  )
+  if (used || scrollYLoad) {
+    rows.push(
+      <tr
+        key={key}
+        data-rowid={rowid}
+        data-rowindex={$rowIndex}
+        data-rowlevel={rowLevel}
+        style={{ display: used ? undefined : 'none' }}
+        class={[
+          'tiny-grid-body__row',
+          {
+            [`row__level-${rowLevel}`]: treeConfig,
+            'row__new': editStore.insertList.includes(row),
+            'row__selected': selection.includes(row),
+            'row__radio': selectRow === row,
+            'row__actived': rowActived
+          },
+          rowClassName
+            ? isFunction(rowClassName)
+              ? rowClassName({ $table, $seq, seq, fixedType: undefined, rowLevel, row, rowIndex, $rowIndex })
+              : rowClassName
+            : ''
+        ]}>
+        {columnPool.map(({ id, item: column, used }, $columnIndex) =>
+          renderColumn({ $columnIndex, $table, _vm, column, id, row, rowid, seq, used })
+        )}
+      </tr>
+    )
+  }
 }
 
 function renderRowGroupTds({ $table, closeable, render, renderGroupCell, row, tds, title, _vm }) {

--- a/packages/vue/src/grid/src/body/src/usePool.ts
+++ b/packages/vue/src/grid/src/body/src/usePool.ts
@@ -36,10 +36,11 @@ const updatePool = (array, context) => {
   expires.forEach((item) => {
     const view = context.idViewMap.get(item.id)
 
-    view.used = false
-
-    context.idViewMap.delete(item.id)
-    context.unusedViews.push(view)
+    if (view) {
+      view.used = false
+      context.idViewMap.delete(item.id)
+      context.unusedViews.push(view)
+    }
   })
 
   array.forEach((item, i) => {


### PR DESCRIPTION
# PR
非虚拟滚动场景，直接移除缓存的行。

在多个表格中来回切换的时候，表格会缓存行，导致可能缓存了两条一样的数据，从而导致表格单选样式错乱。
<img width="945" height="175" alt="image" src="https://github.com/user-attachments/assets/87704ce5-750c-4642-9168-6fea92bf7400" />

<img width="450" height="215" alt="image" src="https://github.com/user-attachments/assets/c0b8656c-2036-4738-b669-de970f7c1b04" />
解决方法：
在非虚拟滚动场景，直接将不显示缓存行，只渲染需要展示的行。

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential crashes in the grid component by adding safety checks to properly handle the expiration and removal of grid items.

* **Performance**
  * Enhanced grid rendering efficiency by implementing conditional row rendering logic that intelligently adapts to vertical scroll activity, reducing unnecessary rendering operations and improving overall responsiveness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->