### PR TITLE
fix(grid): copy old row to insert can not show the insert row 

### DIFF
--- a/packages/vue/src/grid/src/edit/src/methods.ts
+++ b/packages/vue/src/grid/src/edit/src/methods.ts
@@ -124,9 +124,12 @@ export default {
 
     const isColumnFormat = isAsyncColumn && visibleColumn.some((column) => column.format?.async?.fetch)
 
+    const defaultRowId = '_RID'
     let newRecords = records.map((record) => {
       // 增加新增标识
       isColumnFormat && (record[GlobalConfig.constant.insertedField] = true)
+      // 兼容历史版本，将已有行直接copy后直接insert, 由于默认id重复导致显示异常，需要将表格默认rowId删除
+      delete record[defaultRowId]
       // 增加编辑字段和主键字段
       return hooks.reactive(this.defineField(Object.assign({}, record)))
     })


### PR DESCRIPTION
# PR
修复当使用表格默认行id时，复制已存在行后直接insert回导致显示异常。
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display anomalies when inserting new rows in the grid component by resolving duplicate ID conflicts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->