### PR TITLE
fix(grid): fix $rowIndex in tree table is not same as before refactor

### DIFF
--- a/packages/vue/src/grid/src/body/src/body.tsx
+++ b/packages/vue/src/grid/src/body/src/body.tsx
@@ -346,12 +346,13 @@ function renderRows(_vm) {
   const seqCount = { value: 0 }
   const $seq = ''
 
-  rowPool.forEach(({ id, item: { payload: row, level: rowLevel }, used }, $rowIndex) => {
+  rowPool.forEach(({ id, item: { payload: row, level: rowLevel }, used }) => {
     const rowActived = editConfig && actived.row === row
     const virtualRow = isVirtualRow(row)
     const isSkipRowRender = (hideMethod && hideMethod(row, rowLevel)) || virtualRow
     const rowid = getRowid($table, row)
     const rowIndex = $table.getRowIndex(row)
+    const $rowIndex = row[GlobalConfig.$rowIndex]
 
     if (!isSkipRowRender) {
       seqCount.value = seqCount.value + 1

--- a/packages/vue/src/grid/src/body/src/usePool.ts
+++ b/packages/vue/src/grid/src/body/src/usePool.ts
@@ -1,4 +1,5 @@
 import { hooks } from '@opentiny/vue-common'
+import GlobalConfig from '../../config'
 
 const difference = (arr, other) => arr.filter((i) => other.findIndex((j) => i.id === j.id) === -1)
 
@@ -69,6 +70,35 @@ const updatePool = (array, context) => {
   return context
 }
 
+// 为了兼容之前$rowIndex，使用rowPool还原一下之前的虚拟滚动树状结构给$rowIndex赋值
+function addTableDataRowIndex(rowPool) {
+  const treeTableData: Record<string, any>[] = []
+  const $rowIndex = GlobalConfig.$rowIndex
+  const tempChildren = Symbol('tempChildren')
+  rowPool.forEach((rowPoolItem) => {
+    let {
+      item: { payload: row, level, parentNode },
+      used
+    } = rowPoolItem
+    if (!used) {
+      return
+    }
+    row[tempChildren] = []
+    if (level === 0) {
+      treeTableData.push(row)
+      row[$rowIndex] = treeTableData.length - 1
+    } else {
+      let parent = parentNode?.payload
+      parent?.[tempChildren]?.push(row)
+      row[$rowIndex] = parent?.[tempChildren].length - 1
+    }
+  })
+
+  rowPool.forEach((rowPoolItem) => {
+    delete rowPoolItem.item.payload[tempChildren]
+  })
+}
+
 export const usePool = (props) => {
   const columnPool = hooks.ref([])
   const rowPool = hooks.ref([])
@@ -101,6 +131,7 @@ export const usePool = (props) => {
       }
 
       rowPool.value = rowContext?.pool || rowPool.value
+      addTableDataRowIndex(rowPool.value)
       isNoData.value = !(props.tableNode?.length > 0)
     }
   )

--- a/packages/vue/src/grid/src/body/src/usePool.ts
+++ b/packages/vue/src/grid/src/body/src/usePool.ts
@@ -83,15 +83,21 @@ function addTableDataRowIndex(rowPool) {
     if (!used) {
       return
     }
-    row[tempChildren] = []
     if (level === 0) {
       treeTableData.push(row)
       row[$rowIndex] = treeTableData.length - 1
-    } else {
-      let parent = parentNode?.payload
-      parent?.[tempChildren]?.push(row)
-      row[$rowIndex] = parent?.[tempChildren].length - 1
+      return
     }
+    const parent = parentNode?.payload
+    if (!parent) {
+      return
+    }
+    if (!parent[tempChildren]) {
+      parent[tempChildren] = []
+    }
+
+    parent[tempChildren].push(row)
+    row[$rowIndex] = parent[tempChildren].length - 1
   })
 
   rowPool.forEach((rowPoolItem) => {

--- a/packages/vue/src/grid/src/composable/useCellSpan.ts
+++ b/packages/vue/src/grid/src/composable/useCellSpan.ts
@@ -1,6 +1,7 @@
 import { hooks } from '@opentiny/vue-common'
 import { isVirtualRow } from '../table/src/strategy'
 import { getRowid } from '@opentiny/vue-renderless/grid/utils'
+import GlobalConfig from '../config'
 
 export const useCellSpan = (bodyVm, bodyProps) => {
   const $table = bodyVm.$parent
@@ -30,9 +31,9 @@ export const useCellSpan = (bodyVm, bodyProps) => {
       const normalState = {}
       const normalTable = []
 
-      for (let $rowIndex = 0; $rowIndex < tableData.length; $rowIndex++) {
-        const row = tableData[$rowIndex]
-        const rowLevel = tableNode[$rowIndex].level
+      for (let index = 0; index < tableData.length; index++) {
+        const row = tableData[index]
+        const rowLevel = tableNode[index].level
         const rowIndex = $table.getRowIndex(row)
         let virtualRow = false
 
@@ -46,7 +47,7 @@ export const useCellSpan = (bodyVm, bodyProps) => {
           seqCount.value = seqCount.value + 1
         }
 
-        let seq = isOrdered ? seqCount.value : $rowIndex + 1
+        let seq = isOrdered ? seqCount.value : index + 1
 
         if (scrollYLoad) {
           seq += startIndex
@@ -61,7 +62,16 @@ export const useCellSpan = (bodyVm, bodyProps) => {
           }
         }
 
-        const params = { $table, data: tableData, row, $rowIndex, rowIndex, level: rowLevel, $seq: '', seq }
+        const params = {
+          $table,
+          data: tableData,
+          row,
+          $rowIndex: row[GlobalConfig.$rowIndex],
+          rowIndex,
+          level: rowLevel,
+          $seq: '',
+          seq
+        }
 
         stateNormalCell(normalState, normalTable, params, $table)
       }

--- a/packages/vue/src/grid/src/config.ts
+++ b/packages/vue/src/grid/src/config.ts
@@ -63,6 +63,7 @@ const GlobalConfig = {
   defaultTreeIndent: 16,
   defaultTreeSpacing: 30,
   rowId: '_RID', // 行数据的唯一主键字段名
+  $rowIndex: Symbol('$rowIndex'), // 虚拟滚动处理后的行索引
   version: 0, // 版本号，对于某些带数据缓存的功能有用到，上升版本号可以用于重置数据
   optimization: {
     animat: true,


### PR DESCRIPTION
# PR
向前兼容：修复$rowIndex在树表中，与之前表现不一致问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved row-indexing mechanism in the grid to derive visible row indices from virtual-scroll state, improving sequencing consistency.
* **Bug Fixes**
  * Corrected row numbering and cell span calculations under virtual scrolling so row order, sequence numbers, and spans render reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->