### PR TITLE
fix(input): add popMore dialog's content with break-words rule

### DIFF
--- a/packages/vue/src/input/src/mobile-first.vue
+++ b/packages/vue/src/input/src/mobile-first.vue
@@ -335,7 +335,7 @@
         :close-on-click-modal="false"
         @update:visible="state.showDisplayOnlyBox = $event"
       >
-        <pre class="font-[inherit] whitespace-pre-wrap">{{ state.displayOnlyText }}</pre>
+        <pre class="font-[inherit] whitespace-pre-wrap break-words">{{ state.displayOnlyText }}</pre>
         <template #footer>
           <tiny-button @click="state.showDisplayOnlyBox = false">{{ t('ui.input.close') }}</tiny-button>
         </template>


### PR DESCRIPTION
# PR
input 的多端模版， 在只读且显示更多时，弹窗的文字支持换行   ，发81 90
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a display issue where long, uninterrupted text in modals would overflow instead of breaking to new lines, improving text readability and layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->