### PR TITLE
fix(mobile): add mobile dark theme switching

### DIFF
--- a/examples/sites/public/static/css/mobile-dark-theme.css
+++ b/examples/sites/public/static/css/mobile-dark-theme.css
@@ -1,0 +1,1 @@
+@import "@opentiny/vue-theme/dark-theme-index.css";

--- a/examples/sites/src/views/components-doc/mobile.vue
+++ b/examples/sites/src/views/components-doc/mobile.vue
@@ -11,7 +11,7 @@
         <!-- 移动端展示内容 -->
         <div class="phone-container">
           <div class="mobile-iframe-container">
-            <iframe ref="iframeRef" width="100%" height="100%" :src="iframeUrl" frameborder="0"></iframe>
+            <iframe id="iframeDom" ref="iframeRef" width="100%" height="100%" :src="iframeUrl" frameborder="0"></iframe>
           </div>
         </div>
       </div>
@@ -59,6 +59,47 @@ const mobilePreview = import.meta.env.VITE_MOBILE_URL
 const pageInit = (demo) => {
   const { cmpId } = router.currentRoute.value.params
   iframeUrl.value = `${mobilePreview}?component=${cmpId}&demo=${demo.codeFiles[0]}`
+}
+
+const observer = new MutationObserver(() => {
+  const isDarkMode = document.documentElement.classList.contains('dark')
+  if (isDarkMode) {
+    onIframeLoad()
+  } else {
+    try {
+      const iframeDocument = iframeRef.value.contentDocument || iframeRef.value.contentWindow.document
+      const linkElement = iframeDocument.getElementById('theme-style-link')
+      if (linkElement) {
+        linkElement.remove()
+      }
+    } catch (error) {
+      console.error('无法访问 iframe:', error)
+    }
+  }
+})
+
+observer.observe(document.documentElement, {
+  attributes: true,
+  attributeFilter: ['class']
+})
+
+const onIframeLoad = () => {
+  try {
+    const iframeDocument = iframeRef.value.contentDocument || iframeRef.value.contentWindow.document
+    const htmlElement = iframeDocument.documentElement
+
+    // 添加 dark 类
+    htmlElement.classList.add('dark')
+
+    const link = iframeDocument.createElement('link')
+    link.rel = 'stylesheet'
+    link.href = '/public/static/css/mobile-dark-theme.css'
+    link.id = 'theme-style-link'
+
+    iframeDocument.head.appendChild(link)
+  } catch (error) {
+    console.error('无法访问 iframe:', error)
+  }
 }
 </script>
 

--- a/examples/sites/src/views/components-doc/mobile.vue
+++ b/examples/sites/src/views/components-doc/mobile.vue
@@ -68,6 +68,7 @@ const observer = new MutationObserver(() => {
   } else {
     try {
       const iframeDocument = iframeRef.value.contentDocument || iframeRef.value.contentWindow.document
+      iframeDocument.documentElement.classList.remove('dark')
       const linkElement = iframeDocument.getElementById('theme-style-link')
       if (linkElement) {
         linkElement.remove()

--- a/examples/sites/src/views/components-doc/mobile.vue
+++ b/examples/sites/src/views/components-doc/mobile.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, onBeforeUnmount } from 'vue'
 import { router } from '@/router.js'
 import { fetchDemosFile } from '@/tools'
 import ComponentDocs from './common.vue'
@@ -61,7 +61,7 @@ const pageInit = (demo) => {
   iframeUrl.value = `${mobilePreview}?component=${cmpId}&demo=${demo.codeFiles[0]}`
 }
 
-const observer = new MutationObserver(() => {
+let observer = new MutationObserver(() => {
   const isDarkMode = document.documentElement.classList.contains('dark')
   if (isDarkMode) {
     onIframeLoad()
@@ -102,6 +102,11 @@ const onIframeLoad = () => {
     console.error('无法访问 iframe:', error)
   }
 }
+
+onBeforeUnmount(() => {
+  observer?.disconnect()
+  observer = null
+})
 </script>
 
 <style scoped lang="less">


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:
在vue-docs的mobile移动端添加iframe暗色主题切换
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dark theme added to the mobile preview with automatic detection and real-time synchronization to system dark mode.
  * Preview now injects and removes theme styling dynamically for accurate visual parity.
* **Bug Fixes / Reliability**
  * Improved robustness with better error handling and cleanup for theme switching and preview lifecycle.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->