### PR TITLE
fix(tag): add a span tag to the tag and insert a CSS rule for long el…

### DIFF
--- a/packages/theme-saas/src/tag/index.less
+++ b/packages/theme-saas/src/tag/index.less
@@ -32,6 +32,7 @@
   & &__close {
     @apply text-xs;
     @apply ml-1;
+    flex-shrink: 0;
 
     &:hover {
       @apply cursor-pointer;

--- a/packages/theme/src/tag/index.less
+++ b/packages/theme/src/tag/index.less
@@ -151,6 +151,7 @@
     fill: var(--tv-Tag-close-icon-color);
     margin-left: var(--tv-Tag-close-icon-margin-left);
     cursor: pointer;
+    flex-shrink: 0;
 
     &:hover {
       fill: var(--tv-Tag-close-icon-color-hover);

--- a/packages/vue/src/tag/src/pc.vue
+++ b/packages/vue/src/tag/src/pc.vue
@@ -86,12 +86,10 @@ export default defineComponent({
       value || (slots.default && slots.default()) ? (
         <span data-tag="tiny-tag" class={classes} style={styles} onClick={handleClick}>
           {value ? (
-            <span style={maxWidth ? { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap'} : {}}>
-              {value}
-            </span>
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{value}</span>
           ) : (
             slots.default && (
-              <span style={maxWidth ? { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } : {}}>
+              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                 {slots.default()}
               </span>
             )


### PR DESCRIPTION
 
# PR
解决select中嵌套tag时， 文本过长没有省略号。  发 81, 91


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tag close button display to prevent unexpected shrinking in flex layouts
  * Improved tag content text overflow handling with consistent ellipsis styling across all states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->