### PR TITLE
fix(base-select,carousel,date-picker,pager.select,steps,tabs): Isolation is added to the group class in the SaaS mode.

### DIFF
--- a/packages/vue/src/base-select/src/mobile-first.vue
+++ b/packages/vue/src/base-select/src/mobile-first.vue
@@ -2,7 +2,7 @@
   <div
     ref="select"
     data-tag="tiny-base-select"
-    class="inline-block relative w-full outline-0 group [&_[data-tag=tiny-tag]]:max-w-[144px]"
+    class="inline-block relative w-full outline-0 group/base-select [&_[data-tag=tiny-tag]]:max-w-[144px]"
     v-popover:popover
     :class="[
       hoverExpand ? 'align-top is-hover-expand' : '',
@@ -325,7 +325,7 @@
         <template #suffix>
           <slot name="suffix"></slot>
           <span v-if="state.showCopy" class="h-4 cursor-pointer relative z-[1]" @click.stop="handleCopyClick">
-            <icon-copy :class="[gcls('caret'), 'align-top group-hover:fill-color-brand']"></icon-copy>
+            <icon-copy :class="[gcls('caret'), 'align-top group-hover/base-select:fill-color-brand']"></icon-copy>
           </span>
           <span v-if="showProportion && state.selected.length > 0 && state.options.length > 1">
             {{ state.selected.length + '/' + state.options.length }}

--- a/packages/vue/src/carousel-item/src/mobile-first.vue
+++ b/packages/vue/src/carousel-item/src/mobile-first.vue
@@ -9,7 +9,7 @@
         state.carouselParent.type === 'card' ? 'w-1/2 transition-transform duration-300 ease-in-out' : '',
         state.hover ? 'opacity-10' : '',
         state.animate && !state.moving ? 'transition-transform duration-300 ease-in-out' : '',
-        state.inStage && state.carouselParent.type === 'card' ? 'cursor-pointer z-[1] group' : '',
+        state.inStage && state.carouselParent.type === 'card' ? 'cursor-pointer z-[1] group/carousel-item' : '',
         state.active ? 'z-[2]' : ''
       ])
     "
@@ -20,7 +20,7 @@
       data-tag="tiny-carousel-item-card"
       v-if="state.carouselParent.type === 'card'"
       v-show="!state.active"
-      class="absolute h-full top-0 left-0 w-full opacity-20 duration-200 group-hover:opacity-10"
+      class="absolute h-full top-0 left-0 w-full opacity-20 duration-200 group-hover/carousel-item:opacity-10"
       :class="{ 'opacity-10': state.inStage && state.carouselParent.type === 'card' && state.hover }"
     ></div>
     <slot></slot>

--- a/packages/vue/src/carousel/src/mobile-first.vue
+++ b/packages/vue/src/carousel/src/mobile-first.vue
@@ -18,14 +18,14 @@
         v-if="state.hasButtons"
         v-show="(arrow === 'always' || state.hover) && (loop || state.activeIndex > 0)"
         type="button"
-        class="absolute group border-none outline-0 p-0 m-0 h-8 w-8 cursor-pointer z-[3] rounded-full bg-color-bg-3 active:bg-color-bg-7 text-color-text-inverse text-center text-xs flex items-center justify-center hover:bg-color-bg-7"
+        class="absolute group/carousel border-none outline-0 p-0 m-0 h-8 w-8 cursor-pointer z-[3] rounded-full bg-color-bg-3 active:bg-color-bg-7 text-color-text-inverse text-center text-xs flex items-center justify-center hover:bg-color-bg-7"
         :class="[type === 'vertical' ? 'top-4 left-1/2' : 'left-4 top-1/2 -translate-y-4']"
         @mouseenter="handleButtonEnter('left')"
         @mouseleave="handleButtonLeave"
         @click.stop="throttledArrowClick(state.activeIndex - 1)"
       >
         <component
-          class="w-4.5 h-4.5 opacity-50 fill-color-icon-primary group-active:fill-color-bg-2 group-hover:fill-color-bg-1"
+          class="w-4.5 h-4.5 opacity-50 fill-color-icon-primary group-active/carousel:fill-color-bg-2 group-hover/carousel:fill-color-bg-1"
           :is="type === 'vertical' ? 'icon-chevron-up' : 'icon-chevron-left'"
         />
       </button>
@@ -33,14 +33,14 @@
         v-if="state.hasButtons"
         v-show="(arrow === 'always' || state.hover) && (loop || state.activeIndex < state.items.length - 1)"
         type="button"
-        class="absolute group border-none outline-0 p-0 m-0 h-8 w-8 cursor-pointer z-[3] rounded-full bg-color-bg-3 active:bg-color-bg-7 text-color-text-inverse text-center text-xs flex items-center justify-center hover:bg-color-bg-7"
+        class="absolute group/carousel border-none outline-0 p-0 m-0 h-8 w-8 cursor-pointer z-[3] rounded-full bg-color-bg-3 active:bg-color-bg-7 text-color-text-inverse text-center text-xs flex items-center justify-center hover:bg-color-bg-7"
         :class="[type === 'vertical' ? 'top-auto left-1/2 bottom-4' : 'right-4 top-1/2 -translate-y-4']"
         @mouseenter="handleButtonEnter('right')"
         @mouseleave="handleButtonLeave"
         @click.stop="throttledArrowClick(state.activeIndex + 1)"
       >
         <component
-          class="w-4.5 h-4.5 opacity-50 fill-color-icon-primary group-active:fill-color-bg-2 group-hover:fill-color-bg-1"
+          class="w-4.5 h-4.5 opacity-50 fill-color-icon-primary group-active/carousel:fill-color-bg-2 group-hover/carousel:fill-color-bg-1"
           :is="type === 'vertical' ? 'icon-chevron-down' : 'icon-chevron-right'"
         />
       </button>

--- a/packages/vue/src/date-table/src/token.ts
+++ b/packages/vue/src/date-table/src/token.ts
@@ -1,7 +1,7 @@
 const common = {
-  'next-month': 'text-color-text-disabled cursor-pointer group-hover:bg-inherit',
-  'current': 'group-hover:text-color-text-inverse group-hover:bg-color-brand text-color-text-inverse bg-color-brand',
-  'start-date': 'text-color-text-inverse bg-color-brand group-hover:bg-color-brand'
+  'next-month': 'text-color-text-disabled cursor-pointer group-hover/date-table:bg-inherit',
+  'current': 'group-hover/date-table:text-color-text-inverse group-hover/date-table:bg-color-brand text-color-text-inverse bg-color-brand',
+  'start-date': 'text-color-text-inverse bg-color-brand group-hover/date-table:bg-color-brand'
 }
 
 export const classes = {
@@ -10,14 +10,14 @@ export const classes = {
   'pre-month': common['next-month'],
   'selected': common['current'],
   'th': 'px-1 py-4 text-color-text-primary font-normal whitespace-nowrap',
-  'td': 'box-border text-center cursor-pointer relative group',
+  'td': 'box-border text-center cursor-pointer relative group/date-table',
   'cell': 'h-8 mb-2.5 box-border',
   'in-range': '',
   'cell-in-range': 'bg-color-brand-hover-subtle text-color-brand',
-  'disabled': 'text-color-text-disabled group-hover:text-color-text-disabled cursor-pointer cursor-not-allowed bg-color-bg-3 group-hover:bg-color-bg-3',
+  'disabled': 'text-color-text-disabled group-hover/date-table:text-color-text-disabled cursor-pointer cursor-not-allowed bg-color-bg-3 group-hover/date-table:bg-color-bg-3',
   'cell-disabled': 'bg-color-bg-3 text-color-text-disabled',
   'text':
-    'w-8 h-8 leading-8 block absolute left-1/2 box-border -translate-x-2/4 rounded group-hover:bg-color-brand-hover-subtle',
+    'w-8 h-8 leading-8 block absolute left-1/2 box-border -translate-x-2/4 rounded group-hover/date-table:bg-color-brand-hover-subtle',
   'end-date': common['start-date'],
   'token': ''
 }

--- a/packages/vue/src/option/src/mobile-first.vue
+++ b/packages/vue/src/option/src/mobile-first.vue
@@ -9,7 +9,7 @@
     :class="
       m(
         'h-fit flex items-center justify-between rounded text-color-text-primary text-sm sm:text-xs',
-        'min-h-[40px] sm:min-h-[32px] cursor-pointer group sm:hover:bg-color-bg-4 sm:active:bg-color-bg-3 pl-0 pr-3 sm:px-2 my-1 sm:m-1',
+        'min-h-[40px] sm:min-h-[32px] cursor-pointer group/option sm:hover:bg-color-bg-4 sm:active:bg-color-bg-3 pl-0 pr-3 sm:px-2 my-1 sm:m-1',
         {
           'text-color-brand bg-color-bg-1 sm:bg-color-fill-6': state.itemSelected && !disabled,
           'text-color-text-disabled cursor-not-allowed [&_svg]:fill-color-icon-disabled [&_svg_path:first-of-type]:fill-color-bg-3':
@@ -30,7 +30,7 @@
         :is="`icon-${state.selectCls}`"
         :class="
           m('fill-color-icon-secondary relative w-3.5 h-3.5', {
-            'group-hover:fill-color-brand-hover': state.hover,
+            'group-hover/option:fill-color-brand-hover': state.hover,
             'fill-color-brand text-color-brand': state.itemSelected,
             'fill-color-brand-disabled': state.itemSelected && required
           })

--- a/packages/vue/src/pager/src/mobile-first.vue
+++ b/packages/vue/src/pager/src/mobile-first.vue
@@ -31,7 +31,7 @@
         v-else-if="item.trim() === 'sizes'"
         :key="'sizes' + index"
         data-tag="tiny-pager-popover"
-        class="hidden sm:inline-block align-middle text-xs h-7 text-xs text-color-text-primary relative -top-px"
+        class="hidden sm:inline-block align-middle text-xs h-7 text-color-text-primary relative -top-px"
       >
         <popover
           ref="sizesList"
@@ -99,19 +99,19 @@
         v-else-if="item.trim() === 'prev'"
         :key="'prev' + index"
         type="button"
-        class="group min-w-[theme(spacing.7)] h-7 text-xs py-0 px-1 text-color-text-primary bg-color-bg-1 rounded-sm outline-0 ml-0 sm:ml-2 align-bottom cursor-pointer hover:border-color-icon-primary disabled:cursor-default"
+        class="group/pager min-w-[theme(spacing.7)] h-7 text-xs py-0 px-1 text-color-text-primary bg-color-bg-1 rounded-sm outline-0 ml-0 sm:ml-2 align-bottom cursor-pointer hover:border-color-icon-primary disabled:cursor-default"
         :disabled="disabled || internalCurrentPage <= 1"
         @click="prev"
       >
         <span
           v-if="prevText"
-          class="group-disabled:text-color-text-disabled group-disabled:cursor-not-allowed group-hover:text-color-icon-hover"
+          class="group-disabled/pager:text-color-text-disabled group-disabled/pager:cursor-not-allowed group-hover/pager:text-color-icon-hover"
         >
           {{ prevText }}
         </span>
         <tiny-icon-chevron-left
           v-else
-          class="align-sub group-disabled:fill-color-icon-disabled group-disabled:cursor-not-allowed group-hover:fill-color-icon-active"
+          class="align-sub group-disabled/pager:fill-color-icon-disabled group-disabled/pager:cursor-not-allowed group-hover/pager:fill-color-icon-active"
         />
       </button>
 
@@ -133,19 +133,19 @@
         v-else-if="item.trim() === 'next'"
         :key="'next' + index"
         type="button"
-        class="group min-w-[theme(spacing.7)] h-7 text-xs py-0 px-1 text-color-text-primary bg-color-bg-1 rounded-sm outline-0 ml-0 sm:ml-2 align-bottom cursor-pointer hover:border-color-icon-primary disabled:cursor-default"
+        class="group/pager min-w-[theme(spacing.7)] h-7 text-xs py-0 px-1 text-color-text-primary bg-color-bg-1 rounded-sm outline-0 ml-0 sm:ml-2 align-bottom cursor-pointer hover:border-color-icon-primary disabled:cursor-default"
         :disabled="disabled || internalCurrentPage === internalPageCount || internalPageCount === 0"
         @click="next"
       >
         <span
           v-if="nextText"
-          class="group-disabled:text-color-text-disabled group-disabled:cursor-not-allowed group-hover:text-color-icon-hover"
+          class="group-disabled/pager:text-color-text-disabled group-disabled/pager:cursor-not-allowed group-hover/pager:text-color-icon-hover"
         >
           {{ nextText }}
         </span>
         <tiny-icon-chevron-right
           v-else
-          class="align-sub group-disabled:fill-color-icon-disabled group-disabled:cursor-not-allowed group-hover:fill-color-icon-active"
+          class="align-sub group-disabled/pager:fill-color-icon-disabled group-disabled/pager:cursor-not-allowed group-hover/pager:fill-color-icon-active"
         />
       </button>
 

--- a/packages/vue/src/select/src/mobile-first.vue
+++ b/packages/vue/src/select/src/mobile-first.vue
@@ -2,7 +2,7 @@
   <div
     ref="select"
     data-tag="tiny-select"
-    class="inline-block relative w-full outline-0 group [&_[data-tag=tiny-tag]]:max-w-[144px]"
+    class="inline-block relative w-full outline-0 group/select [&_[data-tag=tiny-tag]]:max-w-[144px]"
     v-popover:popover
     :class="[hoverExpand ? 'align-top' : '', $parent.$attrs.class]"
     @mouseleave.self="
@@ -296,7 +296,7 @@
         <template #suffix>
           <slot name="suffix"></slot>
           <span v-if="state.showCopy" class="h-4 cursor-pointer relative z-[1]" @click.stop="handleCopyClick">
-            <icon-copy :class="[gcls('caret'), 'align-top group-hover:fill-color-brand']"></icon-copy>
+            <icon-copy :class="[gcls('caret'), 'align-top group-hover/select:fill-color-brand']"></icon-copy>
           </span>
           <span v-if="showProportion && state.selected.length > 0 && state.options.length > 1">
             {{ state.selected.length + '/' + state.options.length }}

--- a/packages/vue/src/steps/src/mobile-first/mobile-first-advanced.vue
+++ b/packages/vue/src/steps/src/mobile-first/mobile-first-advanced.vue
@@ -56,7 +56,7 @@
                     size === 'large' ? 'w-6 h-6 mr-3' : 'w-4 h-4 mr-2',
                     node[statusField] === 'done' ? 'bg-color-brand' : 'bg-color-border',
                     {
-                      ' bg-color-brand group-hover:text-color-brand group-hover:bg-color-bg-1 ':
+                      ' bg-color-brand group-hover/steps:text-color-brand group-hover/steps:bg-color-bg-1 ':
                         node[statusField] === 'doing'
                     },
                     {
@@ -112,7 +112,7 @@
                       {
                         'text-color-text-secondary': index !== active && ['done', 'doing'].includes(node[statusField])
                       },
-                      { 'group-hover:text-white': index !== active && ['doing'].includes(node[statusField]) }
+                      { 'group-hover/steps:text-white': index !== active && ['doing'].includes(node[statusField]) }
                     )
                   "
                   @mouseenter="handleMouseenter($event, 'bottom')"

--- a/packages/vue/src/steps/src/mobile-first/token/advanced-token.ts
+++ b/packages/vue/src/steps/src/mobile-first/token/advanced-token.ts
@@ -1,7 +1,7 @@
 export const classes = {
   'steps-advanced': 'w-full flex text-color-text text-xs leading-4',
   'steps-block':
-    'flex rounded-sm relative cursor-pointer group text-color-text-primary bg-color-bg-2 hover:bg-color-border-separator',
+    'flex rounded-sm relative cursor-pointer group/steps text-color-text-primary bg-color-bg-2 hover:bg-color-border-separator',
   'steps-block-error': 'text-color-error bg-color-error-subtler hover:bg-error-disabled',
   'steps-block-disabled': 'text-color-text-disabled hover:bg-color-bg-2',
   'steps-block-done': 'bg-color-info-primary-subtler hover:bg-color-info-secondary-disabled',
@@ -10,10 +10,10 @@ export const classes = {
   'steps-block-disabled-active': 'bg-color-bg-2 hover:bg-color-bg-2',
   'steps-block-done-active': 'bg-color-brand hover:bg-color-brand',
   'steps-block-doing-active': 'bg-color-brand hover:bg-color-brand',
-  'steps-text': 'group flex-auto max-w-full truncate text-color-text-secondary',
+  'steps-text': 'group/steps flex-auto max-w-full truncate text-color-text-secondary',
   'steps-text-error': 'text-color-text-primary',
   'steps-text-disabled': 'text-color-border',
   'steps-text-done': 'text-color-text-primary',
-  'steps-text-doing': 'group-hover:text-color-text-inverse text-color-text-primary',
+  'steps-text-doing': 'group-hover/steps:text-color-text-inverse text-color-text-primary',
   'steps-content': 'flex-auto flex max-w-full items-center justify-center px-4 overflow-hidden h-full'
 }

--- a/packages/vue/src/tabs/src/mobile-first/tab-nav-item.vue
+++ b/packages/vue/src/tabs/src/mobile-first/tab-nav-item.vue
@@ -32,7 +32,7 @@ export default defineComponent({
           tabindex: selected ? 0 : -1 // 无障碍：焦点管理，只有选中的 tab 可获得焦点
         },
         class: [
-          'w-max h-11 sm:h-10 inline-flex flex-col justify-center group',
+          'w-max h-11 sm:h-10 inline-flex flex-col justify-center group/tabs',
           'first:ml-3 last:mr-3 hover:cursor-pointer sm:first:pl-0 sm:last:pr-0 sm:first:ml-0 sm:last:mr-0',
           state.separator ? 'mx-3.5 [&:last-of-type>div>span:last-of-type]:hidden [&:not(:last-of-type)]:mr-px' : 'mx-3'
         ],
@@ -52,7 +52,7 @@ export default defineComponent({
           'span',
           {
             class: [
-              'text-base sm:text-sm leading-6 sm:leading-5.5 group-hover:text-color-brand',
+              'text-base sm:text-sm leading-6 sm:leading-5.5 group-hover/tabs:text-color-brand',
               state.tabSize === 'large' ? 'min-w-[theme(spacing.8)]' : 'min-w-[theme(spacing.7)]',
               selected ? 'text-color-brand font-bold' : 'text-color-text-primary'
             ],

--- a/packages/vue/src/upload-list/src/mobile-first.vue
+++ b/packages/vue/src/upload-list/src/mobile-first.vue
@@ -74,7 +74,7 @@
                 </div>
                 <div
                   data-tag="tiny-upload-list-operate"
-                  class="hidden sm:block sm:invisible sm:group-hover:visible min-w-fit text-color-brand-hover text-xs"
+                  class="hidden sm:block sm:invisible sm:group-hover/upload-list:visible min-w-fit text-color-brand-hover text-xs"
                 >
                   <slot name="operate" :file="file">
                     <span
@@ -261,7 +261,7 @@
     >
       <div
         :class="[
-          'group relative',
+          'group/upload-list relative',
           { 'hidden': listType === 'picture-single' && index },
           listType === 'picture-single'
             ? `w-24 h-24 sm:w-[calc(${scale}*theme(spacing.20))] sm:h-20`
@@ -290,7 +290,7 @@
               :style="{ background: imageBgColor }"
               class="relative w-full h-full after:absolute after:w-full after:h-full after:left-0 after:top-0 after:rounded after:bg-color-bg-7"
               :class="[
-                !~['uploading', 'fail'].indexOf(file.status) ? 'after:hidden sm:after:group-hover:block' : '',
+                !~['uploading', 'fail'].indexOf(file.status) ? 'after:hidden sm:after:group-hover/upload-list:block' : '',
                 { 'mb-7': listType === 'picture-card' && showName },
                 ~['video', 'audio'].indexOf(file.type) ? 'after:opacity-0' : 'after:opacity-50'
               ]"
@@ -352,11 +352,11 @@
                   </div>
                 </div>
                 <div v-else-if="~['fail'].indexOf(file.status)">
-                  <span class="block sm:group-hover:hidden">
+                  <span class="block sm:group-hover/upload-list:hidden">
                     <icon-cue-l class="w-6 h-6 fill-color-icon-inverse" />
                     <div class="mt-1 text-color-text-inverse text-xs">{{ t('ui.uploadList.uploadFailed') }}</div>
                   </span>
-                  <span class="hidden sm:group-hover:block">
+                  <span class="hidden sm:group-hover/upload-list:block">
                     <icon-refres
                       v-if="isEdm ? true : handleReUpload"
                       class="w-6 h-6 mr-2 fill-color-icon-inverse"
@@ -373,7 +373,7 @@
                   </span>
                 </div>
                 <div v-else>
-                  <div :class="['hidden', { 'sm:group-hover:block': !~['video', 'audio'].indexOf(file.type) }]">
+                  <div :class="['hidden', { 'sm:group-hover/upload-list:block': !~['video', 'audio'].indexOf(file.type) }]">
                     <slot name="operate" :file="file">
                       <icon-eyeopen
                         v-if="handlePreview"
@@ -397,7 +397,7 @@
                   </div>
                   <div
                     v-if="file.type === 'video'"
-                    class="inline-block w-8 h-8 text-center rounded-full group-hover:bg-color-bg-7"
+                    class="inline-block w-8 h-8 text-center rounded-full group-hover/upload-list:bg-color-bg-7"
                     :class="!file.isPlay ? 'bg-color-bg-7' : 'bg-opacity-0'"
                   >
                     <icon-right
@@ -407,7 +407,7 @@
                     />
                     <icon-pause
                       v-show="file.isPlay"
-                      class="w-6 h-6 hidden group-hover:inline-block mt-1 fill-color-icon-inverse"
+                      class="w-6 h-6 hidden group-hover/upload-list:inline-block mt-1 fill-color-icon-inverse"
                       @click="pause({ file, index, type: 'video' })"
                     />
                   </div>


### PR DESCRIPTION
# PR
fix:saas模式group类添加隔离

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Scoped hover/active styling across multiple Vue components (selects, carousels, date table, options, pager, steps, tabs, upload list, etc.) to avoid style bleed.
  * Result: hover, active and disabled states now behave more consistently and predictably, reducing accidental visual side effects during interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->