### PR TITLE
fix(select-dropdown): after the mf template is loaded, the focus element in the input select is actively out of focus to avoid the cursor in safari

### DIFF
--- a/packages/renderless/src/select-dropdown/index.ts
+++ b/packages/renderless/src/select-dropdown/index.ts
@@ -29,6 +29,13 @@ export const mounted =
     })
 
     selectEmitter.on(constants.EVENT_NAME.destroyPopper, destroyPopper)
+
+    // mf模板的弹出后，要清除当前focus的元素，避免苹果系统出现光标
+    if (selectVm.state.device === 'mb' && selectVm.state.breakpoint === 'default') {
+      if (document.activeElement) {
+        document.activeElement.blur()
+      }
+    }
   }
 
 export const closeModal =

--- a/packages/renderless/src/select-dropdown/index.ts
+++ b/packages/renderless/src/select-dropdown/index.ts
@@ -29,13 +29,6 @@ export const mounted =
     })
 
     selectEmitter.on(constants.EVENT_NAME.destroyPopper, destroyPopper)
-
-    // mf模板的弹出后，要清除当前focus的元素，避免苹果系统出现光标
-    if (selectVm.state.device === 'mb' && selectVm.state.breakpoint === 'default') {
-      if (document.activeElement) {
-        document.activeElement.blur()
-      }
-    }
   }
 
 export const closeModal =

--- a/packages/renderless/src/select/index.ts
+++ b/packages/renderless/src/select/index.ts
@@ -1575,6 +1575,13 @@ export const watchVisible =
           vm.$refs.scrollbar.handleScroll()
         }
       }
+
+      // mf模板的弹出后，要清除当前focus的元素，避免苹果系统出现光标
+      if (value && state.device === 'mb' && state.breakpoint === 'default') {
+        if (document.activeElement) {
+          document.activeElement.blur()
+        }
+      }
     }, props.updateDelay)
 
     if (!value && props.shape === 'filter') {

--- a/packages/vue/src/select/src/mobile-first.vue
+++ b/packages/vue/src/select/src/mobile-first.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="select"
+    data-tag="tiny-select"
     class="inline-block relative w-full outline-0 group [&_[data-tag=tiny-tag]]:max-w-[144px]"
     v-popover:popover
     :class="[hoverExpand ? 'align-top' : '', $parent.$attrs.class]"


### PR DESCRIPTION
# PR
fix(select-dropdown): mf模板加载后，主动失焦 select中 input的focus元素，避免safari中的光标。     发：91，验证后发81
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved on-screen keyboard cursor appearing when opening select popup on Apple mobile devices.

* **Chores**
  * Added internal data attributes to select component for enhanced tracking and monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->