### PR TITLE
fix(input): fixed an issue where multiple lines exceeding the ellipsis value in read-only input mode would display incorrectly in Safari.

### DIFF
--- a/packages/vue/src/input/src/mobile-first.vue
+++ b/packages/vue/src/input/src/mobile-first.vue
@@ -302,25 +302,28 @@
         :popper-options="{ bubbling: true }"
         @mouseenter.native="handleEnterDisplayOnlyContent($event, 'textarea')"
       >
-        <div class="inline-flex max-w-full">
+        <div class="relative inline-block max-w-full">
           <span
             ref="textBox"
-            class="text-box max-w-full break-words line-clamp-5 text-sm text-color-text-primary before:content-[''] before:float-right before:h-full before:-mb-4"
+            class="text-box block max-w-full min-w-0 break-words text-sm leading-5 text-color-text-primary"
             :class="[
               state.inputSizeMf !== 'mini' ? 'sm:text-sm' : 'sm:text-xs',
-              hoverExpand && 'relative left-0 max-w-full leading-5 line-clamp-1',
-              autosize
-                ? 'left-0 max-w-full break-words  whitespace-pre-line leading-5'
-                : 'left-0 max-w-full text-ellipsis overflow-hidden break-words whitespace-pre-wrap line-clamp-5'
+              hoverExpand
+                ? 'line-clamp-1'
+                : state.showMoreBtn
+                  ? 'line-clamp-5 whitespace-pre-wrap pr-10'
+                  : 'line-clamp-5 whitespace-pre-wrap',
+              autosize && 'whitespace-pre-line'
             ]"
             @click="state.showDisplayOnlyBox = true"
+            >{{ state.displayOnlyText }}</span
           >
-            <span
-              v-if="state.showMoreBtn"
-              class="float-right relative top-px clear-both text-color-brand text-sm leading-3 cursor-pointer"
-              >{{ t('ui.input.more') }}></span
-            >{{ state.displayOnlyText }}
-          </span>
+          <span
+            v-if="state.showMoreBtn"
+            class="absolute bottom-0 right-0 text-color-brand text-sm leading-5 cursor-pointer"
+            @click="state.showDisplayOnlyBox = true"
+            >{{ t('ui.input.more') }}></span
+          >
         </div>
       </tiny-tooltip>
       <tiny-dialog-box


### PR DESCRIPTION
fix: 修复input只读状态多行超出省略在safari浏览器中显示异常问题
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expandable "More" control to display full content in read-only input fields

* **Style**
  * Improved layout and text rendering for display-only input mode with enhanced spacing and readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->