### PR TITLE
fix(input): fix textarea height resize after mounted

### DIFF
--- a/examples/sites/demos/pc/app/input/resize.spec.ts
+++ b/examples/sites/demos/pc/app/input/resize.spec.ts
@@ -38,7 +38,7 @@ test('可缩放文本域', async ({ page }) => {
   // autosize 检查高度
   await textarea2.nth(1).fill('')
   defaultHeight = await textarea2
-    .nth(0)
+    .nth(1)
     .boundingBox()
     .then((box) => box?.height)
   await textarea2.nth(1).fill(fillText + fillText)
@@ -47,5 +47,5 @@ test('可缩放文本域', async ({ page }) => {
     .boundingBox()
     .then((box) => box?.height)
   await expect(fill1Height).not.toBeNull()
-  await expect(defaultHeight).toBeGreaterThanOrEqual(fill1Height || 0)
+  await expect(fill1Height).toBeGreaterThanOrEqual(defaultHeight || 0)
 })

--- a/packages/renderless/src/input/vue.ts
+++ b/packages/renderless/src/input/vue.ts
@@ -269,7 +269,7 @@ const mergeApi = ({
     }),
     handleFocus: handleFocus({ api, emit, state }),
     handleInput: handleInput({ api, emit, nextTick, state }),
-    resizeTextarea: debounce(200, resizeTextarea({ api, parent, vm, state, props })),
+    resizeTextarea: debounce(200, true, resizeTextarea({ api, parent, vm, state, props })),
     updateIconOffset: updateIconOffset(api),
     calcTextareaHeight: calcTextareaHeight({
       api,


### PR DESCRIPTION
# PR
修复textarea会在渲染后重新resize一次，导致页面抖动问题
![PixPin_2026-02-05_18-38-01](https://github.com/user-attachments/assets/9bf75635-9c40-47bf-8ed1-91a1f17f41cb)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved textarea autosize responsiveness so input fields resize and provide more immediate visual feedback during typing.

* **Tests**
  * Updated autosize test expectations to reflect the corrected sizing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->