### PR TITLE
feat(filter-panel): add 'size' prop and corresponding styles for filter box component

### DIFF
--- a/examples/sites/demos/apis/filter-panel.js
+++ b/examples/sites/demos/apis/filter-panel.js
@@ -17,7 +17,15 @@ export default {
           pcDemo: 'tip'
         },
         {
-          mode: []
+          name: 'clearable',
+          type: 'boolean',
+          defaultValue: 'true',
+          desc: {
+            'zh-CN': '是否显示清空按钮',
+            'en-US': 'Whether to display the clear button'
+          },
+          mode: ['pc'],
+          pcDemo: 'tip'
         },
         {
           name: 'disabled',
@@ -75,6 +83,18 @@ export default {
           },
           mode: ['pc'],
           pcDemo: 'popper-class'
+        },
+        {
+          name: 'size',
+          type: "'medium'",
+          defaultValue: '',
+          desc: {
+            'zh-CN': '过滤器面板的尺寸，可选值：medium（中等尺寸），不设置则为默认尺寸',
+            'en-US': 'Size of the filter panel. Optional value: medium. If not set, the default size is used'
+          },
+          stable: '3.29.0',
+          mode: ['pc'],
+          pcDemo: 'size'
         },
         {
           name: 'tip',

--- a/examples/sites/demos/pc/app/filter-panel/size-composition-api.vue
+++ b/examples/sites/demos/pc/app/filter-panel/size-composition-api.vue
@@ -1,0 +1,58 @@
+<template>
+  <div>
+    <div class="mb10">
+      <span class="label">选择尺寸：</span>
+      <tiny-radio-group v-model="currentSize">
+        <tiny-radio label="">默认 (default)</tiny-radio>
+        <tiny-radio label="medium">中等 (medium)</tiny-radio>
+      </tiny-radio-group>
+    </div>
+    <div class="box">
+      <tiny-filter-panel
+        ref="filterPanel"
+        label="物品数量"
+        :value="value"
+        :size="currentSize"
+        @handle-clear="handleClear"
+      >
+        <tiny-radio-group v-model="radioVal" size="mini">
+          <tiny-radio label="大于">大于</tiny-radio>
+          <tiny-radio label="等于">等于</tiny-radio>
+          <tiny-radio label="小于">小于</tiny-radio>
+        </tiny-radio-group>
+        <tiny-input type="text" v-model="inputVal" style="margin-top: 20px"></tiny-input>
+      </tiny-filter-panel>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { TinyFilterPanel, TinyRadio, TinyRadioGroup, TinyInput } from '@opentiny/vue'
+
+// 表单数据
+const inputVal = ref('')
+const radioVal = ref('')
+const currentSize = ref('') // 默认尺寸
+
+// 计算显示的值
+const value = computed(() => {
+  return radioVal.value + inputVal.value
+})
+
+// 清空处理
+const handleClear = () => {
+  radioVal.value = ''
+  inputVal.value = ''
+}
+</script>
+
+<style scoped>
+.box {
+  display: flex;
+}
+.label {
+  margin-right: 10px;
+  font-weight: bold;
+}
+</style>

--- a/examples/sites/demos/pc/app/filter-panel/size.spec.ts
+++ b/examples/sites/demos/pc/app/filter-panel/size.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test'
+
+test('测试过滤器面板尺寸', async ({ page }) => {
+  page.on('pageerror', (exception) => expect(exception).toBeNull())
+  await page.goto('filter-panel#size')
+
+  const demo = page.locator('#size')
+  const filterBox = demo.locator('.tiny-filter-box')
+
+  // 测试默认尺寸（不包含 medium class）
+  await expect(filterBox).toHaveClass(/tiny-filter-box/)
+  await expect(filterBox).not.toHaveClass(/tiny-filter-box--medium/)
+
+  // 测试 medium 尺寸
+  await demo.getByText('中等 (medium)').click()
+  await page.waitForTimeout(200)
+  await expect(filterBox).toHaveClass(/tiny-filter-box--medium/)
+
+  // 切换回默认尺寸
+  await demo.getByText('默认 (default)').click()
+  await page.waitForTimeout(200)
+  await expect(filterBox).not.toHaveClass(/tiny-filter-box--medium/)
+})

--- a/examples/sites/demos/pc/app/filter-panel/size.vue
+++ b/examples/sites/demos/pc/app/filter-panel/size.vue
@@ -1,0 +1,68 @@
+<template>
+  <div>
+    <div class="mb10">
+      <span class="label">选择尺寸：</span>
+      <tiny-radio-group v-model="currentSize">
+        <tiny-radio label="">默认 (default)</tiny-radio>
+        <tiny-radio label="medium">中等 (medium)</tiny-radio>
+      </tiny-radio-group>
+    </div>
+    <div class="box">
+      <tiny-filter-panel
+        ref="filterPanel"
+        label="物品数量"
+        :value="value"
+        :size="currentSize"
+        @handle-clear="handleClear"
+      >
+        <tiny-radio-group v-model="radioVal" size="mini">
+          <tiny-radio label="大于">大于</tiny-radio>
+          <tiny-radio label="等于">等于</tiny-radio>
+          <tiny-radio label="小于">小于</tiny-radio>
+        </tiny-radio-group>
+        <tiny-input type="text" v-model="inputVal" style="margin-top: 20px"></tiny-input>
+      </tiny-filter-panel>
+    </div>
+  </div>
+</template>
+
+<script>
+import { TinyFilterPanel, TinyRadio, TinyRadioGroup, TinyInput } from '@opentiny/vue'
+
+export default {
+  components: {
+    TinyRadio,
+    TinyRadioGroup,
+    TinyFilterPanel,
+    TinyInput
+  },
+  data() {
+    return {
+      inputVal: '',
+      radioVal: '',
+      currentSize: '' // 默认尺寸
+    }
+  },
+  computed: {
+    value() {
+      return this.radioVal + this.inputVal
+    }
+  },
+  methods: {
+    handleClear() {
+      this.radioVal = ''
+      this.inputVal = ''
+    }
+  }
+}
+</script>
+
+<style scoped>
+.box {
+  display: flex;
+}
+.label {
+  margin-right: 10px;
+  font-weight: bold;
+}
+</style>

--- a/examples/sites/demos/pc/app/filter-panel/webdoc/filter-panel.js
+++ b/examples/sites/demos/pc/app/filter-panel/webdoc/filter-panel.js
@@ -47,6 +47,19 @@ export default {
       codeFiles: ['tip.vue']
     },
     {
+      demoId: 'size',
+      name: {
+        'zh-CN': '尺寸',
+        'en-US': 'Size'
+      },
+      desc: {
+        'zh-CN': '通过 <code>size</code> 设置过滤器面板的尺寸。支持 <code>medium</code> 中等尺寸，不设置则为默认尺寸。',
+        'en-US':
+          'Set the size of the filter panel through <code>size</code>. Supports <code>medium</code> size. If not set, the default size is used.'
+      },
+      codeFiles: ['size.vue']
+    },
+    {
       demoId: 'manual-hide',
       name: {
         'zh-CN': '手动隐藏',

--- a/packages/theme-saas/src/filter-box/index.less
+++ b/packages/theme-saas/src/filter-box/index.less
@@ -16,6 +16,13 @@
   @apply items-center;
   @apply text-xs;
 
+  &.@{filter-box-prefix-cls}--medium {
+    @apply h-8;
+    @apply leading-8;
+    @apply px-2;
+    @apply text-sm;
+  }
+
   &:hover {
     @apply bg-color-info-primary-subtler;
   }

--- a/packages/theme-saas/src/filter-box/index.less
+++ b/packages/theme-saas/src/filter-box/index.less
@@ -46,7 +46,6 @@
 
   .title {
     height: inherit;
-    @apply text-xs;
     @apply ~'leading-[inherit]';
 
     label {
@@ -85,7 +84,6 @@
     @apply overflow-hidden;
     @apply text-ellipsis;
     @apply whitespace-nowrap;
-    @apply text-xs;
     @apply ~'leading-[inherit]';
     @apply text-color-text-primary;
 

--- a/packages/theme/src/filter-box/index.less
+++ b/packages/theme/src/filter-box/index.less
@@ -56,7 +56,6 @@
   .title {
     height: inherit;
     line-height: var(--tv-FilterBox-btn-title-line-height);
-    font-size: var(--tv-FilterBox-btn-font-size);
     margin-right: 0;
 
     label {
@@ -98,7 +97,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    font-size: var(--tv-FilterBox-btn-font-size);
     color: var(--tv-color-text);
 
     &.placeholder {

--- a/packages/theme/src/filter-box/index.less
+++ b/packages/theme/src/filter-box/index.less
@@ -29,6 +29,12 @@
   align-items: center;
   font-size: var(--tv-FilterBox-btn-font-size);
 
+  &.@{filter-box-prefix-cls}--medium {
+    height: var(--tv-FilterBox-btn-height-medium);
+    line-height: var(--tv-FilterBox-btn-height-medium);
+    font-size: var(--tv-FilterBox-btn-font-size-medium);
+  }
+
   &.disabled {
     cursor: not-allowed;
 

--- a/packages/theme/src/filter-box/vars.less
+++ b/packages/theme/src/filter-box/vars.less
@@ -30,6 +30,12 @@
   --tv-FilterBox-btn-font-size: var(--tv-font-size-sm, 12px);
   // 按钮文本行高
   --tv-FilterBox-btn-title-line-height: var(--tv-line-height-number, 1.5);
+  // 按钮medium文本字号
+  --tv-FilterBox-btn-font-size-medium: var(--tv-font-size-default, 14px);
+  // 按钮medium文本行高
+  --tv-FilterBox-btn-title-line-height-medium: var(--tv-line-height-number, 1.5);
+  // 按钮medium高度
+  --tv-FilterBox-btn-height-medium: var(--tv-size-height-lg, 40px);
 
   // 按钮帮助图标右边距
   --tv-FilterBox-help-btn-margin-right: var(--tv-space-sm, 4px);

--- a/packages/vue/src/filter-box/src/pc.vue
+++ b/packages/vue/src/filter-box/src/pc.vue
@@ -1,5 +1,8 @@
 <template>
-  <div :class="['tiny-filter-box', disabled && 'disabled', blank && 'is-blank']" @click="handeClick">
+  <div
+    :class="['tiny-filter-box', disabled && 'disabled', blank && 'is-blank', size ? 'tiny-filter-box--' + size : '']"
+    @click="handeClick"
+  >
     <p :class="['title', dropDownVisible && 'active']">
       <label>{{ label }}</label>
       <tiny-tooltip v-if="tip" effect="light" :content="tip" placement="top">
@@ -57,6 +60,10 @@ export default defineComponent({
     blank: {
       type: Boolean,
       default: false
+    },
+    size: {
+      type: String,
+      default: ''
     }
   },
   setup(props, context) {

--- a/packages/vue/src/filter-panel/src/pc.vue
+++ b/packages/vue/src/filter-panel/src/pc.vue
@@ -27,6 +27,7 @@
             :value="value"
             :drop-down-visible="state.visible"
             :blank="blank"
+            :size="size"
           ></tiny-filter-box>
         </div>
       </template>
@@ -75,6 +76,10 @@ export default defineComponent({
     blank: {
       type: Boolean,
       default: false
+    },
+    size: {
+      type: String,
+      default: ''
     }
   },
   setup(props, context) {

--- a/packages/vue/src/picker/src/mobile-first.vue
+++ b/packages/vue/src/picker/src/mobile-first.vue
@@ -12,6 +12,7 @@
       :value="state.displayValue.toString()"
       :drop-down-visible="state.pickerVisible"
       :blank="blank"
+      :size="state.pickerSize"
     ></tiny-filter-box>
     <tiny-input
       :tabindex="tabindex"

--- a/packages/vue/src/picker/src/pc.vue
+++ b/packages/vue/src/picker/src/pc.vue
@@ -13,6 +13,7 @@
       :value="state.displayValue.toString()"
       :drop-down-visible="state.pickerVisible"
       :blank="blank"
+      :size="state.pickerSize"
     ></tiny-filter-box>
     <tiny-input
       :tabindex="tabindex"


### PR DESCRIPTION
filter-box和filter-panel组件添加size属性，并添加对应文档

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clearable option (enabled by default) and a size prop with a medium option to filter panels.

* **Documentation**
  * Added a demo showing size selection and clear behavior.

* **Style**
  * Introduced medium-size styling and new variables to support medium button/filter-box sizing.

* **Tests**
  * Added end-to-end tests validating filter panel sizing and class changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->