### PR TITLE
feat(fluent-editor): Intercepting redirection before a rich text hyperlink is followed

### DIFF
--- a/examples/sites/demos/apis/fluent-editor.js
+++ b/examples/sites/demos/apis/fluent-editor.js
@@ -19,6 +19,22 @@ export default {
           pcDemo: 'before-editor-init'
         },
         {
+          name: 'before-link-open',
+          typeAnchorName: 'IBeforeLinkOpen',
+          type: 'IBeforeLinkOpen',
+          defaultValue: '',
+          meta: {
+            stable: '3.30.0'
+          },
+          desc: {
+            'zh-CN':
+              '点击富文本中的超链接前触发。返回 false（或 Promise resolve false）可拦截跳转；返回 true/undefined 继续跳转。',
+            'en-US': ''
+          },
+          mode: ['pc', 'mobile-first'],
+          pcDemo: ''
+        },
+        {
           name: 'data-type',
           type: 'boolean',
           defaultValue: 'true',
@@ -103,6 +119,20 @@ export default {
     }
   ],
   types: [
+    {
+      name: 'IBeforeLinkOpen',
+      type: 'type',
+      code: `
+type IBeforeLinkOpen = (payload: {
+  url: string // 过滤后的安全链接
+  rawUrl: string // 原始 href
+  target: string // 超链接 target，默认 _blank
+  rel: string // 超链接 rel
+  event: MouseEvent // 点击事件对象
+  quill: any // 当前编辑器实例
+}) => boolean | void | Promise<boolean | void>
+      `
+    },
     {
       name: 'IImageUploadOptions',
       type: 'interface',

--- a/packages/renderless/src/fluent-editor/index.ts
+++ b/packages/renderless/src/fluent-editor/index.ts
@@ -5,6 +5,18 @@ import { set } from '../chart-core/deps/utils'
 import { on, off } from '@opentiny/utils'
 import { PopupManager } from '@opentiny/utils'
 
+const isSafeLinkUrl = (url) => /^(https?:|mailto:|tel:|\/|#)/i.test((url || '').trim())
+
+const openLink = (url, target = '_blank') => {
+  if (target === '_blank') {
+    const popup = window.open(url, '_blank', 'noopener,noreferrer')
+    popup && (popup.opener = null)
+    return
+  }
+
+  window.location.assign(url)
+}
+
 export const init =
   ({
     api,
@@ -74,6 +86,8 @@ export const init =
     const quill = new FluentEditor(vm.$refs.editor, state.innerOptions)
     quill.emitter.on('file-change', api.fileOperationToSev)
     state.quill = Object.freeze(quill)
+    state.linkClickHandler = api.handleLinkClick
+    on(state.quill.root, 'click', state.linkClickHandler)
 
     setTimeout(api.setToolbarTitle)
 
@@ -925,8 +939,51 @@ export const beforeUnmount =
     api.removeHandleComposition()
     state.quill.off('selection-change', api.selectionChange)
     state.quill.off('text-change', api.textChange)
+    off(state.quill.root, 'click', state.linkClickHandler)
+    state.linkClickHandler = null
     state.quill = null
     delete state.quill
+  }
+
+export const handleLinkClick =
+  ({ props, state }) =>
+  (event) => {
+    const anchor = event?.target?.closest && event.target.closest('a[href]')
+
+    if (!anchor) {
+      return
+    }
+
+    const rawHref = anchor.getAttribute('href') || ''
+    const href = xss.filterUrl(rawHref)
+
+    event.preventDefault()
+
+    if (!href || !isSafeLinkUrl(href)) {
+      return
+    }
+
+    const payload = {
+      url: href,
+      rawUrl: rawHref,
+      target: anchor.getAttribute('target') || '_blank',
+      rel: anchor.getAttribute('rel') || '',
+      event,
+      quill: state.quill
+    }
+    const beforeLinkOpen = props.beforeLinkOpen
+
+    if (typeof beforeLinkOpen !== 'function') {
+      openLink(payload.url, payload.target)
+      return
+    }
+
+    const open = (allow) => allow !== false && openLink(payload.url, payload.target)
+
+    try {
+      const result = beforeLinkOpen(payload)
+      result && typeof result.then === 'function' ? result.then(open).catch(() => {}) : open(result)
+    } catch (_) {}
   }
 
 export const computePreviewOptions =

--- a/packages/renderless/src/fluent-editor/vue.ts
+++ b/packages/renderless/src/fluent-editor/vue.ts
@@ -36,7 +36,8 @@ import {
   handleCompositionend,
   removeHandleComposition,
   checkTableISEndElement,
-  alignHandler
+  alignHandler,
+  handleLinkClick
 } from './index'
 import { defaultOption, iconOption, iconOptionMobileFirst, simpleToolbar } from './options'
 
@@ -51,6 +52,7 @@ const initState = ({ api, reactive, computed, props }) => {
     innerContent: '',
     fileUploadUrl: (props.fileUpload && props.fileUpload.url) || '',
     quill: null,
+    linkClickHandler: null,
     fileInput: null,
     previewOptions: computed(() => api.computePreviewOptions()),
     previewImgUrl: '',
@@ -160,7 +162,8 @@ const mergeApi = (args) => {
     handleComposition: handleComposition({ state, api }),
     handleCompositionstart: handleCompositionstart({ state }),
     handleCompositionend: handleCompositionend({ state }),
-    removeHandleComposition: removeHandleComposition({ state, api })
+    removeHandleComposition: removeHandleComposition({ state, api }),
+    handleLinkClick: handleLinkClick({ props, state })
   })
 }
 

--- a/packages/vue/src/fluent-editor/src/index.ts
+++ b/packages/vue/src/fluent-editor/src/index.ts
@@ -69,6 +69,10 @@ export const fluentEditorProps = {
   beforeEditorInit: {
     type: Function,
     default: () => {}
+  },
+  beforeLinkOpen: {
+    type: Function,
+    default: null
   }
 }
 

--- a/packages/vue/src/fluent-editor/src/mobile-first.vue
+++ b/packages/vue/src/fluent-editor/src/mobile-first.vue
@@ -107,7 +107,8 @@ export default defineComponent({
     'dataUpgrade',
     'zIndex',
     'imagePasteFailCallback',
-    'beforeEditorInit'
+    'beforeEditorInit',
+    'beforeLinkOpen'
   ],
   setup(props, context) {
     return setup({

--- a/packages/vue/src/fluent-editor/src/pc.vue
+++ b/packages/vue/src/fluent-editor/src/pc.vue
@@ -108,7 +108,8 @@ export default defineComponent({
     'dataUpgrade',
     'zIndex',
     'imagePasteFailCallback',
-    'beforeEditorInit'
+    'beforeEditorInit',
+    'beforeLinkOpen'
   ],
   setup(props, context): any {
     return setup({


### PR DESCRIPTION
# PR
feat:富文本超链接支持跳转前拦截

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Link-click handling added to the fluent editor with safe URL validation.
  * New beforeLinkOpen prop/callback to intercept and customize link opening.
  * Prevents immediate navigation for sanitized links and supports opening in new tabs or same window.
  * Supports both synchronous and asynchronous interceptor returns; returning false blocks navigation.
  * Enhanced security: only allowed schemes (http(s), mailto, tel, /, #) are permitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->