### PR TITLE
Revert "fix(vue-icon): 修改vue-icon@3.28缺少声明文件 "

### DIFF
--- a/internals/automate/src/build-svg-to-js/index.ts
+++ b/internals/automate/src/build-svg-to-js/index.ts
@@ -140,8 +140,7 @@ const tmplUnchecked = uncheckedList
 const tmplRewrite = rewriteList
   .map(
     (exp) =>
-      `import Icon${exp.capName} from './src/${exp.svgName}'
-export { Icon${exp.capName} }
+      `export const Icon${exp.capName} = () => ({...Icon${exp.rewriteCapName}(), name:'Icon${exp.capName}', deprecatedBy: 'Icon${exp.rewriteCapName}' })
 export const icon${exp.capName} = Icon${exp.capName}`
   )
   .join('\n')

--- a/packages/vue-icon-saas/index.ts
+++ b/packages/vue-icon-saas/index.ts
@@ -702,11 +702,6 @@ import IconWeaknet from './src/weaknet'
 import IconWord from './src/word'
 import IconZip from './src/zip'
 
-// 重命名导出
-import IconTotalNolume from './src/total-nolume'
-import IconSubScript from './src/sub-script'
-import IconWriteProductioPlan from './src/write-productio-plan'
-
 // 双图标
 export { IconAbnormalCheckIn, IconAbnormalCheckIn as iconAbnormalCheckIn }
 export { IconAcceptance, IconAcceptance as iconAcceptance }
@@ -1428,11 +1423,21 @@ export { IconWarning, IconWarning as iconWarning }
 export { IconWeaknet, IconWeaknet as iconWeaknet }
 export { IconWord, IconWord as iconWord }
 export { IconZip, IconZip as iconZip }
-export { IconTotalNolume }
+
+// 重命名导出
+export const IconTotalNolume = () => ({
+  ...IconTotalVolume(),
+  name: 'IconTotalNolume',
+  deprecatedBy: 'IconTotalVolume'
+})
 export const iconTotalNolume = IconTotalNolume
-export { IconSubScript }
+export const IconSubScript = () => ({ ...IconSubscript(), name: 'IconSubScript', deprecatedBy: 'IconSubscript' })
 export const iconSubScript = IconSubScript
-export { IconWriteProductioPlan }
+export const IconWriteProductioPlan = () => ({
+  ...IconWriteProductionPlan(),
+  name: 'IconWriteProductioPlan',
+  deprecatedBy: 'IconWriteProductionPlan'
+})
 export const iconWriteProductioPlan = IconWriteProductioPlan
 
 export default {

--- a/packages/vue-icon/index.ts
+++ b/packages/vue-icon/index.ts
@@ -534,9 +534,6 @@ import IconZipType from './src/zip-type'
 import IconZoomIn from './src/zoom-in'
 import IconZoomOut from './src/zoom-out'
 
-// 重命名导出
-import IconSubScript from './src/sub-script'
-
 // 双图标
 export { IconEditorEraser, IconEditorEraser as iconEditorEraser }
 
@@ -1075,7 +1072,9 @@ export { IconYes, IconYes as iconYes }
 export { IconZipType, IconZipType as iconZipType }
 export { IconZoomIn, IconZoomIn as iconZoomIn }
 export { IconZoomOut, IconZoomOut as iconZoomOut }
-export { IconSubScript }
+
+// 重命名导出
+export const IconSubScript = () => ({ ...IconSubscript(), name: 'IconSubScript', deprecatedBy: 'IconSubscript' })
 export const iconSubScript = IconSubScript
 
 export default {

--- a/packages/vue-icon/package.json
+++ b/packages/vue-icon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opentiny/vue-icon",
   "private": true,
-  "version": "3.28.1",
+  "version": "3.28.0",
   "description": "An enterprise-class UI component library, support both Vue.js 2 and Vue.js 3, as well as PC and mobile.",
   "homepage": "https://opentiny.design/tiny-vue",
   "main": "index.ts",


### PR DESCRIPTION
Reverts opentiny/tiny-vue#4005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated three legacy icon names to point to their modern equivalents. Icons previously named with misspellings or naming inconsistencies now resolve to correctly named versions, maintaining backward compatibility while encouraging migration to updated naming conventions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->