### PR TITLE
fix(tree-select): handle modelValue change in single selection mode

### DIFF
--- a/packages/renderless/src/tree-select/index.ts
+++ b/packages/renderless/src/tree-select/index.ts
@@ -1,5 +1,30 @@
 import { find } from '@opentiny/utils'
 
+const getSingleSelectedData = ({ props, data }) => ({
+  ...data,
+  currentLabel: data[props.textField],
+  value: data[props.valueField],
+  state: {
+    currentLabel: data[props.textField]
+  }
+})
+
+const updateSingleSelected = ({ props, vm, data }) => {
+  vm.$refs.baseSelectRef.updateSelectedData(data)
+
+  const baseState = vm.$refs.baseSelectRef.state
+
+  if (!baseState) return
+
+  const currentLabel = data?.[props.textField] || ''
+
+  baseState.selectedLabel = currentLabel
+
+  if (props.filterable || props.searchable) {
+    baseState.query = currentLabel
+  }
+}
+
 /**
  * 树节点过滤事件
  */
@@ -16,13 +41,10 @@ export const nodeClick =
   ({ props, vm, emit }) =>
   (data) => {
     if (!props.multiple) {
-      vm.$refs.baseSelectRef.updateSelectedData({
-        ...data,
-        currentLabel: data[props.textField],
-        value: data[props.valueField],
-        state: {
-          currentLabel: data[props.textField]
-        }
+      updateSingleSelected({
+        props,
+        vm,
+        data: getSingleSelectedData({ props, data })
       })
 
       emit('change', data[props.valueField])
@@ -190,13 +212,10 @@ export const mounted =
       // 如果没有找到节点（例如懒加载场景），直接返回
       if (!data) return
 
-      vm.$refs.baseSelectRef.updateSelectedData({
-        ...data,
-        currentLabel: data[props.textField],
-        value: data[props.valueField],
-        state: {
-          currentLabel: data[props.textField]
-        }
+      updateSingleSelected({
+        props,
+        vm,
+        data: getSingleSelectedData({ props, data })
       })
 
       state.currentKey = data[props.valueField]
@@ -210,18 +229,22 @@ export const watchValue =
     if (!props.multiple) {
       if (newValue === oldValue || newValue === state.currentKey) return
 
+      if (newValue === null || newValue === undefined || newValue === '') {
+        updateSingleSelected({ props, vm, data: {} })
+        state.currentKey = ''
+
+        return
+      }
+
       const options = api.getPluginOption(newValue)
       const data = options && options.length > 0 ? options[0] : null
 
       if (!data) return
 
-      vm.$refs.baseSelectRef.updateSelectedData({
-        ...data,
-        currentLabel: data[props.textField],
-        value: data[props.valueField],
-        state: {
-          currentLabel: data[props.textField]
-        }
+      updateSingleSelected({
+        props,
+        vm,
+        data: getSingleSelectedData({ props, data })
       })
 
       state.currentKey = data[props.valueField]

--- a/packages/renderless/src/tree-select/index.ts
+++ b/packages/renderless/src/tree-select/index.ts
@@ -206,6 +206,30 @@ export const mounted =
 export const watchValue =
   ({ api, props, vm, state }) =>
   (newValue, oldValue) => {
+    // 单选模式处理
+    if (!props.multiple) {
+      if (newValue === oldValue || newValue === state.currentKey) return
+
+      const options = api.getPluginOption(newValue)
+      const data = options && options.length > 0 ? options[0] : null
+
+      if (!data) return
+
+      vm.$refs.baseSelectRef.updateSelectedData({
+        ...data,
+        currentLabel: data[props.textField],
+        value: data[props.valueField],
+        state: {
+          currentLabel: data[props.textField]
+        }
+      })
+
+      state.currentKey = data[props.valueField]
+
+      return
+    }
+
+    // 多选模式处理
     if (props.multiple) {
       // 取新旧值的差集，用来判断是否是删除标签的操作，如果差值只有一个值，说明是删除操作
       // 如果是删除操作，且不是父子严格模式，则需要将父节点的值也删除（严格模式下父子节点勾选相互独立，不会相互影响）

--- a/packages/renderless/src/tree-select/index.ts
+++ b/packages/renderless/src/tree-select/index.ts
@@ -16,7 +16,7 @@ const updateSingleSelected = ({ props, vm, data }) => {
 
   if (!baseState) return
 
-  const currentLabel = data?.[props.textField] || ''
+  const currentLabel = data?.[props.textField] ?? ''
 
   baseState.selectedLabel = currentLabel
 


### PR DESCRIPTION
## PR描述

### 问题
当tree-select组件在单选模式下，v-model绑定的值发生改变时，组件不会更新显示。

### 修复方案
在`watchValue`函数中添加单选模式的处理逻辑，当`modelValue`改变时：
1. 使用`getPluginOption`获取新的树节点数据
2. 调用`baseSelectRef.updateSelectedData`更新选中数据
3. 更新`state.currentKey`保持内部状态同步

### Issue
Fixes #3167

### 验证方式
按照issue中的复现步骤验证：
1. 绑定v-model值为10
2. 点击按钮修改值为4
3. 组件应正确显示新的选中值

## PR Checklist
- [x] Commit信息符合规范
- [ ] 补充E2E测试用例
- [ ] 补充文档

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Single-selection now avoids redundant updates, properly resets on null/empty values, fetches and applies option data when needed, and keeps the selected key in sync.

* **Refactor**
  * Consolidated single-select update flow into a centralized pathway to improve reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->