### PR TITLE
fix: add size prop to tiny-filter-box in various components for improved responsiveness

### DIFF
--- a/packages/vue/src/amount/src/mobile-first.vue
+++ b/packages/vue/src/amount/src/mobile-first.vue
@@ -56,6 +56,7 @@
           @click="toggleVisible"
           :show-close="clearable"
           :blank="blank"
+          :size="size"
         >
         </tiny-filter-box>
         <tiny-input

--- a/packages/vue/src/amount/src/pc.vue
+++ b/packages/vue/src/amount/src/pc.vue
@@ -23,6 +23,7 @@
           @click="toggleVisible"
           :show-close="clearable"
           :blank="blank"
+          :size="size"
         >
         </tiny-filter-box>
         <tiny-input

--- a/packages/vue/src/base-select/src/mobile-first.vue
+++ b/packages/vue/src/base-select/src/mobile-first.vue
@@ -52,6 +52,7 @@
         "
         :drop-down-visible="state.visible"
         :blank="blank"
+        :size="state.selectSize"
       >
       </tiny-filter-box>
       <div

--- a/packages/vue/src/base-select/src/pc.vue
+++ b/packages/vue/src/base-select/src/pc.vue
@@ -63,6 +63,7 @@
           "
           :drop-down-visible="state.visible"
           :blank="blank"
+          :size="state.selectSize"
         >
         </tiny-filter-box>
         <div

--- a/packages/vue/src/cascader/src/pc.vue
+++ b/packages/vue/src/cascader/src/pc.vue
@@ -38,6 +38,7 @@
       :value="state.multiple ? state.presentTags.map((item) => item.text).join('; ') : state.inputValue"
       :drop-down-visible="state.dropDownVisible"
       :blank="blank"
+      :size="state.realSize"
     ></tiny-filter-box>
     <div class="tiny-cascader-content">
       <tiny-input

--- a/packages/vue/src/select/src/mobile-first.vue
+++ b/packages/vue/src/select/src/mobile-first.vue
@@ -47,6 +47,7 @@
         "
         :drop-down-visible="state.visible"
         :blank="blank"
+        :size="state.selectSize"
       >
       </tiny-filter-box>
       <div

--- a/packages/vue/src/select/src/pc.vue
+++ b/packages/vue/src/select/src/pc.vue
@@ -61,6 +61,7 @@
           "
           :drop-down-visible="state.visible"
           :blank="blank"
+          :size="state.selectSize"
         >
         </tiny-filter-box>
         <div


### PR DESCRIPTION
fix：在各种组件中为 tiny-filter-box 添加 size 属性，解决尺寸失效问题

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced size synchronization for filter components across select, cascader, and amount component types.
  * Filter boxes now consistently respect parent component sizing in both mobile and desktop layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->