### PR TITLE
fix(tag-group): fix calculation errors caused by element positioning

### DIFF
--- a/packages/renderless/src/tag-group/index.ts
+++ b/packages/renderless/src/tag-group/index.ts
@@ -33,6 +33,11 @@ export const getHiddenTags =
     Array.from(tags).forEach((el, index) => {
       const item = props.data[index] as ITagGroupDataItem
       const element = el as HTMLElement
+
+      // 更多 这个元素是abs定位，高度是0, 它不应该参与计算
+      if (element.offsetHeight === 0) {
+        return
+      }
       if (element.offsetTop >= element.offsetHeight && item) {
         state.hiddenTags.push({ ...item })
       }


### PR DESCRIPTION
# PR
修复tag-group 因为‘更多' 元素的存在，引起的计算误差    发81

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag group visibility calculation to correctly exclude hidden elements from affecting the determination of which tags should appear or be collapsed in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->