### PR TITLE
fix(grid): fix setActiveRow will error when editConfig is null

### DIFF
--- a/packages/vue/src/grid/src/edit/src/methods.ts
+++ b/packages/vue/src/grid/src/edit/src/methods.ts
@@ -338,7 +338,7 @@ export default {
     let { actived } = editStore
     let isActiveCell = handleActivedCheckCell({ actived, column, editConfig, row })
 
-    if (editor && cell && isActiveCell) {
+    if (editor && cell && isActiveCell && editConfig) {
       // 判断是否禁用编辑
       let type = 'edit-disabled'
       let canActive = await handleActivedCanActive({ editConfig, params })


### PR DESCRIPTION
# PR
修复当用户设置editConfig为null时，且逻辑中主动调用了setActiveRow会报错
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grid editing reliability by adding enhanced validation to prevent potential errors when initiating edit mode on grid cells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->