### PR TITLE
fix(auto-tip): fix auto-tip in Vue2， the directive value may be true

### DIFF
--- a/packages/vue-directive/src/auto-tip.ts
+++ b/packages/vue-directive/src/auto-tip.ts
@@ -126,7 +126,7 @@ const bind = (el, { value }: { value: BoundingValueType }) => {
   // 如果是知己使用指令v-auto-tip，什么都不传也需要添加省略提示功能
   let resultValue = value === undefined ? {} : value
 
-  // fix vue2:  在jsx中，直接使用 v-auto-tip 在dom上， 渲染 directives:[{name:'auto-tip',  value: true}]，
+  // fix vue2:  在jsx中，在dom上直接使用 v-auto-tip，渲染 directives:[{name:'auto-tip',  value: true}]，
   // 此时 resultValue=true, 会bug
   // (vue3中同样写法， 渲染后 value = undefined, 不会bug)
   if (typeof resultValue === 'boolean' && resultValue) {

--- a/packages/vue-directive/src/auto-tip.ts
+++ b/packages/vue-directive/src/auto-tip.ts
@@ -124,7 +124,14 @@ const mouseleaveHandler = () => {
 // 指令绑定，只有第一次value有值时，才添加事件，之后并不移除事件
 const bind = (el, { value }: { value: BoundingValueType }) => {
   // 如果是知己使用指令v-auto-tip，什么都不传也需要添加省略提示功能
-  const resultValue = value === undefined ? {} : value
+  let resultValue = value === undefined ? {} : value
+
+  // fix vue2:  在jsx中，直接使用 v-auto-tip 在dom上， 渲染 directives:[{name:'auto-tip',  value: true}]，
+  // 此时 resultValue=true, 会bug
+  // (vue3中同样写法， 渲染后 value = undefined, 不会bug)
+  if (typeof resultValue === 'boolean' && resultValue) {
+    resultValue = {}
+  }
 
   el.boundingValue = resultValue
   if (resultValue && !el.boundingValue?.listened) {


### PR DESCRIPTION
# PR
JSX中使用 v-auto-tip， 在vue2,vue3中渲染的指令value不同。所以处理一下，防止报错。   发 r81,  r91
anchor 使用了 jsx  + 指令的写法。vue2下渲染报错


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Vue2 JSX rendering issue where a directive value of `true` could lead to incorrect initialization; the directive now normalizes that case to ensure correct behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->