### PR TITLE
fix: Fixed the issue where the grid operation column slots failed to render in Vue 2.

### DIFF
--- a/packages/vue/src/grid/src/cell/src/cell.ts
+++ b/packages/vue/src/grid/src/cell/src/cell.ts
@@ -329,12 +329,7 @@ export const Cell = {
     const columnSlotsWeakMap = $table.columnSlotsWeakMap || ($table.columnSlotsWeakMap = new WeakMap())
 
     if (slots && slots.default) {
-      const slotRender = getColumnSlotRender({ h, slots, columnSlotsWeakMap })
-
-      if (slotRender) {
-        // 与其他分支保持一致，返回 vnode 数组
-        return [slotRender(params)]
-      }
+      return slots.default(params, h)
     }
 
     const value = get(row, column.property)
@@ -396,8 +391,8 @@ export const Cell = {
         customExpandIcon
           ? customExpandIcon(h, { active: isActive, ...params })
           : h(iconArrowBottom(), {
-            class: ['tiny-grid-tree__node-btn', icon.tree, { 'is__active': isActive }]
-          })
+              class: ['tiny-grid-tree__node-btn', icon.tree, { 'is__active': isActive }]
+            })
       ]
     }
     const map = {
@@ -769,47 +764,47 @@ export const Cell = {
         isColGroup
           ? []
           : [
-            column.order === 'desc' || !icon.sortDefault
-              ? h(icon.sortAsc, {
-                class: [
-                  'tiny-grid-sort__btn',
-                  {
-                    'sort__active': column.order === (!icon.sortDefault ? 'asc' : 'desc')
-                  }
-                ],
-                on: {
-                  click(event) {
-                    $table.triggerSortEvent(event, column, !icon.sortDefault ? 'asc' : '')
-                  }
-                }
-              })
-              : '',
-            column.order === 'asc' || !icon.sortDefault
-              ? h(icon.sortDesc, {
-                class: [
-                  'tiny-grid-sort__btn',
-                  {
-                    'sort__active': column.order === (!icon.sortDefault ? 'desc' : 'asc')
-                  }
-                ],
-                on: {
-                  click(event) {
-                    $table.triggerSortEvent(event, column, 'desc')
-                  }
-                }
-              })
-              : '',
-            !column.order && icon.sortDefault
-              ? h(icon.sortDefault, {
-                class: ['tiny-grid-sort__btn'],
-                on: {
-                  click(event) {
-                    $table.triggerSortEvent(event, column, 'asc')
-                  }
-                }
-              })
-              : ''
-          ]
+              column.order === 'desc' || !icon.sortDefault
+                ? h(icon.sortAsc, {
+                    class: [
+                      'tiny-grid-sort__btn',
+                      {
+                        'sort__active': column.order === (!icon.sortDefault ? 'asc' : 'desc')
+                      }
+                    ],
+                    on: {
+                      click(event) {
+                        $table.triggerSortEvent(event, column, !icon.sortDefault ? 'asc' : '')
+                      }
+                    }
+                  })
+                : '',
+              column.order === 'asc' || !icon.sortDefault
+                ? h(icon.sortDesc, {
+                    class: [
+                      'tiny-grid-sort__btn',
+                      {
+                        'sort__active': column.order === (!icon.sortDefault ? 'desc' : 'asc')
+                      }
+                    ],
+                    on: {
+                      click(event) {
+                        $table.triggerSortEvent(event, column, 'desc')
+                      }
+                    }
+                  })
+                : '',
+              !column.order && icon.sortDefault
+                ? h(icon.sortDefault, {
+                    class: ['tiny-grid-sort__btn'],
+                    on: {
+                      click(event) {
+                        $table.triggerSortEvent(event, column, 'asc')
+                      }
+                    }
+                  })
+                : ''
+            ]
       )
     ]
   },


### PR DESCRIPTION
fix: 修复gird操作列插槽在vue2下无法渲染的问题
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized cell rendering logic in the grid component by simplifying the default slot rendering path, removing unnecessary intermediary wrapper layers to improve code efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->