### PR TITLE
fix(anchor): events compatible with Vue 2

### DIFF
--- a/packages/renderless/src/anchor/index.ts
+++ b/packages/renderless/src/anchor/index.ts
@@ -223,12 +223,23 @@ export const onItersectionObserver =
   }
 
 export const linkClick =
-  ({ state, vm, emit, props, api }: Pick<IAnchorRenderlessParams, 'state' | 'vm' | 'emit' | 'props' | 'api'>) =>
+  ({
+    state,
+    vm,
+    emit,
+    props,
+    api,
+    framework
+  }: Pick<IAnchorRenderlessParams, 'state' | 'vm' | 'emit' | 'props' | 'api'>) =>
   (e: Event, item: IAnchorLinkItem) => {
     state.isScroll = true
     const { link, title } = item
     const emitLink = { link, title }
     emit('linkClick', e, emitLink)
+
+    if (framework === 'vue2') {
+      emit('link-click', e, emitLink)
+    }
 
     const isChangeHash = setCurrentHash({ state })
     const { scrollContainer } = state

--- a/packages/renderless/src/anchor/index.ts
+++ b/packages/renderless/src/anchor/index.ts
@@ -230,14 +230,14 @@ export const linkClick =
     props,
     api,
     framework
-  }: Pick<IAnchorRenderlessParams, 'state' | 'vm' | 'emit' | 'props' | 'api'>) =>
+  }: Pick<IAnchorRenderlessParams, 'state' | 'vm' | 'emit' | 'props' | 'api' | 'framework'>) =>
   (e: Event, item: IAnchorLinkItem) => {
     state.isScroll = true
     const { link, title } = item
     const emitLink = { link, title }
     emit('linkClick', e, emitLink)
 
-    if (framework === 'vue2') {
+    if (framework === 'vue2' || framework === 'vue2.7') {
       emit('link-click', e, emitLink)
     }
 

--- a/packages/renderless/src/anchor/vue.ts
+++ b/packages/renderless/src/anchor/vue.ts
@@ -42,7 +42,7 @@ export const api = [
 export const renderless = (
   props: IAnchorProps,
   { onMounted, onUnmounted, onUpdated, reactive, watch }: ISharedRenderlessParamHooks,
-  { vm, emit, nextTick }: ISharedRenderlessParamUtils<never>
+  { vm, emit, nextTick, framework }: ISharedRenderlessParamUtils<never>
 ): IAnchorApi => {
   const api = {} as IAnchorApi
   const state: IAnchorState = reactive({
@@ -63,7 +63,7 @@ export const renderless = (
     updated: updated({ api }),
     unmounted: unmounted({ state, api }),
     getContainer: getContainer({ props }),
-    linkClick: linkClick({ state, vm, emit, props, api }),
+    linkClick: linkClick({ state, vm, emit, props, api, framework }),
     onItersectionObserver: onItersectionObserver({ state, props, api, vm, emit }),
     setScrollContainer: setScrollContainer({ state, api }),
     getCurrentAnchor: getCurrentAnchor({ vm, state, emit }),


### PR DESCRIPTION
# PR

兼容vue2的事件:
         vue2的事件名不会自动转换。这样写， 用户使用  @linkClick  @link-click 都能正常接收




## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vue 2 compatibility for anchor clicks: the component now emits an additional Vue‑2-style event variant when running under Vue 2 (including 2.7), alongside the existing click event, ensuring older integrations receive the expected event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->