### PR TITLE
fix(fluent-editor): Rich text editor tables cannot be centered in batches.

### DIFF
--- a/packages/renderless/src/fluent-editor/index.ts
+++ b/packages/renderless/src/fluent-editor/index.ts
@@ -666,6 +666,106 @@ export const uploadImageToSev =
     xhr.send(fd)
   }
 
+export const alignHandler =
+  ({ state, FluentEditor }) =>
+  (value) => {
+    const range = state.quill.getSelection(true)
+    
+    if (!range) {
+      return
+    }
+    
+    const betterTableModule = state.quill.getModule('better-table')
+    
+    // 尝试通过 DOM 查找表格
+    {
+      const editorElement = state.quill.root
+      const selection = window.getSelection()
+      
+      if (selection && selection.rangeCount > 0) {
+        const domRange = selection.getRangeAt(0)
+        let container = domRange.commonAncestorContainer
+        
+        // 如果 container 是文本节点，获取其父元素
+        if (container.nodeType === Node.TEXT_NODE) {
+          container = container.parentElement
+        }
+        
+        // 向上查找表格元素
+        while (container && container !== editorElement) {
+          if (container.tagName === 'TABLE') {
+            // 找到表格，获取所有单元格
+            const cells = container.querySelectorAll('td, th')
+            if (cells.length > 1) {
+              // 将 DOM 元素转换为 Blot，并对所有单元格应用对齐
+              Array.from(cells).forEach((cellElement) => {
+                const cellBlot = state.quill.scroll.find(cellElement)
+                if (cellBlot) {
+                  // 获取单元格内的所有行（table-cell-line）
+                  const lines = []
+                  const findLines = (blot) => {
+                    if (blot && blot.statics && blot.statics.blotName === 'table-cell-line') {
+                      lines.push(blot)
+                    }
+                    if (blot && blot.children && blot.children.length > 0) {
+                      blot.children.forEach((child) => findLines(child))
+                    }
+                  }
+                  findLines(cellBlot)
+                  
+                  // 对每个行应用对齐格式
+                  lines.forEach((line) => {
+                    try {
+                      const lineIndex = state.quill.getIndex(line)
+                      if (lineIndex !== null && lineIndex >= 0) {
+                        const lineLength = line.length()
+                        if (lineLength > 0) {
+                          state.quill.formatText(lineIndex, lineLength, 'align', value, FluentEditor.sources.USER)
+                        }
+                      }
+                    } catch (e) {
+                      try {
+                        if (line.format) {
+                          line.format('align', value)
+                        }
+                      } catch (err) {
+                        // 忽略错误
+                      }
+                    }
+                  })
+                }
+              })
+              
+              // 清除表格选择状态，避免 better-table 模块报错
+              if (betterTableModule && betterTableModule.table) {
+                try {
+                  // 尝试清除选择状态
+                  if (betterTableModule.table.clearSelection) {
+                    betterTableModule.table.clearSelection()
+                  } else if (betterTableModule.hideTableTools) {
+                    betterTableModule.hideTableTools()
+                  }
+                } catch (e) {
+                  // 忽略错误
+                }
+              }
+              
+              return
+            }
+          }
+          container = container.parentElement
+        }
+      }
+      
+      // 如果还是找不到，使用默认行为
+      state.quill.format('align', value, FluentEditor.sources.USER)
+      return
+    }
+    
+    // 默认行为：使用 Quill 的标准对齐处理
+    state.quill.format('align', value, FluentEditor.sources.USER)
+  }
+
 export const handlers =
   ({ api }) =>
   () => {
@@ -675,7 +775,8 @@ export const handlers =
       lineheight: api.lineheightHandler,
       file: api.fileHandler,
       image: api.imageHandler,
-      inputFile: api.inputFileHandler
+      inputFile: api.inputFileHandler,
+      align: api.alignHandler
     }
   }
 

--- a/packages/renderless/src/fluent-editor/vue.ts
+++ b/packages/renderless/src/fluent-editor/vue.ts
@@ -35,7 +35,8 @@ import {
   handleCompositionstart,
   handleCompositionend,
   removeHandleComposition,
-  checkTableISEndElement
+  checkTableISEndElement,
+  alignHandler
 } from './index'
 import { defaultOption, iconOption, iconOptionMobileFirst, simpleToolbar } from './options'
 
@@ -104,6 +105,7 @@ const initApi = ({ api, state, service, emit, props, nextTick, FluentEditor, Upl
     undoHandler: undoHandler({ state }),
     redoHandler: redoHandler({ state }),
     lineheightHandler: lineheightHandler({ state, FluentEditor }),
+    alignHandler: alignHandler({ state, FluentEditor }),
     inputFileHandler: inputFileHandler({ state, UploaderDfls }),
     insertFileToEditor: insertFileToEditor({ state, FluentEditor, Delta }),
     insertImageToEditor: insertImageToEditor({ state, FluentEditor, Delta }),

--- a/packages/theme-saas/src/fluent-editor/index.less
+++ b/packages/theme-saas/src/fluent-editor/index.less
@@ -132,6 +132,12 @@
             @apply -top-px;
           }
         }
+
+        .ql-picker-label {
+          @apply flex;
+          @apply items-center;
+          @apply justify-center;
+        }
       }
 
       span.ql-picker.ql-color-picker.ql-expanded {
@@ -143,7 +149,9 @@
 
       .ql-align.ql-picker {
         .ql-picker-label {
-          @apply pt-1 ~'pr-1.5' pb-0 ~'pl-1.5';
+          @apply flex;
+          @apply items-center;
+          @apply justify-center;
         }
       }
 
@@ -166,6 +174,13 @@
               @apply inline-block;
             }
           }
+        }
+      }
+
+      .ql-better-table {
+        svg {
+          @apply h-4;
+          @apply w-4;
         }
       }
 


### PR DESCRIPTION
# PR
fix:富文本编辑器表格无法批量居中

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advanced table alignment functionality with improved cell and line handling.

* **Style**
  * Improved alignment picker label centering using flexbox for better visual consistency.
  * Enhanced table element icon sizing for improved UI appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->