### PR TITLE
fix(nav-menu): modify the misalignment issue of dropdown content

### DIFF
--- a/packages/theme/src/nav-menu/index.less
+++ b/packages/theme/src/nav-menu/index.less
@@ -297,7 +297,7 @@
             > span,
             > a {
               display: inline-block;
-              width: 100px;
+              width: 100%;
               overflow: hidden;
               text-overflow: ellipsis;
               white-space: nowrap;

--- a/packages/theme/src/nav-menu/index.less
+++ b/packages/theme/src/nav-menu/index.less
@@ -296,8 +296,12 @@
 
             > span,
             > a {
+              display: block;
+              width: 100px;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
               color: var(--tv-NavMenu-popmenu-text-color-normal);
-              white-space: normal;
               word-break: break-all;
               text-decoration: none;
               font-size: var(--tv-NavMenu-popmenu-text-font-size);

--- a/packages/theme/src/nav-menu/index.less
+++ b/packages/theme/src/nav-menu/index.less
@@ -296,7 +296,7 @@
 
             > span,
             > a {
-              display: block;
+              display: inline-block;
               width: 100px;
               overflow: hidden;
               text-overflow: ellipsis;


### PR DESCRIPTION
# PR
问题：菜单内容溢出错位
![gif12](https://github.com/user-attachments/assets/f16fcc59-beda-461b-9206-d799f831dd9b)
修改后：
![gif123](https://github.com/user-attachments/assets/135d4404-7489-4604-8e63-9864369d5124)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Style**
  * Updated the navigation menu sub-menu styling so items render on a single line and truncate with an ellipsis when they exceed available width, improving readability and visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->