### PR TITLE
fix: add size prop for collapse

### DIFF
--- a/examples/sites/demos/apis/collapse.js
+++ b/examples/sites/demos/apis/collapse.js
@@ -51,6 +51,18 @@ export default {
           },
           mode: ['mobile-first'],
           mfDemo: ''
+        },
+        {
+          name: 'size',
+          type: 'String',
+          defaultValue: '',
+          desc: {
+            'zh-CN': '控制折叠面板的尺寸，可选值为 "" | "medium"',
+            'en-US': 'adjust the size of the fold panel. Available options: "" | "medium"'
+          },
+          mode: ['pc', 'mobile-first'],
+          mfDemo: '',
+          pcDemo: 'size.vue'
         }
       ],
       events: [

--- a/examples/sites/demos/apis/collapse.js
+++ b/examples/sites/demos/apis/collapse.js
@@ -62,7 +62,10 @@ export default {
           },
           mode: ['pc', 'mobile-first'],
           mfDemo: '',
-          pcDemo: 'size.vue'
+          pcDemo: 'size.vue',
+          meta: {
+            stable: '3.31.0'
+          }
         }
       ],
       events: [

--- a/examples/sites/demos/pc/app/collapse/size-composition-api.vue
+++ b/examples/sites/demos/pc/app/collapse/size-composition-api.vue
@@ -1,0 +1,34 @@
+<template>
+  <tiny-collapse class="demo-collapse-wrap" v-model="activeNames" size="medium">
+    <tiny-collapse-item title="一致性 Consistency" name="1">
+      <div>与现实生活一致：与现实生活的流程、逻辑保持一致，遵循用户习惯的语言和概念；</div>
+      <div>在界面中一致：所有的元素和结构需保持一致，比如：设计样式、图标和文本、元素的位置等。</div>
+    </tiny-collapse-item>
+    <tiny-collapse-item title="反馈 Feedback" name="2">
+      <div>控制反馈：通过界面样式和交互动效让用户可以清晰的感知自己的操作；</div>
+      <div>页面反馈：操作后，通过页面元素的变化清晰地展现当前状态。</div>
+    </tiny-collapse-item>
+    <tiny-collapse-item title="效率 Efficiency" name="3">
+      <div>简化流程：设计简洁直观的操作流程；</div>
+      <div>清晰明确：语言表达清晰且表意明确，让用户快速理解进而作出决策；</div>
+      <div>帮助用户识别：界面简单直白，让用户快速识别而非回忆，减少用户记忆负担。</div>
+    </tiny-collapse-item>
+    <tiny-collapse-item title="可控 Controllability" name="4">
+      <div>用户决策：根据场景可给予用户操作建议或安全提示，但不能代替用户进行决策；</div>
+      <div>结果可控：用户可以自由的进行操作，包括撤销、回退和终止当前操作等。</div>
+    </tiny-collapse-item>
+  </tiny-collapse>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { TinyCollapse, TinyCollapseItem } from '@opentiny/vue'
+
+const activeNames = ref(['1', '3'])
+</script>
+
+<style scoped lang="less">
+.demo-collapse-wrap ::v-deep .tiny-collapse-item__content > * {
+  line-height: 1.6;
+}
+</style>

--- a/examples/sites/demos/pc/app/collapse/size.vue
+++ b/examples/sites/demos/pc/app/collapse/size.vue
@@ -1,0 +1,43 @@
+<template>
+  <tiny-collapse class="demo-collapse-wrap" v-model="activeNames" size="medium">
+    <tiny-collapse-item title="一致性 Consistency" name="1">
+      <div>与现实生活一致：与现实生活的流程、逻辑保持一致，遵循用户习惯的语言和概念；</div>
+      <div>在界面中一致：所有的元素和结构需保持一致，比如：设计样式、图标和文本、元素的位置等。</div>
+    </tiny-collapse-item>
+    <tiny-collapse-item title="反馈 Feedback" name="2">
+      <div>控制反馈：通过界面样式和交互动效让用户可以清晰的感知自己的操作；</div>
+      <div>页面反馈：操作后，通过页面元素的变化清晰地展现当前状态。</div>
+    </tiny-collapse-item>
+    <tiny-collapse-item title="效率 Efficiency" name="3">
+      <div>简化流程：设计简洁直观的操作流程；</div>
+      <div>清晰明确：语言表达清晰且表意明确，让用户快速理解进而作出决策；</div>
+      <div>帮助用户识别：界面简单直白，让用户快速识别而非回忆，减少用户记忆负担。</div>
+    </tiny-collapse-item>
+    <tiny-collapse-item title="可控 Controllability" name="4">
+      <div>用户决策：根据场景可给予用户操作建议或安全提示，但不能代替用户进行决策；</div>
+      <div>结果可控：用户可以自由的进行操作，包括撤销、回退和终止当前操作等。</div>
+    </tiny-collapse-item>
+  </tiny-collapse>
+</template>
+
+<script>
+import { TinyCollapse, TinyCollapseItem } from '@opentiny/vue'
+
+export default {
+  components: {
+    TinyCollapse,
+    TinyCollapseItem
+  },
+  data() {
+    return {
+      activeNames: ['1', '3']
+    }
+  }
+}
+</script>
+
+<style scoped lang="less">
+.demo-collapse-wrap ::v-deep .tiny-collapse-item__content > * {
+  line-height: 1.6;
+}
+</style>

--- a/examples/sites/demos/pc/app/collapse/webdoc/collapse.js
+++ b/examples/sites/demos/pc/app/collapse/webdoc/collapse.js
@@ -47,6 +47,19 @@ export default {
       codeFiles: ['disable.vue']
     },
     {
+      demoId: 'size',
+      name: {
+        'zh-CN': '面板大小',
+        'en-US': 'Custom Panel Size'
+      },
+      desc: {
+        'zh-CN': '通过 <code>size</code> 属性可以指定折叠面板的尺寸，可选值为 "" | "medium"。',
+        'en-US':
+          'by <code>size</code> prop can be used to specify the size of the collapse panel. The optional values are "" | "medium".'
+      },
+      codeFiles: ['size.vue']
+    },
+    {
       demoId: 'title',
       name: {
         'zh-CN': '面板标题',

--- a/packages/renderless/src/collapse-item/vue.ts
+++ b/packages/renderless/src/collapse-item/vue.ts
@@ -44,6 +44,7 @@ export const renderless = (
     focusing: false,
     contentHeight: 0,
     contentWrapStyle: { height: 'auto', display: 'block' },
+    size: parent.collapse.size,
     isActive: computed(() => parent.collapse.state.activeNames.includes(props.name)),
     arrowIcon: props.expandIcon || designConfig?.icons?.arrowIcon || 'IconChevronRight'
   })

--- a/packages/theme-saas/src/collapse-item/index.less
+++ b/packages/theme-saas/src/collapse-item/index.less
@@ -40,7 +40,7 @@
     @apply flex;
     @apply items-center;
     @apply h-10;
-    @apply leading-10;
+    @apply ~'leading-5.5';
     @apply rounded;
     @apply text-color-text-primary;
     @apply py-0 pl-0;

--- a/packages/theme-saas/src/collapse/index.less
+++ b/packages/theme-saas/src/collapse/index.less
@@ -1,5 +1,15 @@
 @import '../custom.less';
 
 @collapse-prefix-cls: ~'@{css-prefix}collapse';
+@collapse-item-prefix-cls: ~'@{css-prefix}collapse-item';
 
+.@{collapse-prefix-cls}.is-medium {
+  .@{collapse-item-prefix-cls} {
+    &__header {
+      height: 42px;
+      @apply leading-6;
+      @apply text-base;
+    }
+  }
+}
 /* 动画类已移出 */

--- a/packages/theme/src/collapse/index.less
+++ b/packages/theme/src/collapse/index.less
@@ -13,8 +13,17 @@
 @import '../custom.less';
 @import './vars.less';
 @collapse-prefix-cls: ~'@{css-prefix}collapse';
+@collapse-item-prefix-cls: ~'@{css-prefix}collapse-item';
 
 .@{collapse-prefix-cls} {
   .inject-Collapse-vars();
   border-bottom: 1px solid var(--tv-Collapse-divider-line-color);
+
+  &.is-medium {
+    .@{collapse-item-prefix-cls} {
+      &__header {
+        font-size: 16px;
+      }
+    }
+  }
 }

--- a/packages/vue/src/collapse-item/src/mobile-first.vue
+++ b/packages/vue/src/collapse-item/src/mobile-first.vue
@@ -16,18 +16,22 @@
         :id="`tiny-collapse-head-${state.id}`"
         :tabindex="disabled ? undefined : 0"
         @keyup.space.enter.stop="handleEnterClick"
-        :class="
+        :class="[
           disabled
             ? 'text-color-text-disabled'
-            : 'text-color-text-primary sm:[&:has(.peer:hover)_[role=title]]:text-color-brand'
-        "
+            : 'text-color-text-primary sm:[&:has(.peer:hover)_[role=title]]:text-color-brand',
+          state.size === 'medium' ? 'text-base sm:h-[42px]' : 'text-sm sm:h-10'
+        ]"
         @focus="handleFocus"
         @blur="state.focusing = false"
       >
         <div
           data-tag="tiny-collapse-item-title"
           class="whitespace-nowrap overflow-hidden overflow-ellipsis inline-block peer"
-          :class="[disabled ? 'cursor-not-allowed' : 'cursor-pointer sm:hover:text-color-brand']"
+          :class="[
+            disabled ? 'cursor-not-allowed' : 'cursor-pointer sm:hover:text-color-brand',
+            state.size === 'medium' ? 'leading-6' : 'leading-5.5'
+          ]"
           role="title"
           @click="handleHeaderClick"
         >

--- a/packages/vue/src/collapse/src/index.ts
+++ b/packages/vue/src/collapse/src/index.ts
@@ -32,6 +32,10 @@ export const collapseProps = {
   modelValue: {
     type: [Array, String, Number],
     default: () => []
+  },
+  size: {
+    type: String,
+    default: ''
   }
 }
 

--- a/packages/vue/src/collapse/src/mobile-first.vue
+++ b/packages/vue/src/collapse/src/mobile-first.vue
@@ -9,7 +9,7 @@ import { renderless, api } from '@opentiny/vue-renderless/collapse/vue'
 import { props, setup, defineComponent } from '@opentiny/vue-common'
 
 export default defineComponent({
-  props: [...props, 'accordion', 'modelValue', 'beforeClose'],
+  props: [...props, 'accordion', 'modelValue', 'beforeClose', 'size'],
   emits: ['update:modelValue', 'change'],
   setup(props, context): any {
     return setup({ props, context, renderless, api })

--- a/packages/vue/src/collapse/src/pc.vue
+++ b/packages/vue/src/collapse/src/pc.vue
@@ -10,7 +10,7 @@
  *
  -->
 <template>
-  <div class="tiny-collapse" role="tablist" aria-multiselectable="true">
+  <div class="tiny-collapse" :class="{ 'is-medium': size === 'medium' }" role="tablist" aria-multiselectable="true">
     <slot></slot>
   </div>
 </template>
@@ -20,7 +20,7 @@ import { renderless, api } from '@opentiny/vue-renderless/collapse/vue'
 import { props, setup, defineComponent } from '@opentiny/vue-common'
 
 export default defineComponent({
-  props: [...props, 'accordion', 'modelValue', 'beforeClose'],
+  props: [...props, 'accordion', 'modelValue', 'beforeClose', 'size'],
   setup(props, context) {
     return setup({ props, context, renderless, api })
   }


### PR DESCRIPTION
# PR
同步 AUI的collapse组件的 size属性， 修改theme/theme-saas/mf模板 都增加相关的样式。
增加size属性的文档   v81

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `size` prop to Collapse with a "medium" option that adjusts item height, font size, and line-height for improved readability.

* **Demos**
  * Added new demo examples showcasing the medium size and composition API usage with preset open sections.

* **Style**
  * Updated collapse styles to support the medium variant and refined header line-heights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->