### PR TITLE
test(e2e): Changes the element locator from `getByRole` to a more precise CSS selector.

### DIFF
--- a/examples/sites/demos/pc/app/time-select/basic-usage.spec.ts
+++ b/examples/sites/demos/pc/app/time-select/basic-usage.spec.ts
@@ -4,7 +4,7 @@ test('基础用法', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
   await page.goto('time-select#basic-usage')
   const input = page.locator('#basic-usage').locator('.tiny-input__inner')
-  const timeInput = page.locator('#basic-usage').getByRole('textbox', { name: '选择时间' })
+  const timeInput = page.locator('#basic-usage').getByRole('combobox', { name: '选择时间' })
   await timeInput.click()
   await page.getByText('10:00').click()
   await expect(input).toHaveValue('10:00')

--- a/examples/sites/demos/pc/app/time-select/clear-icon.spec.ts
+++ b/examples/sites/demos/pc/app/time-select/clear-icon.spec.ts
@@ -4,9 +4,8 @@ test('自定义清空图标', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
   await page.goto('time-select#clear-icon')
   const demo = page.locator('#clear-icon')
-  const timeInput = page.getByRole('textbox', { name: '选择时间' })
   const input = demo.locator('.tiny-input__inner')
-  await timeInput.click()
+  await input.click()
   await page.getByText('10:00').click()
   await input.hover()
   //   点击图标，清除输入框内容

--- a/examples/sites/demos/pc/app/time-select/focus.spec.ts
+++ b/examples/sites/demos/pc/app/time-select/focus.spec.ts
@@ -4,6 +4,6 @@ test('事件', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
   await page.goto('time-select#focus')
   await page.getByRole('button', { name: '手动获取焦点' }).click()
-  const focus = page.getByRole('textbox', { name: '选择时间' })
+  const focus = page.locator('#focus').locator('.tiny-input__inner')
   await expect(focus).toBeFocused()
 })

--- a/examples/sites/demos/pc/app/time-select/picker-options.spec.ts
+++ b/examples/sites/demos/pc/app/time-select/picker-options.spec.ts
@@ -3,5 +3,6 @@ import { test, expect } from '@playwright/test'
 test('指定时间点', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
   await page.goto('time-select#picker-options')
-  expect(await page.getByRole('textbox', { name: '选择时间' }).getAttribute('title')).not.toBeNull()
+  const input = page.locator('#picker-options').locator('.tiny-input__inner')
+  expect(await input.getAttribute('title')).not.toBeNull()
 })

--- a/examples/sites/demos/pc/app/time-select/range-placeholder.spec.ts
+++ b/examples/sites/demos/pc/app/time-select/range-placeholder.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test'
 test('固定时间范围', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
   await page.goto('time-select#range-placeholder')
-  const timeInput = page.getByRole('textbox', { name: '起始时间' })
+  const timeInput = page.locator('.tiny-input-suffix .tiny-input__inner').first()
   const options = page.locator('.tiny-picker-panel').nth(1).locator('div')
   await timeInput.click()
   // options 的第一条是 options.first()，时间是 08:30；最后一条（最大时间）是 options.nth(43)，时间是 18:30
@@ -13,7 +13,7 @@ test('固定时间范围', async ({ page }) => {
   options.nth(10).click()
   await expect(page.locator('.tiny-input-suffix .tiny-input__inner').first()).toHaveValue('10:00')
 
-  const timeEnd = page.getByRole('textbox', { name: '结束时间' })
+  const timeEnd = page.locator('.tiny-input-suffix .tiny-input__inner').last()
   const endOptions = page.locator('.tiny-picker-panel').nth(1).locator('div')
   await timeEnd.click()
   await expect(endOptions.first()).toContainText('08:30')

--- a/examples/sites/demos/pc/app/time-select/size-medium.spec.ts
+++ b/examples/sites/demos/pc/app/time-select/size-medium.spec.ts
@@ -3,9 +3,9 @@ import { test, expect } from '@playwright/test'
 test('medium 尺寸', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
   await page.goto('time-select#size-medium')
-  const mediumBox = page.getByRole('textbox', { name: '尺寸：medium' })
-  const smallBox = page.getByRole('textbox', { name: '尺寸：small' })
-  const miniBox = page.getByRole('textbox', { name: '尺寸：mini' })
+  const mediumBox = page.locator('#size-medium').locator('.tiny-input__inner').nth(0)
+  const smallBox = page.locator('#size-medium').locator('.tiny-input__inner').nth(1)
+  const miniBox = page.locator('#size-medium').locator('.tiny-input__inner').nth(2)
   await expect(mediumBox).toHaveCSS('height', '40px')
   await expect(smallBox).toHaveCSS('height', '28px')
   await expect(miniBox).toHaveCSS('height', '24px')


### PR DESCRIPTION
test(e2e): 将元素定位器从 `getByRole` 更改为更精确的 CSS 选择器。
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated time-select test selectors to use more robust element locators, improving stability and maintainability across multiple scenarios.
  * No changes to public APIs or user-facing behavior; these are test-only adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->