### PR TITLE
feat: fix the issue where the color of the other half does not change when half of the rate component is selected

### DIFF
--- a/packages/renderless/src/rate/index.ts
+++ b/packages/renderless/src/rate/index.ts
@@ -177,9 +177,8 @@ export const showDecimalIcon =
   }
 
 export const getIconStyle =
-  ({ api, props, state }) =>
+  ({ props, state }) =>
   (item) => {
-    const isHalf = api.showDecimalIcon(item)
     const voidColor = props.disabled ? props.disabledVoidColor : props.voidColor
 
     if (props.radio) {
@@ -188,9 +187,8 @@ export const getIconStyle =
         'font-size': props.size || '18px'
       }
     }
-
     return {
-      fill: isHalf ? 'transparent' : item <= state.currentValue ? state.activeColor : voidColor,
+      fill: item <= state.currentValue ? state.activeColor : voidColor,
       'font-size': props.size || '18px'
     }
   }

--- a/packages/renderless/src/rate/vue.ts
+++ b/packages/renderless/src/rate/vue.ts
@@ -144,7 +144,7 @@ export const renderless = (
     computedActiveColor: computedActiveColor(props),
     computedActiveClass: computedActiveClass(props),
     showDecimalIcon: showDecimalIcon({ props, state }),
-    getIconStyle: getIconStyle({ api, props, state }),
+    getIconStyle: getIconStyle({ props, state }),
     ...changeValue.api
   })
 

--- a/packages/theme/src/rate/index.less
+++ b/packages/theme/src/rate/index.less
@@ -50,7 +50,8 @@
     position: absolute;
     top: 0;
     left: 50%;
-    transform: translateX(-50%);
+    transform-origin: center center;
+    transform: translateX(-50%) scale(1.2);
   }
 
   & &__text {


### PR DESCRIPTION
… when half of the rate component is selected

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized rate component icon styling logic.

* **Style**
  * Enhanced decimal icon appearance with improved scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->