### PR TITLE
fix(vue2-common): createComponent function add parent param

### DIFF
--- a/packages/vue-common/src/adapter/vue2/index.ts
+++ b/packages/vue-common/src/adapter/vue2/index.ts
@@ -354,9 +354,10 @@ export const isEmptyVnode = (vnode) => !vnode || !vnode.tag
 export const h = hooks.h
 
 export const createComponentFn = (design) => {
-  return ({ component, propsData, el }) => {
+  // parent入参: 仅支持Vue2,所以只在这里增加了， vue3-common没该参数。 目的是支持Vue2中的 Vue.extend 使用时不丢失父元素
+  return ({ component, propsData, el, parent }) => {
     const comp = Object.assign(component, { provide: { [design.configKey]: design.configInstance } })
-    return new (Vue.extend(comp))({ propsData, el }).$mount()
+    return new (Vue.extend(comp))({ propsData, el, parent }).$mount()
   }
 }
 

--- a/packages/vue/src/tooltip/src/mobile-first.vue
+++ b/packages/vue/src/tooltip/src/mobile-first.vue
@@ -132,7 +132,7 @@ export default defineComponent({
           get: () => {
             if (!_cacheVm.value) {
               _cacheVm.value = createComponent({
-                parent: { ...this },
+                parent: this,
                 el: document.createElement('div'),
                 component: {
                   render: () => {

--- a/packages/vue/src/tooltip/src/mobile-first.vue
+++ b/packages/vue/src/tooltip/src/mobile-first.vue
@@ -132,6 +132,7 @@ export default defineComponent({
           get: () => {
             if (!_cacheVm.value) {
               _cacheVm.value = createComponent({
+                parent: { ...this },
                 el: document.createElement('div'),
                 component: {
                   render: () => {

--- a/packages/vue/src/tooltip/src/pc.vue
+++ b/packages/vue/src/tooltip/src/pc.vue
@@ -150,7 +150,7 @@ export default defineComponent({
           get: () => {
             if (!_cacheVm.value) {
               _cacheVm.value = createComponent({
-                parent: { ...this },
+                parent: this,
                 el: document.createElement('div'),
                 propsData: null,
                 component: {

--- a/packages/vue/src/tooltip/src/pc.vue
+++ b/packages/vue/src/tooltip/src/pc.vue
@@ -150,6 +150,7 @@ export default defineComponent({
           get: () => {
             if (!_cacheVm.value) {
               _cacheVm.value = createComponent({
+                parent: { ...this },
                 el: document.createElement('div'),
                 propsData: null,
                 component: {


### PR DESCRIPTION
# PR
tooltip 创建子弹出层时，传入一个parent属性。 
vue2的common层接收这个属性。  vue3的common忽略这个传入的属性。     发81

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dynamically created child components (like tooltips/poppers) now correctly inherit their parent component context, improving state propagation and resolving issues with context-dependent behavior. This ensures more reliable rendering and interaction for nested UI elements.



<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->