### PR TITLE
feat(radio,radio-group): adapt to Radio Components

### DIFF
--- a/packages/theme/src/adaptation-index.less
+++ b/packages/theme/src/adaptation-index.less
@@ -18,7 +18,7 @@
 // @import './form-item/adaptation.less';
 // @import './input/adaptation.less';
 // @import './numeric/adaptation.less';
-// @import './radio/adaptation.less';
+@import './radio/responsive.less';
 // @import './radio-group/adaptation.less';
 // @import './search/adaptation.less';
 // @import './select/adaptation.less';

--- a/packages/theme/src/radio-group/index.less
+++ b/packages/theme/src/radio-group/index.less
@@ -22,6 +22,9 @@
   .inject-RadioGroup-vars();
 
   display: inline-flex;
+  // 此处需要添加一个换行样式，才合理，支持单行和多行展示
+  flex-wrap: wrap;
+  align-items: center;
 
   &.list-inline {
     flex-direction: column;

--- a/packages/theme/src/radio/responsive.less
+++ b/packages/theme/src/radio/responsive.less
@@ -1,0 +1,14 @@
+@import '../custom.less';
+@import './vars.less';
+
+@radio-prefix-cls: ~'@{css-prefix}radio';
+
+@media screen and (max-width: 1280px) {
+  .@{radio-prefix-cls} {
+    .inject-radio-vars();
+
+    &__label {
+      white-space: pre-wrap;
+    }
+  }
+}

--- a/packages/theme/src/radio/responsive.less
+++ b/packages/theme/src/radio/responsive.less
@@ -5,8 +5,6 @@
 
 @media screen and (max-width: 1280px) {
   .@{radio-prefix-cls} {
-    .inject-radio-vars();
-
     &__label {
       white-space: pre-wrap;
     }


### PR DESCRIPTION
# PR
radio-group组件 :pc和小屏显示，应该默认都需要支持可换行显示
<img width="1649" height="805" alt="image" src="https://github.com/user-attachments/assets/bf4a79f3-ce10-4773-9572-1213e1373fb2" />

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:
适配小屏显示
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added responsive design support for radio components optimized for smaller screens

* **Style**
  * Improved radio group layout with automatic wrapping and vertical centering
  * Enhanced text wrapping behavior for better readability on compact displays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->