### PR TITLE
fix: 修复input只读状态多行 在safari浏览器中有大段空白的问题

### DIFF
--- a/packages/vue/src/input/src/mobile-first.vue
+++ b/packages/vue/src/input/src/mobile-first.vue
@@ -302,7 +302,7 @@
         :popper-options="{ bubbling: true }"
         @mouseenter.native="handleEnterDisplayOnlyContent($event, 'textarea')"
       >
-        <div class="relative inline-block max-w-full">
+        <div class="relative inline-flex max-w-full">
           <span
             ref="textBox"
             class="text-box block max-w-full min-w-0 break-words text-sm leading-5 text-color-text-primary"


### PR DESCRIPTION
# PR

fix: 修复input只读状态多行 在safari浏览器中有大段空白的问题

说明：
经在mac上测试， 修改为inline-flex 或者 添加overflow:hidden 都可以解决空白问题。  
为了和以前一致，还原回inline-flex了

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual layout alignment for textarea components in read-only display mode, improving horizontal content flow without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->