### PR TITLE
fix(form-item): solve the overlap between strong prompts and verification prompt content

### DIFF
--- a/examples/sites/demos/mobile-first/app/form/prompt-slot.vue
+++ b/examples/sites/demos/mobile-first/app/form/prompt-slot.vue
@@ -3,7 +3,7 @@
     <tiny-form ref="ruleForm" :model="createData" :rules="rules" label-width="96px" show-message>
       <tiny-form-item label="必填项" prop="users" required>
         <template #prompt>
-          <div class="relative sm:absolute text-xs leading-normal text-color-alert" title="强提示插槽">强提示插槽</div>
+          <div class="text-xs leading-normal text-color-alert" title="强提示插槽">强提示插槽</div>
         </template>
         <tiny-input v-model="createData.users"></tiny-input>
       </tiny-form-item>

--- a/packages/vue/src/form-item/src/mobile-first.vue
+++ b/packages/vue/src/form-item/src/mobile-first.vue
@@ -141,7 +141,7 @@
           {{ state.validateMessage }}
         </div>
       </slot>
-      <slot v-if="state.validateState !== 'error' && showMessage && state.showMessage" name="prompt"> </slot>
+      <slot v-if="showMessage && state.showMessage" name="prompt"> </slot>
     </div>
   </div>
 </template>


### PR DESCRIPTION
解决在form-item多端模板中配置自定义强提示插槽prompt后，强提示与表单校验提示内容重叠的问题

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated form validation prompt display behavior to show prompts independently of validation state.
  * Adjusted prompt message styling and positioning for improved visibility and layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->