### PR TITLE
ci(workflow): add option to control automatic patch version upgrade in alpha release workflow

### DIFF
--- a/.github/workflows/dispatch-ui-publish-alpha.yml
+++ b/.github/workflows/dispatch-ui-publish-alpha.yml
@@ -10,6 +10,11 @@ on:
           例如： `input alert`.
         required: false
         type: string
+      updateVersion:
+        description: '是否自动升级 patch 版本号'
+        required: false
+        type: boolean
+        default: true
 concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}
   cancel-in-progress: true
@@ -57,7 +62,13 @@ jobs:
         run: pnpm build:ui
 
       - name: Run Release alpha
-        run: pnpm release:alpha -u
+        run: |
+          # 根据工作流输入决定是否自动升级 patch 版本号
+          if [ "${{ inputs.updateVersion }}" = "true" ]; then
+            pnpm release:alpha -u   # 自动升级 patch 版本
+          else
+            pnpm release:alpha      # 不升级版本
+          fi
 
       - name: Publish
         run: |

--- a/.github/workflows/dispatch-ui-publish-alpha.yml
+++ b/.github/workflows/dispatch-ui-publish-alpha.yml
@@ -62,8 +62,9 @@ jobs:
         run: pnpm build:ui
 
       - name: Run Release alpha
+        shell: bash
         run: |
-          # 根据工作流输入决定是否自动升级 patch 版本号
+          # 根据工作流输入决定是否自动升级 patch 版本号（使用 bash 语法）
           if [ "${{ inputs.updateVersion }}" = "true" ]; then
             pnpm release:alpha -u   # 自动升级 patch 版本
           else


### PR DESCRIPTION
ci(workflow): 在 alpha 版本发布工作流程中添加控制自动补丁版本升级的选项
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Enhanced the alpha release workflow configuration by adding a new option to control whether patch version numbers are automatically updated during alpha releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->