### PR TITLE
feat: 按钮组增加了一个props

### DIFF
--- a/examples/sites/demos/apis/button-group.js
+++ b/examples/sites/demos/apis/button-group.js
@@ -110,6 +110,18 @@ export default {
           mode: ['pc', 'mobile-first'],
           pcDemo: 'text-value-field',
           mfDemo: ''
+        },
+        // displayMode
+        {
+          name: 'display-mode',
+          type: "'default' | 'merged'",
+          defaultValue: "'default'",
+          desc: {
+            'zh-CN': '按钮组显示模式，可选值为"default"和"merged"，默认为"default"。当设置为"merged"时，按钮组内的按钮将合并显示，形成一个整体的外观。',
+            'en-US': 'Button group display mode, optional values are "default" and "merged", the default is "default". When set to "merged", the buttons in the button group will be merged to form an overall appearance.'
+          },
+          mode: ['pc','mobile-first'],
+          pcDemo: 'display-mode'
         }
       ],
       events: [

--- a/examples/sites/demos/apis/button-group.js
+++ b/examples/sites/demos/apis/button-group.js
@@ -121,7 +121,10 @@ export default {
             'en-US': 'Button group display mode, optional values are "default" and "merged", the default is "default". When set to "merged", the buttons in the button group will be merged to form an overall appearance.'
           },
           mode: ['pc','mobile-first'],
-          pcDemo: 'display-mode'
+          pcDemo: 'display-mode',
+          meta: {
+            stable: '3.29.0'
+          }
         }
       ],
       events: [

--- a/examples/sites/demos/mobile-first/app/button-group/display-mode.vue
+++ b/examples/sites/demos/mobile-first/app/button-group/display-mode.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    <!-- 默认模式 -->
+    <tiny-button-group :data="groupData" v-model="checkedVal" />
+    <br>
+    <br>
+    
+    <!-- 圆角合并模式 -->
+    <tiny-button-group :data="groupData" v-model="checkedVal" display-mode="merged" />
+  </div>
+</template>
+
+<script>
+import { TinyButtonGroup } from "@opentiny/vue";
+
+export default {
+  components: {
+    TinyButtonGroup,
+  },
+  data() {
+    return {
+      checkedVal: "Button1",
+      groupData: [
+        { text: "Button1", value: "Button1" },
+        { text: "Button2", value: "Button2" },
+        { text: "Button3", value: "Button3" },
+      ],
+    };
+  },
+};
+</script>

--- a/examples/sites/demos/mobile-first/app/button-group/webdoc/button-group.js
+++ b/examples/sites/demos/mobile-first/app/button-group/webdoc/button-group.js
@@ -52,6 +52,19 @@ export default {
         'en-US': '<p>bbutton click</p>'
       },
       codeFiles: ['enumeration.vue']
+    },
+    {
+      demoId: 'display-mode',
+      name: {
+        'zh-CN': '按钮组显示模式',
+        'en-US': 'button mode'
+      },
+      desc: {
+        'zh-CN':
+          '<p>通过 <code>display-mode</code> 属性设置按钮组显示模式，可选值有 <code>default</code>（默认）和 <code>merged</code>（选块合并）。</p>',
+        'en-US': '<p>button mode</p>'
+      },
+      codeFiles: ['display-mode.vue']
     }
   ]
 }

--- a/examples/sites/demos/pc/app/button-group/display-mode.vue
+++ b/examples/sites/demos/pc/app/button-group/display-mode.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    <!-- 默认模式 -->
+    <tiny-button-group :data="groupData" v-model="checkedVal" />
+    <br>
+    <br>
+    
+    <!-- 圆角合并模式 -->
+    <tiny-button-group :data="groupData" v-model="checkedVal" display-mode="merged" />
+  </div>
+</template>
+
+<script>
+import { TinyButtonGroup } from "@opentiny/vue";
+
+export default {
+  components: {
+    TinyButtonGroup,
+  },
+  data() {
+    return {
+      checkedVal: "Button1",
+      groupData: [
+        { text: "Button1", value: "Button1" },
+        { text: "Button2", value: "Button2" },
+        { text: "Button3", value: "Button3" },
+      ],
+    };
+  },
+};
+</script>

--- a/examples/sites/demos/pc/app/button-group/webdoc/button-group.js
+++ b/examples/sites/demos/pc/app/button-group/webdoc/button-group.js
@@ -149,6 +149,20 @@ export default {
         'en-US': '<p>The <code>change</code> event is triggered when the selected button is changed. </p>'
       },
       codeFiles: ['change-event.vue']
+    },
+    {
+      demoId: 'display-mode',
+      name: {
+        'zh-CN': '按钮组显示模式',
+        'en-US': 'Button Group Display Mode'
+      },
+      desc: {
+        'zh-CN':
+        '<p>通过 <code>display-mode</code> 属性设置按钮组显示模式，可选值有 <code>default</code>（默认）和 <code>merged</code>（选块合并）。</p>',
+        'en-US':
+        '<p>Set the display mode of the button group through the <code>display-mode</code> attribute. The optional values are: <code>default</code> (default) and <code>merged</code> (merged).</p>'
+      },
+      codeFiles: ['display-mode.vue']
     }
   ],
   features: [

--- a/packages/renderless/types/button-group.type.ts
+++ b/packages/renderless/types/button-group.type.ts
@@ -5,6 +5,7 @@ import type { handleChange, handleClick, moreNodeClick, getItemClass } from '../
 
 export type IButtonGroupProps = ExtractPropTypes<typeof buttonGroupProps>
 
+
 export interface IButtonGroupItemClass {
   disabled?: boolean
   plain?: boolean

--- a/packages/theme/src/button-group/index.less
+++ b/packages/theme/src/button-group/index.less
@@ -200,3 +200,23 @@
     }
   }
 }
+.@{button-group-prefix-cls}--merged {
+  // 第一个按钮：左圆角
+  .@{group-item-prefix-cls} li:first-child > button {
+    border-top-left-radius: var(--tv-ButtonGroup-border-radius);
+    border-bottom-left-radius: var(--tv-ButtonGroup-border-radius);
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+  // 最后一个按钮：右圆角
+  .@{group-item-prefix-cls} li:last-child > button {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-top-right-radius: var(--tv-ButtonGroup-border-radius);
+    border-bottom-right-radius: var(--tv-ButtonGroup-border-radius);
+  }
+  // 中间按钮：直角
+  .@{group-item-prefix-cls} li > button {
+    border-radius: 0;
+  }
+}

--- a/packages/vue/src/button-group/src/index.ts
+++ b/packages/vue/src/button-group/src/index.ts
@@ -47,7 +47,7 @@ export const buttonGroupProps = {
   },
   displayMode: {
     type: String as PropType<'default' | 'merged'>,
-    default: 'merged',
+    default: 'default',
     validator: (val: string) => ['default', 'merged'].includes(val)
   }
 }

--- a/packages/vue/src/button-group/src/index.ts
+++ b/packages/vue/src/button-group/src/index.ts
@@ -44,6 +44,11 @@ export const buttonGroupProps = {
   border: {
     type: Boolean,
     default: true
+  },
+  displayMode: {
+    type: String as PropType<'default' | 'merged'>,
+    default: 'merged',
+    validator: (val: string) => ['default', 'merged'].includes(val)
   }
 }
 

--- a/packages/vue/src/button-group/src/pc.vue
+++ b/packages/vue/src/button-group/src/pc.vue
@@ -12,7 +12,7 @@
 <template>
   <div
     class="tiny-button-group"
-    :class="[size ? 'tiny-button-group--' + size : '', border ? '' : 'tiny-button-group--borderless']"
+    :class="[size ? 'tiny-button-group--' + size : '', border ? '' : 'tiny-button-group--borderless', displayMode === 'merged' ? 'tiny-button-group--merged' : '']"
   >
     <slot>
       <template v-if="data.length > 0">
@@ -134,7 +134,8 @@ export default defineComponent({
     'textField',
     'showMore',
     'showEdit',
-    'border'
+    'border',
+    'displayMode'
   ],
   components: {
     TinyPopover: Popover,


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  3771

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
 主要增加了按钮组中间的情况，不再是圆角，为了适应，就提供了两种模式，这样会更好一些，这次没有格式化的问题 1，呼

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "display-mode" prop to Button Group with two modes: "default" and "merged", enabling a merged visual grouping option.

* **Documentation**
  * Added demos and localized descriptions illustrating both display modes for desktop and mobile-first examples.

* **Style**
  * Introduced merged styling to render end buttons with rounded corners and middle buttons square for the grouped appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->