### PR TITLE
fix(form-item): fix the issue of the width of the tiny-cascader, which is affected by the multi-end form-item

### DIFF
--- a/packages/vue/src/form-item/src/mobile-first.vue
+++ b/packages/vue/src/form-item/src/mobile-first.vue
@@ -110,7 +110,6 @@
           '[&_[aria-label=checkbox-group]]:pl-0.5 sm:[&_[aria-label=checkbox-group]]:pl-0',
           '[&_>:first-child[data-tag=tiny-checkbox]]:pl-0.5 sm:[&_>:first-child[data-tag=tiny-checkbox]]:pl-0',
           '[&_[class^=tiny-autocomplete]]:w-full',
-          '[&_[class^=tiny-cascader]]:w-full',
           state.isDisplayOnly
             ? '[&_>*:not([data-tag^=tiny-],[class^=tiny-])]:leading-8 [&_>*:not([data-tag^=tiny-],[class^=tiny-])]:sm:leading-normal'
             : ''


### PR DESCRIPTION
fix(form-item): 多端的form-item上，去控制tiny-cascader 的宽度为w-full， 引起tiny-cacader的所有有类名的元素的宽度都是100% 的bug。

多端的form-item上，去控制tiny-cascader 的宽度为w-full是早期同步AUI的代码。 不清楚它控制的场景。但它这句话影响有点大，所以去掉。

如果最小改动，给重叠dom添加padding-right来规避， 那么正常使用cascader的就会多出来一个padding， 造成2倍空间，明显不合适, 因为不能保证是多端form-item 嵌套一个pc模板的cascader 这一种用法。

发91

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Adjusted cascader component styling to remove forced full-width layout on mobile devices, allowing more flexible display options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->