### PR TITLE
fix(dropdown): The playground of the SaaSDropdown component is displayed abnormally.

### DIFF
--- a/packages/theme-saas/src/dropdown-item/index.less
+++ b/packages/theme-saas/src/dropdown-item/index.less
@@ -1,8 +1,9 @@
 @import '../custom.less';
 
-@dropdown-prefix-cls: ~'@{css-prefix}dropdown-item';
+@dropdown-item-prefix-cls: ~'@{css-prefix}dropdown-item';
+@dropdown-menu-prefix-cls: ~'@{css-prefix}dropdown-menu';
 
-.@{dropdown-prefix-cls} {
+.@{dropdown-item-prefix-cls} {
   @apply list-none;
   @apply leading-7;
   @apply py-0;
@@ -13,6 +14,7 @@
   @apply text-color-text-primary;
   @apply cursor-pointer;
   @apply outline-0;
+  @apply relative;
 
   &:focus,
   &:not(.is-disabled):hover {
@@ -28,13 +30,55 @@
     @apply cursor-not-allowed;
     @apply text-color-text-disabled;
   }
+
+  .@{dropdown-item-prefix-cls}__wrap {
+    @apply flex items-center;
+    @apply h-full;
+    @apply w-full;
+
+    // 展开（右侧子菜单）容器：与默认主题一致，默认展开到父项左侧
+    .@{dropdown-item-prefix-cls}--child {
+      @apply absolute;
+      @apply right-full;
+      @apply top-0;
+      @apply hidden;
+    }
+
+    .@{dropdown-item-prefix-cls}__expand {
+      @apply flex;
+      @apply items-center;
+    }
+
+    .@{dropdown-item-prefix-cls}__content {
+      @apply flex;
+      @apply items-center;
+      @apply w-full;
+
+      .@{dropdown-item-prefix-cls}__label {
+        @apply min-w-0;
+        @apply shrink-0;
+        @apply overflow-hidden;
+        @apply text-ellipsis;
+        @apply whitespace-nowrap;
+        @apply transform-gpu;
+      }
+    }
+  }
+
+  &:not(.is-disabled):hover > .@{dropdown-item-prefix-cls}__wrap > .@{dropdown-item-prefix-cls}--child {
+    @apply block;
+  }
+
+  &:not(.is-disabled).has-children:hover {
+    @apply bg-transparent;
+  }
 }
 
-.@{dropdown-prefix-cls}:not(:last-of-type) {
+.@{dropdown-item-prefix-cls}:not(:last-of-type) {
   @apply !mb-1;
 }
 
-.@{dropdown-prefix-cls}--divided {
+.@{dropdown-item-prefix-cls}--divided {
   @apply relative;
   @apply ~'mt-1.5';
 
@@ -49,7 +93,31 @@
   }
 }
 
-.@{dropdown-prefix-cls}--check-status {
+.@{dropdown-item-prefix-cls}--check-status {
   @apply bg-color-fill-6;
   @apply text-color-brand;
+}
+
+.@{dropdown-menu-prefix-cls}[x-placement='bottom-start'],
+.@{dropdown-menu-prefix-cls}[x-placement='top-start'],
+.@{dropdown-menu-prefix-cls}[data-popper-placement^='bottom-start'],
+.@{dropdown-menu-prefix-cls}[data-popper-placement^='top-start'] {
+  .@{dropdown-item-prefix-cls}__wrap {
+    @apply flex-row-reverse;
+
+    .@{dropdown-item-prefix-cls}__expand {
+      .tiny-svg {
+        transform: scaleX(-1);
+      }
+    }
+
+    .@{dropdown-item-prefix-cls}__content {
+      @apply flex-row;
+    }
+
+    .@{dropdown-item-prefix-cls}--child {
+      right: unset;
+      left: 100%;
+    }
+  }
 }

--- a/packages/theme-saas/src/dropdown-menu/index.less
+++ b/packages/theme-saas/src/dropdown-menu/index.less
@@ -1,12 +1,16 @@
 @import '../custom.less';
 
 @dropdown-menu-prefix-cls: ~'@{css-prefix}dropdown-menu';
+@dropdown-item-prefix-cls: ~'@{css-prefix}dropdown-item';
 
-.@{dropdown-menu-prefix-cls} {
+.@{dropdown-menu-prefix-cls}:not(.@{dropdown-item-prefix-cls}--child) {
   @apply absolute;
   @apply top-0;
   @apply left-0;
   @apply z-10;
+}
+
+.@{dropdown-menu-prefix-cls} {
   @apply py-1 px-0;
   @apply my-1 mx-0;
   @apply bg-color-bg-1;
@@ -52,7 +56,7 @@
     @apply border-b-0;
   }
 
-    &.@{css-prefix}popper[x-placement^='bottom'] {
+  &.@{css-prefix}popper[x-placement^='bottom'] {
     @apply mt-1;
   }
 

--- a/packages/theme-saas/src/dropdown-menu/index.less
+++ b/packages/theme-saas/src/dropdown-menu/index.less
@@ -1,8 +1,8 @@
 @import '../custom.less';
 
-@dropdown-prefix-cls: ~'@{css-prefix}dropdown-menu';
+@dropdown-menu-prefix-cls: ~'@{css-prefix}dropdown-menu';
 
-.@{dropdown-prefix-cls} {
+.@{dropdown-menu-prefix-cls} {
   @apply absolute;
   @apply top-0;
   @apply left-0;
@@ -52,7 +52,7 @@
     @apply border-b-0;
   }
 
-  &.@{css-prefix}popper[x-placement^='bottom'] {
+    &.@{css-prefix}popper[x-placement^='bottom'] {
     @apply mt-1;
   }
 
@@ -115,57 +115,57 @@
   }
 }
 
-.@{dropdown-prefix-cls}--medium {
+.@{dropdown-menu-prefix-cls}--medium {
   @apply ~'py-1.5' px-0;
 
-  .@{dropdown-prefix-cls}__item {
+  .@{dropdown-menu-prefix-cls}__item {
     @apply leading-8;
     @apply py-0 px-3;
     @apply text-sm;
 
-    &.@{dropdown-prefix-cls}__item--divided {
+    &.@{dropdown-menu-prefix-cls}__item--divided {
       @apply ~'mt-1.5';
     }
 
-    &.@{dropdown-prefix-cls}__item--divided:before {
+    &.@{dropdown-menu-prefix-cls}__item--divided:before {
       @apply ~'h-1.5';
       @apply my-0 -mx-3;
     }
   }
 }
 
-.@{dropdown-prefix-cls}--small {
+.@{dropdown-menu-prefix-cls}--small {
   @apply ~'py-1.5' px-0;
 
-  .@{dropdown-prefix-cls}__item {
+  .@{dropdown-menu-prefix-cls}__item {
     @apply leading-6;
     @apply py-0 px-4;
     @apply text-xs;
 
-    &.@{dropdown-prefix-cls}__item--divided {
+    &.@{dropdown-menu-prefix-cls}__item--divided {
       @apply mt-1;
     }
 
-    &.@{dropdown-prefix-cls}__item--divided:before {
+    &.@{dropdown-menu-prefix-cls}__item--divided:before {
       @apply h-1;
       @apply my-0 -mx-4;
     }
   }
 }
 
-.@{dropdown-prefix-cls}--mini {
+.@{dropdown-menu-prefix-cls}--mini {
   @apply py-1 px-0;
 
-  .@{dropdown-prefix-cls}__item {
+  .@{dropdown-menu-prefix-cls}__item {
     @apply leading-6;
     @apply py-0 ~'px-2.5';
     @apply text-xs;
 
-    &.@{dropdown-prefix-cls}__item--divided {
+    &.@{dropdown-menu-prefix-cls}__item--divided {
       @apply mt-1;
     }
 
-    &.@{dropdown-prefix-cls}__item--divided:before {
+    &.@{dropdown-menu-prefix-cls}__item--divided:before {
       @apply h-px;
       @apply my-0 ~'-mx-2.5';
     }


### PR DESCRIPTION
# PR
fix:修复saas模式dropdown组件演练场显示异常,以及多级面板显示重叠

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dropdown items now include nested submenu behavior: child menus reveal on hover, maintain transparent parent backgrounds when applicable, and adjust icon/layout when positioned at start edges.
* **Refactor**
  * Internal styling and class structure for dropdown menus and items reorganized and size modifiers updated. No public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->