### PR TITLE
fix(icon): fix build:ui icon and dont generate dts files

### DIFF
--- a/internals/automate/src/build-svg-to-js/index.ts
+++ b/internals/automate/src/build-svg-to-js/index.ts
@@ -140,7 +140,8 @@ const tmplUnchecked = uncheckedList
 const tmplRewrite = rewriteList
   .map(
     (exp) =>
-      `export const Icon${exp.capName} = () => ({...Icon${exp.rewriteCapName}(), name:'Icon${exp.capName}', deprecatedBy: 'Icon${exp.rewriteCapName}' })
+      `import Icon${exp.capName} from './src/${exp.svgName}'
+export { Icon${exp.capName} }
 export const icon${exp.capName} = Icon${exp.capName}`
   )
   .join('\n')

--- a/packages/vue-icon-saas/index.ts
+++ b/packages/vue-icon-saas/index.ts
@@ -803,6 +803,11 @@ import IconWeaknet from './src/weaknet'
 import IconWord from './src/word'
 import IconZip from './src/zip'
 
+// 重命名导出
+import IconTotalNolume from './src/total-nolume'
+import IconSubScript from './src/sub-script'
+import IconWriteProductioPlan from './src/write-productio-plan'
+
 // 双图标
 export { IconAIAbout, IconAIAbout as iconAIAbout }
 export { IconAIApplication, IconAIApplication as iconAIApplication }
@@ -1625,21 +1630,11 @@ export { IconWarning, IconWarning as iconWarning }
 export { IconWeaknet, IconWeaknet as iconWeaknet }
 export { IconWord, IconWord as iconWord }
 export { IconZip, IconZip as iconZip }
-
-// 重命名导出
-export const IconTotalNolume = () => ({
-  ...IconTotalVolume(),
-  name: 'IconTotalNolume',
-  deprecatedBy: 'IconTotalVolume'
-})
+export { IconTotalNolume }
 export const iconTotalNolume = IconTotalNolume
-export const IconSubScript = () => ({ ...IconSubscript(), name: 'IconSubScript', deprecatedBy: 'IconSubscript' })
+export { IconSubScript }
 export const iconSubScript = IconSubScript
-export const IconWriteProductioPlan = () => ({
-  ...IconWriteProductionPlan(),
-  name: 'IconWriteProductioPlan',
-  deprecatedBy: 'IconWriteProductionPlan'
-})
+export { IconWriteProductioPlan }
 export const iconWriteProductioPlan = IconWriteProductioPlan
 
 export default {

--- a/packages/vue-icon/index.ts
+++ b/packages/vue-icon/index.ts
@@ -534,6 +534,9 @@ import IconZipType from './src/zip-type'
 import IconZoomIn from './src/zoom-in'
 import IconZoomOut from './src/zoom-out'
 
+// 重命名导出
+import IconSubScript from './src/sub-script'
+
 // 双图标
 export { IconEditorEraser, IconEditorEraser as iconEditorEraser }
 
@@ -1072,9 +1075,7 @@ export { IconYes, IconYes as iconYes }
 export { IconZipType, IconZipType as iconZipType }
 export { IconZoomIn, IconZoomIn as iconZoomIn }
 export { IconZoomOut, IconZoomOut as iconZoomOut }
-
-// 重命名导出
-export const IconSubScript = () => ({ ...IconSubscript(), name: 'IconSubScript', deprecatedBy: 'IconSubscript' })
+export { IconSubScript }
 export const iconSubScript = IconSubScript
 
 export default {


### PR DESCRIPTION
# PR
修复重命名导出图标时，造成无法生成 d.ts文件

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured icon export patterns across the library to use direct re-exports and aliases instead of wrapped functions.
  * Updated three icons (IconTotalNolume, IconSubScript, IconWriteProductioPlan) to follow the new export approach.
  * Simplified icon access paths while maintaining backward compatibility through alias exports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->