### PR TITLE
fix(sites): conditionally apply icon source plugins based on config mode

### DIFF
--- a/examples/sites/vite.config.ts
+++ b/examples/sites/vite.config.ts
@@ -35,7 +35,7 @@ export default defineConfig((config) => {
     envDir: './env',
     base: env.VITE_APP_BUILD_BASE_URL || '/tiny-vue/',
     plugins: [
-      ...fixIconSrcPlugins(),
+      ...(config.mode.includes('inner') ? [] : fixIconSrcPlugins()),
       virtualTemplatePlugin({ include: ['**/packages/vue/**/src/index.ts'], env }),
       vue({
         include: [/\.vue$/, /\.md$/]


### PR DESCRIPTION
# PR
修复当使用包构建时，提示vue-icon路径不存在的问题
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to conditionally manage plugin behavior based on build environment, ensuring proper handling across different modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->