### PR TITLE
fix(fluent-editor): z-index  is applied only when the screen is in full-screen mode

### DIFF
--- a/packages/vue/src/fluent-editor/src/mobile-first.vue
+++ b/packages/vue/src/fluent-editor/src/mobile-first.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="tiny-editor-wrapper" :class="{ 'fullscreen': state.isFullscreen }" :style="{ 'z-index': state.zIndex }">
+  <div
+    class="tiny-editor-wrapper"
+    :class="{ 'fullscreen': state.isFullscreen }"
+    :style="state.isFullscreen ? { 'z-index': state.zIndex } : null"
+  >
     <div ref="editor" id="editor" class="tiny-editor" @dblclick="handleDblclick"></div>
     <tiny-image-viewer v-if="state.showPreview" v-bind="state.previewOptions"></tiny-image-viewer>
     <div class="toolbar-icon" ref="editor-toolbar-icon">

--- a/packages/vue/src/fluent-editor/src/pc.vue
+++ b/packages/vue/src/fluent-editor/src/pc.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="tiny-editor-wrapper" :class="{ 'fullscreen': state.isFullscreen }" :style="{ 'z-index': state.zIndex }">
+  <div
+    class="tiny-editor-wrapper"
+    :class="{ 'fullscreen': state.isFullscreen }"
+    :style="state.isFullscreen ? { 'z-index': state.zIndex } : null"
+  >
     <div ref="editor" id="editor" class="tiny-editor" @dblclick="handleDblclick"></div>
     <tiny-image-viewer v-if="state.showPreview" v-bind="state.previewOptions"></tiny-image-viewer>
     <div class="toolbar-icon" ref="editor-toolbar-icon">


### PR DESCRIPTION
 
# PR
fluent-editor 在全屏时，才增加z-index属性
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated z-index stacking behavior in the editor to apply conditionally during fullscreen mode, ensuring proper display layering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->