### PR TITLE
fix(tabs-mf):  beforeLeave trigger twice

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
-
-npx --no-install commitlint --edit
+# 兼容node25
+pnpm exec commitlint --edit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged
+# 兼容node25
+pnpm exec lint-staged

--- a/packages/renderless/src/tabs-mf/index.ts
+++ b/packages/renderless/src/tabs-mf/index.ts
@@ -6,7 +6,7 @@ import { fastdom } from '@opentiny/utils'
 export const setActive =
   ({ state, api }) =>
   (name) => {
-    const current = state.currentItem ? state.currentItem.name : ''
+    const current = state.cacheCurrentItem ? state.cacheCurrentItem.name : ''
 
     if (current && current !== name) {
       api.canLeave(name, current).then((result) => {


### PR DESCRIPTION
# PR

## PR Checklist

1、tabs-mf 的state.cacheCurrentItem  与 currentItem 两个变量混用。  增加cacheCurrentItem 似乎没什么道理。  发81

2、升级node25之后， husky 中的命令需要调整才能运行。



Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab state management for more reliable active tab selection.

* **Chores**
  * Updated development tool execution configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->