### PR TITLE
fix(tag): Set the maximum width not to display the ellipsis.

### DIFF
--- a/examples/sites/demos/pc/app/tag/basic-usage.spec.ts
+++ b/examples/sites/demos/pc/app/tag/basic-usage.spec.ts
@@ -4,7 +4,7 @@ test('配置式标签', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).not.toBeNull())
   await page.goto('tag#basic-usage')
 
-  const tag = page.locator('.all-demos-container').getByText('配置式标签')
+  const tag = page.locator('span').filter({ hasText: '配置式标签' }).first()
 
   await expect(tag).toHaveCount(1)
 })

--- a/examples/sites/demos/pc/app/tag/color-border.spec.ts
+++ b/examples/sites/demos/pc/app/tag/color-border.spec.ts
@@ -5,8 +5,8 @@ test('边框和自定义背景色', async ({ page }) => {
   await page.goto('tag#color-border')
 
   const tags = page.locator('.all-demos-container').locator('.tiny-tag')
-  const red = tags.getByText('red 标签')
-  const custom = tags.getByText('自定义背景色', { exact: true })
+  const red = page.locator('span').filter({ hasText: 'red 标签' }).first()
+  const custom = page.locator('span').filter({ hasText: '自定义背景色' }).first()
 
   await expect(red).toHaveClass(/tiny-tag--red/)
   await expect(custom).toHaveCSS('background-color', 'rgba(82, 196, 26, 0.8)')

--- a/examples/sites/demos/pc/app/tag/max-width.spec.ts
+++ b/examples/sites/demos/pc/app/tag/max-width.spec.ts
@@ -4,7 +4,7 @@ test('测试最大宽度', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).not.toBeNull())
   await page.goto('tag#max-width')
 
-  const normal = page.getByText('文本超长超长的标签')
+  const normal = page.getByLabel('示例', { exact: true }).locator('span').first()
 
   await expect(normal).toHaveCSS('max-width', '80px')
 })

--- a/examples/sites/demos/pc/app/tag/size.spec.ts
+++ b/examples/sites/demos/pc/app/tag/size.spec.ts
@@ -4,9 +4,9 @@ test('各型号尺寸是否正常', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).not.toBeNull())
   await page.goto('tag#size')
 
-  const normal = page.getByText('默认标签')
-  const medium = page.getByText('中等标签')
-  const small = page.getByText('小型标签')
+  const normal = page.locator('span').filter({ hasText: '默认标签' }).first()
+  const medium = page.locator('span').filter({ hasText: '中等标签' }).first()
+  const small = page.locator('span').filter({ hasText: '小型标签' }).first()
 
   await expect(normal).toHaveCSS('height', '24px')
   await expect(medium).toHaveCSS('height', '32px')

--- a/examples/sites/demos/pc/app/tag/slot-default.spec.ts
+++ b/examples/sites/demos/pc/app/tag/slot-default.spec.ts
@@ -3,9 +3,9 @@ import { expect, test } from '@playwright/test'
 test('图标是否正常显示', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).not.toBeNull())
   await page.goto('tag#slot-default')
-
-  const left = page.locator('.tiny-tag > svg:nth-child(1)').first()
-  const right = page.locator('.tiny-tag > svg:nth-child(2)').first()
+  
+  const left = page.getByLabel('示例', { exact: true }).getByRole('img').first()
+  const right = page.getByLabel('示例', { exact: true }).getByRole('img').nth(2)
 
   await expect(left).toBeVisible()
   await expect(right).toBeVisible()

--- a/packages/vue/src/tag/src/pc.vue
+++ b/packages/vue/src/tag/src/pc.vue
@@ -85,7 +85,17 @@ export default defineComponent({
     const tagElement =
       value || (slots.default && slots.default()) ? (
         <span data-tag="tiny-tag" class={classes} style={styles} onClick={handleClick}>
-          {value ? <span>{value}</span> : slots.default && slots.default()}
+          {value ? (
+            <span style={maxWidth ? { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap'} : {}}>
+              {value}
+            </span>
+          ) : (
+            slots.default && (
+              <span style={maxWidth ? { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } : {}}>
+                {slots.default()}
+              </span>
+            )
+          )}
           {closable && <icon-close class="tiny-svg-size tiny-tag__close" onClick={handleClose}></icon-close>}
         </span>
       ) : (


### PR DESCRIPTION
# PR
fix(tag):设置最大宽度不显示省略号
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tag component now truncates long text with an ellipsis when a maximum width is set, applying to both explicit values and default slot content to prevent layout overflow.

* **Tests**
  * Updated demo tests for tag behavior with more precise element selection; added a height assertion for the small tag size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->