### PR TITLE
fix(common): solve the problem of reactive property loss in the provide scenario caused by the Longque API in the HarmonyOS environment

### DIFF
--- a/packages/vue-common/src/adapter/vue2/index.ts
+++ b/packages/vue-common/src/adapter/vue2/index.ts
@@ -198,6 +198,19 @@ const originalDefineProperties = (vm, instance, filter) => {
 const harmonyDefineProperties = (vm, instance) => {
   const propertyFilterFlags = __TINY__.SKIP_PREFIX_UNDERSCORE | __TINY__.SKIP_PREFIX_DOLLAR | __TINY__.SKIP_CONSTRUCTOR
   __TINY__.createDelegate(instance, vm, propertyFilterFlags)
+
+  // 对于provider 场景，会存在属性响应式的问题，这里对常见属性做兼容处理，后续龙雀API修复后可以删除
+  const targetKeys = ['size', 'disabled', 'displayOnly']
+  for (const name in instance) {
+    if (targetKeys.includes(name)) {
+      Object.defineProperty(vm, name, {
+        configurable: true,
+        enumerable: true,
+        get: () => instance[name],
+        set: (value) => (instance[name] = value)
+      })
+    }
+  }
 }
 
 const defineProperties = __TINY__ ? harmonyDefineProperties : originalDefineProperties

--- a/packages/vue/src/file-upload/src/pc.vue
+++ b/packages/vue/src/file-upload/src/pc.vue
@@ -270,7 +270,7 @@ export default defineComponent({
           <TinyIconSuccessful class="thumb-success-icon" />,
           <span
             class={['thumb-item-name', !showDel ? 'hide-close-icon' : '', !showDownload ? 'hide-download-icon' : '']}
-            onclick={() => {
+            onClick={() => {
               handleFileClick(file)
             }}>
             {file.name}

--- a/packages/vue/src/file-upload/src/pc.vue
+++ b/packages/vue/src/file-upload/src/pc.vue
@@ -269,7 +269,10 @@ export default defineComponent({
         return [
           <TinyIconSuccessful class="thumb-success-icon" />,
           <span
-            class={['thumb-item-name', !showDel ? 'hide-close-icon' : '', !showDownload ? 'hide-download-icon' : '']}>
+            class={['thumb-item-name', !showDel ? 'hide-close-icon' : '', !showDownload ? 'hide-download-icon' : '']}
+            onclick={() => {
+              handleFileClick(file)
+            }}>
             {file.name}
           </span>,
           getThumIcon(file)
@@ -314,12 +317,7 @@ export default defineComponent({
                                   h(
                                     'div',
                                     {
-                                      class: 'thumb-item',
-                                      on: {
-                                        click: () => {
-                                          handleFileClick(item)
-                                        }
-                                      }
+                                      class: 'thumb-item'
                                     },
                                     [getThumbList(item)]
                                   )


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File upload thumbnails: click handling moved to the filename element for more precise selection and to prevent accidental clicks on surrounding thumbnail areas.

* **Chores**
  * Improved Vue 2 adapter compatibility for internal property handling to enhance stability across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->