### PR TITLE
fix(dropdown): the style after clicking the unified button

### DIFF
--- a/packages/vue/src/dropdown/src/pc.vue
+++ b/packages/vue/src/dropdown/src/pc.vue
@@ -142,7 +142,8 @@ export default defineComponent({
             size={size}
             onClick={handleMainButtonClick}
             disabled={disabled}
-            class="tiny-dropdown__title-button">
+            class="tiny-dropdown__title-button"
+            reset-time={0}>
             {defaultSlot || <span>{title}</span>}
           </tiny-button>
           <tiny-button


### PR DESCRIPTION
# PR
修改前：
![v1](https://github.com/user-attachments/assets/599ef35a-7f61-4d4d-94c2-da536155e204)

修改后：
![v2](https://github.com/user-attachments/assets/2a11f168-5fbe-4f9e-8e73-cb83db93873e)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:
统一点击后按钮的显示状态
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown split-button timing behavior to ensure proper state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->