### PR TITLE
fix(file-upload): solve the problem of multiple commas appearing in the prompt for uploading files

### DIFF
--- a/packages/renderless/src/file-upload/index.ts
+++ b/packages/renderless/src/file-upload/index.ts
@@ -2807,8 +2807,7 @@ export const getTipMessage =
     }
 
     let limitTip = limit ? t(constants.NUMBER_LIMIT, { number: limit }) : ''
-
-    if ((fileSize || acceptTip.length !== 0) && limit) {
+    if ((fileSize || acceptTip.length !== 0) && limit && fileSize?.length === 2 && Array.isArray(fileSize)) {
       limitTip = `${t(constants.COMMA)} ` + limitTip
     }
     return acceptTip + fileSizeTip + limitTip


### PR DESCRIPTION
解决在上传文件组件中配置file-size为空数组的时候会出现多个逗号的问题

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file upload tip message formatting to display comma separators more accurately. The tip message now only adds a comma prefix to the limit text when appropriate, preventing unnecessary punctuation in certain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->