### PR TITLE
fix(file-upload): Uploading the component name "group" causes it to become invalid.

### DIFF
--- a/packages/vue/src/upload-list/src/mobile-first.vue
+++ b/packages/vue/src/upload-list/src/mobile-first.vue
@@ -14,7 +14,7 @@
         <div
           data-tag="tiny-upload-list-item"
           ref="uploadListLi"
-          class="group relative sm:inline-block min-w-full py-1.5 px-3 mr-2 border-0.5 sm:border border-color-border-separator rounded hover:bg-color-bg-2"
+          class="group/upload-list relative sm:inline-block min-w-full py-1.5 px-3 mr-2 border-0.5 sm:border border-color-border-separator rounded hover:bg-color-bg-2"
           :class="{
             'sm:border-color-brand border-color-border-separator': file.uid === (selected && selected.uid),
             'mb-2': index !== state.files.length - 1,


### PR DESCRIPTION
# PR
fix:上传组件名group失效         发 81

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hover interactions on the upload list component to ensure UI controls respond correctly to user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->