### PR TITLE
fix(radio): add truncate for radio__label

### DIFF
--- a/packages/theme-saas/src/radio/index.less
+++ b/packages/theme-saas/src/radio/index.less
@@ -173,6 +173,7 @@
     @apply text-sm;
     @apply pl-2;
     @apply align-middle;
+    @apply truncate;
   }
 
   &--medium {

--- a/packages/theme/src/radio/index.less
+++ b/packages/theme/src/radio/index.less
@@ -160,6 +160,10 @@
     font-size: var(--tv-Radio-font-size);
     padding-left: 8px;
     vertical-align: middle;
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   &.is-checked.is-display-only {

--- a/packages/vue/src/radio/package.json
+++ b/packages/vue/src/radio/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@opentiny/vue-common": "workspace:~",
     "@opentiny/vue-renderless": "workspace:~",
+    "@opentiny/vue-directive": "workspace:~",
     "@opentiny/vue-icon": "workspace:~",
     "@opentiny/vue-theme": "workspace:~"
   },

--- a/packages/vue/src/radio/src/mobile-first.vue
+++ b/packages/vue/src/radio/src/mobile-first.vue
@@ -119,6 +119,7 @@
         )
       "
       @keydown.stop
+      v-auto-tip
     >
       <slot>{{ text || label }}</slot>
     </span>
@@ -130,10 +131,12 @@ import { renderless, api } from '@opentiny/vue-renderless/radio/vue'
 import { props, setup, defineComponent } from '@opentiny/vue-common'
 import { iconRadio, iconRadioselected, iconMobileRadio, iconMobileRadioSelected } from '@opentiny/vue-icon'
 import { classes } from './token'
+import { AutoTip } from '@opentiny/vue-directive'
 import type { IRadioApi } from '@opentiny/vue-renderless/types/radio.type'
 
 export default defineComponent({
   emits: ['change', 'update:modelValue'],
+  directives: { AutoTip },
   props: [
     ...props,
     'modelValue',

--- a/packages/vue/src/radio/src/pc.vue
+++ b/packages/vue/src/radio/src/pc.vue
@@ -52,7 +52,7 @@
         @click.stop
       />
     </span>
-    <span :id="`${name || 'radio'}-${label}-label`" class="tiny-radio__label" @keydown.stop>
+    <span :id="`${name || 'radio'}-${label}-label`" class="tiny-radio__label" @keydown.stop v-auto-tip>
       <slot>{{ text || label }}</slot>
     </span>
   </label>
@@ -62,10 +62,12 @@
 import { renderless, api } from '@opentiny/vue-renderless/radio/vue'
 import { props, setup, defineComponent } from '@opentiny/vue-common'
 import type { IRadioApi } from '@opentiny/vue-renderless/types/radio.type'
+import { AutoTip } from '@opentiny/vue-directive'
 import '@opentiny/vue-theme/radio/index.less'
 
 export default defineComponent({
   emits: ['change', 'update:modelValue'],
+  directives: { AutoTip },
   props: [
     ...props,
     'modelValue',

--- a/packages/vue/src/radio/src/token.ts
+++ b/packages/vue/src/radio/src/token.ts
@@ -1,6 +1,6 @@
 export const classes = {
   'radio-default': 'radio inline-flex items-center leading-4 cursor-pointer sm:flex-row py-px sm:py-0 h-fit',
-  'radio-label-common': 'relative text-center w-7 h-7 mr-2 sm:mr-0',
+  'radio-label-common': 'relative text-center w-7 h-7 mr-2 sm:mr-0 shrink-0',
   'radio-label-size-common': 'sm:w-4 sm:h-4',
   'radio-label-size-medium': 'sm:w-6 sm:h-6',
   'radio-label-circle': 'inline-flex p-3 sm:p-0',
@@ -27,7 +27,7 @@ export const classes = {
   'mobile-icon-radio-disabled':
     '[&_path:nth-of-type(2)]:fill-color-icon-disabled [&_path:nth-of-type(1)]:fill-color-bg-3 cursor-not-allowed',
   'radio-input': 'absolute left-0 right-0 top-0 bottom-0 w-0 h-0 -z-10 opacity-0',
-  'radio-text-common': 'sm:h-4 text-color-text-primary align-middle text-sm',
+  'radio-text-common': 'sm:h-4 text-color-text-primary align-middle text-sm truncate',
   'radio-text-size-common': 'sm:text-xs',
   'radio-text-size-medium': 'sm:text-sm',
   'radio-hover': 'sm:[&_path:nth-of-type(1)]:hover:fill-color-brand-hover',


### PR DESCRIPTION
# PR
为radio 的文字部分添加 超长省略号的功能，并添加 v-auto-tip    发81
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Radio component labels now feature automatic tooltip functionality, providing context when hovering over truncated text.
  * Long label text is now gracefully truncated with ellipsis instead of breaking the layout, ensuring a cleaner and more consistent user interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->