### PR TITLE
fix(form-item): fixed an issue where validation would fail to trigger after continuous input when form items were configured with validation stabilization and the focus would quickly drop.

### DIFF
--- a/examples/sites/demos/pc/app/form/basic-usage.spec.ts
+++ b/examples/sites/demos/pc/app/form/basic-usage.spec.ts
@@ -18,15 +18,17 @@ test('测试基本表单', async ({ page }) => {
   await decreaseIcon.click()
   await expect(numericInput).toHaveValue('0')
 
-  // 日期选择器
-  const datePicker = demo.getByRole('textbox').first()
+  // 日期选择器（PR #4028 后，role 从 textbox 改为 combobox）
+  const datePicker = demo.getByRole('combobox').first()
   await datePicker.click()
+  await page.waitForTimeout(200) // 等待弹出层显示
   await page.getByRole('cell', { name: '15' }).getByText('15').click()
   await expect(datePicker).toHaveValue(/15/)
 
-  // 時間选择器
-  const timePicker = demo.getByRole('combobox').nth(0)
+  // 时间选择器
+  const timePicker = demo.getByRole('combobox').nth(1) // 第二个 combobox（第一个是日期选择器）
   await timePicker.click()
+  await page.waitForTimeout(200) // 等待下拉列表显示
   await page.getByRole('option').filter({ hasText: '00:30' }).click()
   await expect(timePicker).toHaveValue('00:30')
 

--- a/packages/renderless/src/form-item/index.ts
+++ b/packages/renderless/src/form-item/index.ts
@@ -416,10 +416,12 @@ export const getFilteredRule =
       .map((rule) => merge({}, rule))
   }
 
+// blur 事件触发时，直接调用原始的 validate 函数，不应用防抖
 export const onFieldBlur = (api: IFormItemRenderlessParams['api']) => (): void => {
-  api.validate('blur')
+  api.validateOrigin('blur')
 }
 
+// change 事件触发时，调用可能被防抖包装的 validate 函数
 export const onFieldChange =
   ({ api, state }: Pick<IFormItemRenderlessParams, 'api' | 'state'>) =>
   (): void => {

--- a/packages/renderless/src/form-item/vue.ts
+++ b/packages/renderless/src/form-item/vue.ts
@@ -56,6 +56,7 @@ import type {
 export const api = [
   'state',
   'validate',
+  'validateOrigin',
   'clearValidate',
   'resetField',
   'getRules',
@@ -144,6 +145,9 @@ const initState = ({
 }
 
 const initApi = ({ api, state, dispatch, broadcast, props, constants, vm, t, nextTick, slots }) => {
+  // 创建原始的 validate 函数（不经过防抖处理）
+  const validateOriginFunc = validate({ api, props, state, t })
+
   Object.assign(api, {
     state,
     dispatch,
@@ -172,7 +176,8 @@ const initApi = ({ api, state, dispatch, broadcast, props, constants, vm, t, nex
     onFieldBlur: onFieldBlur(api),
     onFieldChange: onFieldChange({ api, state }),
     addValidateEvents: addValidateEvents({ api, vm, props, state }),
-    validate: wrapValidate({ validateFunc: validate({ api, props, state, t }), props }),
+    validateOrigin: validateOriginFunc,
+    validate: wrapValidate({ validateFunc: validateOriginFunc, props }),
     getDisplayedValue: getDisplayedValue({ state }),
     clearDisplayedValue: clearDisplayedValue({ state }),
     handleLabelMouseenter: handleLabelMouseenter({ props, state, slots }),

--- a/packages/renderless/types/form-item.type.ts
+++ b/packages/renderless/types/form-item.type.ts
@@ -144,6 +144,7 @@ export interface IFormItemApi {
   onFieldChange: ReturnType<typeof onFieldChange>
   addValidateEvents: ReturnType<typeof addValidateEvents>
   validate: ReturnType<typeof validate>
+  validateOrigin: ReturnType<typeof validate> // 原始的 validate 函数，不经过防抖处理
   getDisplayedValue: ReturnType<typeof getDisplayedValue>
   clearDisplayedValue: ReturnType<typeof clearDisplayedValue>
   handleMouseenter: ReturnType<typeof handleMouseenter>


### PR DESCRIPTION
fix(form-item): 修复当表单项配置了校验防抖，在连续输入后快速失焦无法触发校验的问题
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new API method to invoke the original (non-debounced) validation directly.

* **Improvements**
  * Blur events now trigger the original, immediate validation; change events continue to use debounced validation.

* **Tests**
  * Updated date/time picker test selectors and added brief waits to stabilize interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->