### PR TITLE
feat(rich-text): i18n support for rich text and fixing the editor's pop-up border display.

### DIFF
--- a/packages/renderless/src/rich-text/index.ts
+++ b/packages/renderless/src/rich-text/index.ts
@@ -147,6 +147,27 @@ export const initQuill =
     emit('ready', state.quill)
 
     api.setToolbarTips()
+    api.setTooltipI18n()
+    state.tooltipI18nHandler = () =>
+      setTimeout(() => {
+        api.setTooltipI18n()
+        api.adjustTooltipPosition()
+      })
+    state.tooltipResizeHandler = () => api.adjustTooltipPosition()
+    vm.$el.addEventListener('click', state.tooltipI18nHandler)
+    vm.$el.addEventListener('keyup', state.tooltipI18nHandler)
+    window.addEventListener('resize', state.tooltipResizeHandler)
+    if (typeof MutationObserver !== 'undefined') {
+      state.tooltipObserver = new MutationObserver(() => {
+        requestAnimationFrame(() => api.adjustTooltipPosition())
+      })
+      state.tooltipObserver.observe(vm.$el, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['style', 'class', 'data-mode']
+      })
+    }
   }
 
 export const handleClick =
@@ -190,6 +211,80 @@ export const setToolbarTips =
 
       Array.prototype.slice.call(tip).forEach((ite) => {
         ite.innerHTML = getOuterHTML(iconEl)
+      })
+    }
+  }
+
+export const setTooltipI18n =
+  ({ t, vm }) =>
+  () => {
+    const richTextEl = vm.$el
+    const tips = richTextEl.querySelectorAll('.ql-container .ql-tooltip')
+    const getPlaceholderByMode = (mode) => {
+      if (mode === 'video') return t('ui.richText.enterVideo')
+      if (mode === 'formula') return t('ui.richText.enterFormula')
+      return t('ui.richText.enterLink')
+    }
+
+    if (tips.length) {
+      Array.prototype.slice.call(tips).forEach((tip) => {
+        const mode = tip.getAttribute('data-mode') || 'link'
+        const input = tip.querySelector("input[type='text']")
+
+        tip.setAttribute('data-visit-url-text', `${t('ui.richText.visitUrl')}:`)
+        tip.setAttribute('data-edit-text', t('ui.richText.edit'))
+        tip.setAttribute('data-remove-text', t('ui.richText.remove'))
+        tip.setAttribute('data-save-text', t('ui.richText.save'))
+        tip.setAttribute('data-enter-link-text', `${t('ui.richText.enterLink')}:`)
+        tip.setAttribute('data-enter-formula-text', `${t('ui.richText.enterFormula')}:`)
+        tip.setAttribute('data-enter-video-text', `${t('ui.richText.enterVideo')}:`)
+
+        if (input) {
+          input.setAttribute('placeholder', getPlaceholderByMode(mode))
+        }
+      })
+    }
+  }
+
+export const adjustTooltipPosition =
+  ({ vm }) =>
+  () => {
+    const container = vm.$el.querySelector('.ql-container')
+    const tips = vm.$el.querySelectorAll('.ql-container .ql-tooltip')
+    const minGap = 8
+
+    if (!container) {
+      return
+    }
+
+    const containerRect = container.getBoundingClientRect()
+
+    if (tips.length) {
+      Array.prototype.slice.call(tips).forEach((tip) => {
+        if (!tip.classList.contains('ql-editing')) {
+          return
+        }
+
+        const offsetParent = tip.offsetParent || tip.parentElement
+
+        if (!offsetParent) {
+          return
+        }
+
+        const parentRect = offsetParent.getBoundingClientRect()
+        const currentLeft = parseFloat(tip.style.left || '0')
+        const safeCurrentLeft = Number.isFinite(currentLeft) ? currentLeft : 0
+        const minLeft = containerRect.left - parentRect.left + minGap
+        const maxLeft = containerRect.right - parentRect.left - tip.offsetWidth - minGap
+
+        // 当 tooltip 比容器更宽时，至少保持左侧可见
+        if (maxLeft <= minLeft) {
+          tip.style.left = `${minLeft}px`
+          return
+        }
+
+        const clampedLeft = Math.min(Math.max(safeCurrentLeft, minLeft), maxLeft)
+        tip.style.left = `${clampedLeft}px`
       })
     }
   }
@@ -317,16 +412,25 @@ export const mounted =
     }
 
     if (i18n) {
-      watch(() => i18n.locale, api.setToolbarTips)
+      watch(() => i18n.locale, () => {
+        api.setToolbarTips()
+        api.setTooltipI18n()
+        api.adjustTooltipPosition()
+      })
     }
   }
 
 export const beforeUnmount =
-  ({ api, state }) =>
+  ({ api, state, vm }) =>
   () => {
     state.quill.off('selection-change', api.selectionChange)
     state.quill.off('text-change', api.textChange)
     state.quill.root.removeEventListener('click', api.handleClick)
+    state.tooltipI18nHandler && vm.$el.removeEventListener('click', state.tooltipI18nHandler)
+    state.tooltipI18nHandler && vm.$el.removeEventListener('keyup', state.tooltipI18nHandler)
+    state.tooltipResizeHandler && window.removeEventListener('resize', state.tooltipResizeHandler)
+    state.tooltipObserver && state.tooltipObserver.disconnect()
+    state.tooltipObserver = null
     state.quill = null
     delete state.quill
   }

--- a/packages/renderless/src/rich-text/vue.ts
+++ b/packages/renderless/src/rich-text/vue.ts
@@ -2,6 +2,8 @@ import {
   initContent,
   initQuill,
   setToolbarTips,
+  setTooltipI18n,
+  adjustTooltipPosition,
   setPlaceholder,
   getFileUploadUrl,
   selectionChange,
@@ -19,6 +21,8 @@ export const api = [
   'initContent',
   'initQuill',
   'setToolbarTips',
+  'setTooltipI18n',
+  'adjustTooltipPosition',
   'setPlaceholder',
   'selectionChange',
   'textChange',
@@ -33,7 +37,10 @@ const initState = ({ reactive, props, computed, api }) => {
     content: props.modelValue || props.content,
     maxLength: computed(() => api.maxLength()),
     pasteCanceled: false,
-    isDisplayOnly: computed(() => api.isDisplayOnly())
+    isDisplayOnly: computed(() => api.isDisplayOnly()),
+    tooltipI18nHandler: null,
+    tooltipResizeHandler: null,
+    tooltipObserver: null
   })
 
   return state
@@ -48,12 +55,14 @@ const initApi = (args) => {
     initContent: initContent({ state, props, nextTick }),
     initQuill: initQuill({ service, emit, props, api, state, vm, ImageDrop, FileUpload, ImageUpload, Quill }),
     setToolbarTips: setToolbarTips({ t, vm }),
+    setTooltipI18n: setTooltipI18n({ t, vm }),
+    adjustTooltipPosition: adjustTooltipPosition({ vm }),
     setPlaceholder: setPlaceholder({ state, props }),
     getFileUploadUrl: getFileUploadUrl({ service }),
     selectionChange: selectionChange({ emit, state }),
     textChange: textChange({ emit, vm, state, Modal, t }),
     mounted: mounted({ api, props, state, i18n, watch }),
-    beforeUnmount: beforeUnmount({ api, state }),
+    beforeUnmount: beforeUnmount({ api, state, vm }),
     maxLength: maxLength({ props, constants }),
     handlePaste: handlePaste({ state }),
     isDisplayOnly: isDisplayOnly({ state, props, parent, nextTick }),

--- a/packages/theme-saas/src/rich-text/index.less
+++ b/packages/theme-saas/src/rich-text/index.less
@@ -1656,9 +1656,11 @@
     color: #444;
     padding: 5px 12px;
     @apply whitespace-nowrap;
+    max-width: calc(100vw - 16px);
+    @apply box-border;
 
     &::before {
-      content: 'Visit URL:';
+      content: attr(data-visit-url-text);
       line-height: 26px;
       @apply mr-2;
     }
@@ -1682,13 +1684,13 @@
 
     a.ql-action::after {
       border-right: 1px solid #ccc;
-      content: 'Edit';
+      content: attr(data-edit-text);
       @apply ml-4;
       @apply pr-2;
     }
 
     a.ql-remove::before {
-      content: 'Remove';
+      content: attr(data-remove-text);
       @apply ml-2;
     }
 
@@ -1708,21 +1710,21 @@
 
       a.ql-action::after {
         @apply border-r-0;
-        content: 'Save';
+        content: attr(data-save-text);
         @apply pr-0;
       }
     }
 
     &[data-mode='link']::before {
-      content: 'Enter link:';
+      content: attr(data-enter-link-text);
     }
 
     &[data-mode='formula']::before {
-      content: 'Enter formula:';
+      content: attr(data-enter-formula-text);
     }
 
     &[data-mode='video']::before {
-      content: 'Enter video:';
+      content: attr(data-enter-video-text);
     }
   }
 

--- a/packages/theme/src/rich-text/index.less
+++ b/packages/theme/src/rich-text/index.less
@@ -1658,9 +1658,11 @@
     color: #444;
     padding: 5px 12px;
     white-space: nowrap;
+    max-width: calc(100vw - 16px);
+    box-sizing: border-box;
 
     &::before {
-      content: 'Visit URL:';
+      content: attr(data-visit-url-text);
       line-height: 26px;
       margin-right: 8px;
     }
@@ -1685,13 +1687,13 @@
 
     a.ql-action::after {
       border-right: 1px solid #ccc;
-      content: 'Edit';
+      content: attr(data-edit-text);
       margin-left: 16px;
       padding-right: 8px;
     }
 
     a.ql-remove::before {
-      content: 'Remove';
+      content: attr(data-remove-text);
       margin-left: 8px;
     }
 
@@ -1711,21 +1713,21 @@
 
       a.ql-action::after {
         border-right: 0px;
-        content: 'Save';
+        content: attr(data-save-text);
         padding-right: 0px;
       }
     }
 
     &[data-mode='link']::before {
-      content: 'Enter link:';
+      content: attr(data-enter-link-text);
     }
 
     &[data-mode='formula']::before {
-      content: 'Enter formula:';
+      content: attr(data-enter-formula-text);
     }
 
     &[data-mode='video']::before {
-      content: 'Enter video:';
+      content: attr(data-enter-video-text);
     }
   }
 

--- a/packages/vue-locale/src/lang/en.ts
+++ b/packages/vue-locale/src/lang/en.ts
@@ -681,7 +681,14 @@ export default {
       deleteTable: 'Delete Table',
       colorPicker: 'Background Color',
       placeholder: 'Insert text here...',
-      maxLength: 'Text Length exceeds the Limit, max Length config is '
+      maxLength: 'Text Length exceeds the Limit, max Length config is ',
+      visitUrl: 'Visit URL',
+      edit: 'Edit',
+      remove: 'Remove',
+      save: 'Save',
+      enterLink: 'Enter link',
+      enterFormula: 'Enter formula',
+      enterVideo: 'Enter video'
     },
     fluentEditor: {
       undo: 'Undo',

--- a/packages/vue-locale/src/lang/es-LA.ts
+++ b/packages/vue-locale/src/lang/es-LA.ts
@@ -685,7 +685,14 @@ export default {
       deleteTable: 'Eliminar tabla',
       colorPicker: 'Color de fondo',
       placeholder: 'Insertar texto aquí...',
-      maxLength: 'La longitud del texto supera el límite, la configuración de longitud máxima es '
+      maxLength: 'La longitud del texto supera el límite, la configuración de longitud máxima es ',
+      visitUrl: 'Visitar URL',
+      edit: 'Editar',
+      remove: 'Eliminar',
+      save: 'Guardar',
+      enterLink: 'Ingresar enlace',
+      enterFormula: 'Ingresar fórmula',
+      enterVideo: 'Ingresar video'
     },
     fluentEditor: {
       undo: 'Deshacer',

--- a/packages/vue-locale/src/lang/pt-BR.ts
+++ b/packages/vue-locale/src/lang/pt-BR.ts
@@ -685,7 +685,14 @@ export default {
       deleteTable: 'Excluir tabela',
       colorPicker: 'Cor de fundo',
       placeholder: 'Inserir texto aqui...',
-      maxLength: 'O comprimento do texto excede o limite, o comprimento máximo config é '
+      maxLength: 'O comprimento do texto excede o limite, o comprimento máximo config é ',
+      visitUrl: 'Visitar URL',
+      edit: 'Editar',
+      remove: 'Remover',
+      save: 'Salvar',
+      enterLink: 'Digite o endereço do link',
+      enterFormula: 'Digite a fórmula',
+      enterVideo: 'Digite o endereço do vídeo'
     },
     fluentEditor: {
       undo: 'Desfazer',

--- a/packages/vue-locale/src/lang/zh-CN.ts
+++ b/packages/vue-locale/src/lang/zh-CN.ts
@@ -676,7 +676,14 @@ export default {
       deleteTable: '删除表格',
       colorPicker: '背景颜色',
       placeholder: '在此处插入文本...',
-      maxLength: '文本长度超过限制，支持的最大长度是 '
+      maxLength: '文本长度超过限制，支持的最大长度是 ',
+      visitUrl: '访问链接',
+      edit: '编辑',
+      remove: '移除',
+      save: '保存',
+      enterLink: '输入链接地址',
+      enterFormula: '输入公式',
+      enterVideo: '输入视频地址'
     },
     fluentEditor: {
       undo: '撤销',


### PR DESCRIPTION
# PR
feat:富文本支持国际化以及修复编辑器弹窗边界展示

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tooltips in the rich-text editor now update labels/placeholders from locale strings and reapply localization at runtime.
  * Tooltips automatically reposition on clicks, typing, resize, and content changes to stay visible.

* **Style**
  * Tooltip styling constrained to viewport with improved sizing.

* **Localization**
  * Added/enhanced translations for editor actions and prompts (en, zh-CN, es-LA, pt-BR).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->