### PR TITLE
feat(drawer): 补充closed事件，用于标识抽屉关闭动画完成

### DIFF
--- a/examples/sites/demos/apis/drawer.js
+++ b/examples/sites/demos/apis/drawer.js
@@ -246,7 +246,10 @@ export default {
           },
           mode: ['pc', 'mobile-first'],
           pcDemo: 'events',
-          mfDemo: ''
+          mfDemo: '',
+          meta: {
+            stable: '3.28.0'
+          }
         },
         {
           name: 'confirm',

--- a/examples/sites/demos/apis/drawer.js
+++ b/examples/sites/demos/apis/drawer.js
@@ -237,6 +237,18 @@ export default {
           mfDemo: ''
         },
         {
+          name: 'closed',
+          type: '() => void',
+          defaultValue: '',
+          desc: {
+            'zh-CN': '关闭抽屉动画结束时的事件',
+            'en-US': 'Event emitted when drawer closing animation ends'
+          },
+          mode: ['pc', 'mobile-first'],
+          pcDemo: 'events',
+          mfDemo: ''
+        },
+        {
           name: 'confirm',
           type: '() => void',
           defaultValue: '',
@@ -371,6 +383,7 @@ interface IDrawerConfigs extends IDrawerProps {
   events: {
     // 监听事件
     close: () => void
+    closed: () => void
     confirm: () => void
     show: (instance: Component) => void
   },

--- a/examples/sites/demos/apis/drawer.js
+++ b/examples/sites/demos/apis/drawer.js
@@ -248,7 +248,7 @@ export default {
           pcDemo: 'events',
           mfDemo: '',
           meta: {
-            stable: '3.28.0'
+            stable: '3.29.0'
           }
         },
         {

--- a/examples/sites/demos/pc/app/drawer/webdoc/drawer.js
+++ b/examples/sites/demos/pc/app/drawer/webdoc/drawer.js
@@ -227,6 +227,7 @@ export default {
         'zh-CN': `
           <p><code>open</code>：当抽屉打开时触发；</p>
           <p><code>confirm</code>：当抽屉底部确定按钮点击时触发，该按钮仅当设置 <code>show-footer</code> 属性为 true 时可见；</p>
+          <p><code>closed</code>：当抽屉关闭动画结束时触发；</p>
           <p><code>close</code>：当抽屉关闭时触发。关闭抽屉的途径有：</p>
             <ul>
               <li>点击右上角关闭按钮；</li>
@@ -416,11 +417,11 @@ export default {
       support: {
         value: true
       },
-      description: '支持 open、confirm、close 等事件。',
+      description: '支持 open、confirm、close、closed 等事件。',
       cloud: {
         value: true
       },
-      apis: ['open', 'confirm', 'close'],
+      apis: ['open', 'confirm', 'close', 'closed'],
       demos: ['events']
     }
   ]

--- a/packages/renderless/src/drawer/index.ts
+++ b/packages/renderless/src/drawer/index.ts
@@ -37,6 +37,14 @@ export const close =
     api.handleClose('close', typeof force === 'boolean' ? force : false)
   }
 
+export const closed =
+  ({ state, emit }: Pick<IDrawerRenderlessParams, 'state' | 'emit'>) =>
+  () => {
+    if (!state.visible) {
+      emit('closed')
+    }
+  }
+
 export const watchVisible =
   ({ state, api }: Pick<IDrawerRenderlessParams, 'state' | 'api'>) =>
   (value: boolean) => {

--- a/packages/renderless/src/drawer/vue.ts
+++ b/packages/renderless/src/drawer/vue.ts
@@ -1,5 +1,6 @@
 import {
   close,
+  closed,
   watchVisible,
   confirm,
   mousedown,
@@ -25,7 +26,7 @@ import type {
   ISharedRenderlessParamHooks
 } from '@/types'
 
-export const api = ['state', 'close', 'confirm', 'handleClose', 'open']
+export const api = ['state', 'close', 'closed', 'confirm', 'handleClose', 'open']
 
 export const renderless = (
   props: IDrawerProps,
@@ -49,6 +50,7 @@ export const renderless = (
     open: open({ state, emit, vm }),
     confirm: confirm({ api }),
     close: close({ api }),
+    closed: closed({ state, emit }),
     handleClose: handleClose({ emit, props, state }),
     mousedown: mousedown({ state, vm }),
     mousemove: mousemove({ state, props, emit }),

--- a/packages/renderless/types/drawer.type.ts
+++ b/packages/renderless/types/drawer.type.ts
@@ -3,6 +3,7 @@ import type { drawerProps, $constants } from '@/drawer/src'
 import type {
   open,
   close,
+  closed,
   watchVisible,
   confirm,
   mousedown,
@@ -32,6 +33,7 @@ export interface IDrawerApi {
   open: ReturnType<typeof open>
   confirm: ReturnType<typeof confirm>
   close: ReturnType<typeof close>
+  closed: ReturnType<typeof closed>
   mousemove: ReturnType<typeof mousemove>
   mouseup: ReturnType<typeof mouseup>
   mousedown: ReturnType<typeof mousedown>

--- a/packages/vue/src/drawer/src/pc.vue
+++ b/packages/vue/src/drawer/src/pc.vue
@@ -13,7 +13,7 @@
     </transition>
 
     <!-- main -->
-    <transition :name="`drawer-slide-${placement}`">
+    <transition :name="`drawer-slide-${placement}`" @after-leave="closed">
       <div
         data-tag="tiny-drawer-main"
         ref="drawerBox"
@@ -167,7 +167,7 @@ export default defineComponent({
     'customSlots',
     'closeOnPressEscape'
   ],
-  emits: ['update:visible', 'open', 'close', 'confirm', 'drag'],
+  emits: ['update:visible', 'open', 'close', 'closed', 'confirm', 'drag'],
   setup(props, context) {
     return setup({ props, context, renderless, api })
   }


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Drawer 组件仅提供close事件，缺少「关闭动画完全结束」的closed事件，无法满足业务中 “动画结束后执行回调” 的场景需求

## What is the new behavior?

新增closed事件：在 Drawer 组件关闭动画完成后触发；
closed事件仅在state.visible为false时触发，避免无效调用；
同步调整api；

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "closed" event to the drawer component that fires when the close animation finishes, enabling post-close handling.

* **Documentation**
  * Updated drawer API docs, demos, and feature descriptions to list and explain the new "closed" event.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->