### PR TITLE
fix(input): remove input mf outline, which is black border

### DIFF
--- a/packages/vue/src/cascader-mobile/src/mobile-first.vue
+++ b/packages/vue/src/cascader-mobile/src/mobile-first.vue
@@ -44,7 +44,7 @@
             <IconSearch custom-class="h-4 w-4" class="mr-1 fill-color-icon-disabled"></IconSearch>
             <input
               v-model="state.search.input"
-              class="h-5 flex-auto text-xs bg-transparent outline-0"
+              class="h-5 flex-auto text-xs bg-transparent outline-none"
               :placeholder="t('ui.select.pleaseSearch')"
               @input="searchMethod"
             />

--- a/packages/vue/src/cascader-view/src/mobile-first.vue
+++ b/packages/vue/src/cascader-view/src/mobile-first.vue
@@ -27,7 +27,7 @@
             <IconSearch custom-class="h-4 w-4" class="mr-1 fill-color-icon-disabled"></IconSearch>
             <input
               v-model="state.search.input"
-              class="h-5 flex-auto text-xs bg-transparent outline-0"
+              class="h-5 flex-auto text-xs bg-transparent outline-none"
               :placeholder="t('ui.select.pleaseSearch')"
               @input="inputKeyword"
               @keyup.enter="searchMethod"

--- a/packages/vue/src/cascader/src/pc-first.vue
+++ b/packages/vue/src/cascader/src/pc-first.vue
@@ -47,7 +47,7 @@
           v-model.trim="state.inputValue"
           type="text"
           data-tag="tiny-cascader__search-input"
-          class="flex-1 h-6 text-color-text-primary text-xs border-none outline-0 box-border"
+          class="flex-1 h-6 text-color-text-primary text-xs border-none outline-none box-border"
           :placeholder="state.presentTags.length ? '' : placeholder"
           @focus="handleFocus"
           @blur="handleBlur"

--- a/packages/vue/src/input/src/mobile-first.vue
+++ b/packages/vue/src/input/src/mobile-first.vue
@@ -87,7 +87,7 @@
                 'sm:focus:border-color-brand-focus sm:disabled:border-color-border ' +
                 'placeholder:text-color-text-placeholder placeholder:text-sm sm:disabled:placeholder:text-color-text-disabled text-sm text-color-text-primary ' +
                 'bg-color-bg-1 disabled:cursor-not-allowed disabled:text-color-text-disabled sm:disabled:text-color-text-disabled ' +
-                'sm:disabled:bg-color-bg-6 py-0 outline-0 transition-colors duration-200 ease-in-out ',
+                'sm:disabled:bg-color-bg-6 py-0 outline-none transition-colors duration-200 ease-in-out ',
               state.inputSizeMf === 'medium'
                 ? `h-8 leading-8 ${m('sm:text-sm')} placeholder:text-sm`
                 : state.inputSizeMf === 'mini'
@@ -344,7 +344,7 @@
         ref="textarea"
         v-bind="a($attrs, ['type', 'class', 'style', '^on[A-Z]'])"
         :tabindex="tabindex"
-        class="block w-full border-0 sm:border-solid sm:border-color-border sm:hover:border-color-border-hover sm:focus:border-color-brand-focus sm:disabled:border-color-border outline-0 rounded placeholder:text-color-text-placeholder placeholder:text-sm sm:disabled:placeholder:text-color-text-disabled text-sm text-color-text-primary bg-color-bg-1 disabled:cursor-not-allowed disabled:text-color-text-disabled sm:disabled:text-color-text-disabled sm:disabled:bg-color-bg-6"
+        class="block w-full border-0 sm:border-solid sm:border-color-border sm:hover:border-color-border-hover sm:focus:border-color-brand-focus sm:disabled:border-color-border outline-none rounded placeholder:text-color-text-placeholder placeholder:text-sm sm:disabled:placeholder:text-color-text-disabled text-sm text-color-text-primary bg-color-bg-1 disabled:cursor-not-allowed disabled:text-color-text-disabled sm:disabled:text-color-text-disabled sm:disabled:bg-color-bg-6"
         :class="[
           readonly ? 'sm:border-0 px-0 py-0' : 'sm:border px-3 ',
           state.isDisplayOnly ? 'hidden' : '',

--- a/packages/vue/src/numeric/src/token.ts
+++ b/packages/vue/src/numeric/src/token.ts
@@ -25,7 +25,7 @@ export const classes = {
   'numeric_input-disabled':
     'bg-inherit sm:bg-color-bg-6 sm:[&_input]:bg-transparent cursor-not-allowed sm:border border-0.5 border-solid rounded border-color-border-separator text-color-text-disabled sm:text-color-text-secondary',
 
-  'numeric_input_inner': 'w-full z-10 leading-7 sm:text-sm inline-block overflow-hidden outline-0 bg-color-bg-1',
+  'numeric_input_inner': 'w-full z-10 leading-7 sm:text-sm inline-block overflow-hidden outline-none bg-color-bg-1',
   'numeric-text-center': 'text-center',
   'numeric-text-left': 'text-left',
   'numeric_input_inner_size': 'leading-7 text-sm',

--- a/packages/vue/src/pager/src/mobile-first.vue
+++ b/packages/vue/src/pager/src/mobile-first.vue
@@ -161,7 +161,7 @@
             ref="jumperInput"
             type="tel"
             :disabled="disabled"
-            class="w-8 h-7 text-center align-top rounded-sm inline-block border border-solid border-color-border hover:text-color-icon-primary hover:border-color-icon-primary text-color-text-primary text-xs transition-[border] duration-300 outline-0 box-border mr-0 focus:border-color-border-focus"
+            class="w-8 h-7 text-center align-top rounded-sm inline-block border border-solid border-color-border hover:text-color-icon-primary hover:border-color-icon-primary text-color-text-primary text-xs transition-[border] duration-300 outline-none box-border mr-0 focus:border-color-border-focus"
             :value="jumperValue"
             @focus="handleJumperFocus"
             @input="handleJumperInput"

--- a/packages/vue/src/radio-button/src/mobile-first.vue
+++ b/packages/vue/src/radio-button/src/mobile-first.vue
@@ -18,7 +18,7 @@
   >
     <input
       ref="radio"
-      class="opacity-0 outline-0 absolute -z-10"
+      class="opacity-0 outline-none absolute -z-10"
       :value="label"
       type="radio"
       v-model="state.value"

--- a/packages/vue/src/search/src/token.ts
+++ b/packages/vue/src/search/src/token.ts
@@ -20,7 +20,7 @@ export const classes = {
   'pc-search-input-background-transparent': ' border-transparent',
   'pc-search-input-background-transparent-collapse': 'bg-color-bg-1',
   'pc-search-input-default':
-    'pl-2 table-cell relative align-middle right-0 text-color-text-primary border-0 outline-0 bg-transparent placeholder:text-color-none focus:placeholder:text-color-text-placeholder',
+    'pl-2 table-cell relative align-middle right-0 text-color-text-primary border-0 outline-none bg-transparent placeholder:text-color-none focus:placeholder:text-color-text-placeholder',
   'pc-search-input-collapse': 'w-7 float-right p-0',
   'pc-search-input-uncollapse': 'w-full',
   'pc-search-input-collapse-big': 'pl-3',

--- a/packages/vue/src/select-mobile/src/mobile-first.vue
+++ b/packages/vue/src/select-mobile/src/mobile-first.vue
@@ -63,7 +63,7 @@
             <IconSearch custom-class="h-4 w-4" class="mr-1 fill-color-icon-disabled"></IconSearch>
             <input
               v-model="state.search.input"
-              class="h-5 flex-auto text-xs bg-transparent outline-0"
+              class="h-5 flex-auto text-xs bg-transparent outline-none"
               :placeholder="t('ui.select.pleaseSearch')"
               @input="searchMethod"
             />

--- a/packages/vue/src/select-view/src/mobile-first.vue
+++ b/packages/vue/src/select-view/src/mobile-first.vue
@@ -28,7 +28,7 @@
             <input
               v-model="state.search.input"
               @keydown.enter="searchMethod"
-              class="h-5 flex-auto text-xs bg-transparent outline-0"
+              class="h-5 flex-auto text-xs bg-transparent outline-none"
               :placeholder="placeholder || t('ui.select.pleaseSearch')"
             />
           </div>

--- a/packages/vue/src/select/src/mobile-first.vue
+++ b/packages/vue/src/select/src/mobile-first.vue
@@ -219,7 +219,7 @@
           v-if="filterable && !state.selectDisabled"
           v-model="state.query"
           type="text"
-          class="hidden sm:inline-block border-none outline-0 p-0 ml-px text-color-text-primary text-xs h-7 appearance-none bg-transparent"
+          class="hidden sm:inline-block border-none outline-none p-0 ml-px text-color-text-primary text-xs h-7 appearance-none bg-transparent"
           :class="[
             state.selectSize === 'mini' ? 'h-6' : '',
             state.selectSize === 'small' ? 'h-9' : '',


### PR DESCRIPTION
# PR
多端的input 有一个黑色的边框                      runtime  81,91
批量把其它一些在 input上，使用outline-0 的统一替换成 outline-none.  后者更稳定，不产生黑色框。

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Replaced outline utility usage across multiple input, search, pager, radio, and numeric components for consistent focus/outline behavior and improved visual consistency.
  * Minor class formatting refinements in the upload list template for clearer styling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->