### PR TITLE
fix(theme): select-dropdown's wrap dom add overflow = auto

### DIFF
--- a/examples/sites/demos/pc/app/icon/webdoc/icon.js
+++ b/examples/sites/demos/pc/app/icon/webdoc/icon.js
@@ -24,7 +24,7 @@ export default {
           </div>
         `,
         'en-US': `
-          Introduce icon functions from the <code>@opentiny/vue-icon</code> icon library. The execution of the icon function generates a valid <code> Vue </code> icon component that can be used in the template. <br>
+          Introduce icon functions from the <code>@opentiny/vue-icon</code> icon library. The execution of the icon function generates a valid <code> Vue </code> icon component that can be used in the template.Save the icon component variables for binding within the component. Avoid directly binding the icon function execution on the template. <br>
           Specify the size of the icon by modifying the <code>font-size</code> style, and specify the color of the icon by modifying <code>fill</code>.
           <div class="tip custom-block">
             <p class="custom block title"> Common icon usage </p>
@@ -32,6 +32,7 @@ export default {
             1. Import labels in the template. For example, <code> &lt; tiny-shared /&gt;  </code> <br>
             2, in the template by <code> &lt; component&gt;  The </code> component is introduced. For example, <code> &lt; component :is="tinyShared" /&gt;  </code> <br>
             3. Pass in component properties. For example, <code> &lt; tiny-button :icon="tinyShared" &gt;  </code> <br>
+            4. Avoid executing template-bound icon functions.Not recommended <code> &lt;component :is="IconShared()" /&gt; </code> 
           </div>
           `
       },

--- a/examples/sites/demos/pc/app/icon/webdoc/icon.js
+++ b/examples/sites/demos/pc/app/icon/webdoc/icon.js
@@ -12,7 +12,7 @@ export default {
       },
       desc: {
         'zh-CN': `
-          从 <code>@opentiny/vue-icon</code> 图标库中引入图标函数。图标函数执行后生成一个有效的 <code> Vue </code> 图标组件，可以在模板中使用。<br>
+          从 <code>@opentiny/vue-icon</code> 图标库中引入图标函数，图标函数执行后生成一个有效的 <code> Vue </code> 图标组件，可以在模板中使用。在组件内应该保存图标组件的变量用于绑定，要避免在模板上直接绑定图标函数的执行。<br>
           通过修改图标的 <code>font-size</code> 的样式，指定图标的大小，通过修改<code>fill</code> 的样式指定图标的颜色。
           <div class="tip custom-block">
             <p class="custom block title"> 常见的图标使用方式 </p>
@@ -20,6 +20,7 @@ export default {
             1、在模板中通过标签式引入。比如 <code> &lt;tiny-shared /&gt; </code> <br>
             2、在模板中通过<code> &lt;component&gt; </code> 组件引入。比如 <code> &lt;component :is="tinyShared" /&gt; </code> <br>
             3、在组件属性中传入。比如 <code> &lt;tiny-button :icon="tinyShared" &gt; </code> <br>
+            4、避免模板绑定图标函数的执行。不建议 <code> &lt;component :is="IconShared()" /&gt; </code> 
           </div>
         `,
         'en-US': `

--- a/packages/theme-saas/src/select-dropdown/index.less
+++ b/packages/theme-saas/src/select-dropdown/index.less
@@ -146,6 +146,7 @@
 }
 
 .@{select-prefix-cls}__popper-maxh-50 {
+  overflow: auto;
   max-height: 50%;
 }
 

--- a/packages/theme/src/select-dropdown/index.less
+++ b/packages/theme/src/select-dropdown/index.less
@@ -197,5 +197,6 @@
 }
 
 .@{select-prefix-cls}__popper-maxh-50 {
+  overflow: auto;
   max-height: 50%;
 }


### PR DESCRIPTION
# PR

为 select 的下拉面板默认增加 overflow:auto; 避免文字过长时超出显示。
顺便给icon的示例加一句话，方便 skill 生成更好的代码

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved icon component binding guidance with best practices for template usage.

* **Bug Fixes**
  * Select dropdowns now properly scroll when content exceeds maximum height instead of hiding overflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->