### PR TITLE
fix(grid): fix sort logic not effect while use custom type

### DIFF
--- a/packages/vue/src/grid/src/table/src/methods.ts
+++ b/packages/vue/src/grid/src/table/src/methods.ts
@@ -1511,7 +1511,7 @@ const Methods = {
   // 点击排序事件
   triggerSortEvent(event, column, order) {
     let property = column.property
-    let isColumnSortable = column.type ? false : column.sortable || column.remoteSort
+    let isColumnSortable = column.sortable || column.remoteSort
     if (this.sortable && isColumnSortable) {
       let evntParams = { $table: this, column, order, property }
 
@@ -1531,7 +1531,7 @@ const Methods = {
     let { remoteSort, tableFullColumn, visibleColumn } = this
     let column = find(visibleColumn, (item) => item.property === field)
     let isRemote = isBoolean(column.remoteSort) ? column.remoteSort : remoteSort
-    let isColumnSortable = column.type ? false : column.sortable || column.remoteSort
+    let isColumnSortable = column.sortable || column.remoteSort
 
     if (this.sortable && isColumnSortable) {
       if (column.order !== order) {


### PR DESCRIPTION
# PR
自定义类型允许进行排序逻辑
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where columns with certain type configurations were prevented from being sortable. Columns can now be sorted based on their sortable or remoteSort settings, improving grid flexibility and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->