### PR TITLE
fix(input): when the text of the placeholder attribute of the input box component is too long, the tooltip displays all the content

### DIFF
--- a/packages/renderless/src/input/index.ts
+++ b/packages/renderless/src/input/index.ts
@@ -48,8 +48,7 @@ const STYLE = {
 }
 
 /**
- * 检测 placeholder 是否超长，用于显示 Tooltip
- * 仅在非 textarea 类型时生效
+ * 仅在非 textarea 类型时生效，检测 placeholder 是否超长，用于显示 Tooltip
  */
 export const checkPlaceholderOverflow =
   ({ vm, state }: Pick<IInputRenderlessParams, 'vm' | 'state'>) =>

--- a/packages/renderless/src/input/index.ts
+++ b/packages/renderless/src/input/index.ts
@@ -47,6 +47,54 @@ const STYLE = {
   BorderBottomWidth: 'border-bottom-width'
 }
 
+/**
+ * 检测 placeholder 是否超长，用于显示 Tooltip
+ * 仅在非 textarea 类型时生效
+ */
+export const checkPlaceholderOverflow =
+  ({ vm, state }: Pick<IInputRenderlessParams, 'vm' | 'state'>) =>
+  (): void => {
+    const input = vm.$refs.input as HTMLInputElement | undefined
+    if (!input) {
+      state.placeholderOverflow = false
+      return
+    }
+
+    const placeholder = input.placeholder
+    if (!placeholder) {
+      state.placeholderOverflow = false
+      return
+    }
+
+    // 创建临时测量元素
+    const measureEl = document.createElement('span')
+    measureEl.style.cssText = `
+      position: absolute;
+      visibility: hidden;
+      white-space: nowrap;
+      pointer-events: none;
+      z-index: -9999;
+    `
+    document.body.appendChild(measureEl)
+
+    const inputStyle = window.getComputedStyle(input)
+    measureEl.style.fontFamily = inputStyle.fontFamily
+    measureEl.style.fontSize = inputStyle.fontSize
+    measureEl.style.fontWeight = inputStyle.fontWeight
+    measureEl.style.letterSpacing = inputStyle.letterSpacing
+    measureEl.textContent = placeholder
+
+    // 可用宽度 = 总宽度 - 左右 padding
+    const paddingLeft = parseFloat(inputStyle.paddingLeft) || 0
+    const paddingRight = parseFloat(inputStyle.paddingRight) || 0
+    const availableWidth = input.clientWidth - paddingLeft - paddingRight
+
+    state.placeholderOverflow = measureEl.scrollWidth > availableWidth
+    state.placeholderTooltipContent = placeholder
+
+    document.body.removeChild(measureEl)
+  }
+
 const isKorean = (text: string): boolean => /([(\uAC00-\uD7AF)|(\u3130-\u318F)])+/gi.test(text)
 
 export const showBox = (state: IInputState) => (): void => {

--- a/packages/renderless/src/input/vue.ts
+++ b/packages/renderless/src/input/vue.ts
@@ -53,7 +53,8 @@ import {
   getDisplayOnlyText,
   setShowMoreBtn,
   handleTextareaMouseDown,
-  handleTextareaMouseUp
+  handleTextareaMouseUp,
+  checkPlaceholderOverflow
 } from './index'
 import useStorageBox from '../tall-storage/vue-storage-box'
 import { on, off } from '@opentiny/utils'
@@ -181,7 +182,14 @@ const initState = ({
     hiddenPassword: computed(() => api.hiddenPassword()),
     displayedMaskValue: computed(() => api.getDisplayedMaskValue()),
     displayOnlyText: computed(() => api.getDisplayOnlyText()),
-    isDragging: false
+    isDragging: false,
+    placeholderOverflow: false,
+    placeholderTooltipContent: '',
+    // 新增：placeholder tooltip 是否应该显示
+    placeholderTooltipVisible: computed(() => {
+      // 条件：placeholder 必须超长 && 输入框必须为空（没有输入值）
+      return state.placeholderOverflow && !state.nativeInputValue
+    })
   })
 
   return state as IInputState
@@ -222,7 +230,8 @@ const initApi = ({
     handleLeaveTextarea: handleLeaveTextarea({ api, state, props, nextTick, vm }),
     inputStyle: inputStyle({ props }),
     handleTextareaMouseDown: handleTextareaMouseDown({ state }),
-    handleTextareaMouseUp: handleTextareaMouseUp({ state, api })
+    handleTextareaMouseUp: handleTextareaMouseUp({ state, api }),
+    checkPlaceholderOverflow: checkPlaceholderOverflow({ vm, state })
   })
 }
 
@@ -296,9 +305,10 @@ const initWatch = ({
   props,
   nextTick,
   emit,
+  parent,
   componentName,
   eventName
-}: Pick<IInputRenderlessParams, 'watch' | 'state' | 'api' | 'props' | 'nextTick' | 'emit'> & {
+}: Pick<IInputRenderlessParams, 'watch' | 'state' | 'api' | 'props' | 'nextTick' | 'emit' | 'parent'> & {
   componentName: string
   eventName: IInputEventNameConstants
 }) => {
@@ -374,6 +384,12 @@ const initWatch = ({
     (value) => api.watchFormSelect(value),
     { immediate: true }
   )
+
+  // size 变化时重新检测
+  watch(
+    () => props.size,
+    () => nextTick(api.checkPlaceholderOverflow)
+  )
 }
 
 export const renderless = (
@@ -413,6 +429,8 @@ export const renderless = (
     if (vm.$attrs.autofocus) {
       api.focus()
     }
+
+    nextTick(api.checkPlaceholderOverflow)
   })
 
   onBeforeUnmount(() => {
@@ -423,6 +441,7 @@ export const renderless = (
 
   onUpdated(() => {
     nextTick(api.updateIconOffset)
+    nextTick(api.checkPlaceholderOverflow) // 组件更新时自动检测
   })
 
   return api

--- a/packages/renderless/src/input/vue.ts
+++ b/packages/renderless/src/input/vue.ts
@@ -187,7 +187,7 @@ const initState = ({
     placeholderTooltipContent: '',
     // 新增：placeholder tooltip 是否应该显示
     placeholderTooltipVisible: computed(() => {
-      // 条件：placeholder 必须超长 && 输入框必须为空（没有输入值）
+      // placeholder 必须超长 && 输入框必须为空
       return state.placeholderOverflow && !state.nativeInputValue
     })
   })

--- a/packages/theme/src/input/index.less
+++ b/packages/theme/src/input/index.less
@@ -131,6 +131,9 @@
     box-sizing: border-box;
     appearance: none;
     transition: border-color 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     .placeholder(@color: var(--tv-Input-placeholder-text-color));
 
     &:hover,

--- a/packages/vue/src/input/src/pc.vue
+++ b/packages/vue/src/input/src/pc.vue
@@ -69,31 +69,41 @@
           </span>
           <span class="tiny-input-display-only__content" v-else>{{ state.displayOnlyText }}</span>
         </tiny-tooltip>
-        <input
-          v-if="type !== 'textarea'"
-          ref="input"
-          :name="name"
-          data-tag="tiny-input-inner"
-          v-bind="a($attrs, ['type', 'class', 'style', '^on[A-Z]', 'id', 'aria-required', 'aria-invalid'])"
-          :class="['tiny-input__inner', mask && state.inputDisabled && !state.maskValueVisible && 'tiny-input__mask']"
-          :tabindex="tabindex"
-          :type="showPassword ? (state.passwordVisible ? 'text' : 'password') : type"
-          :disabled="state.inputDisabled"
-          :readonly="readonly"
-          :unselectable="readonly ? 'on' : 'off'"
-          :autocomplete="autocomplete"
-          @compositionend="handleCompositionEnd"
-          @compositionupdate="handleCompositionUpdate"
-          @compositionstart="handleCompositionStart"
-          @blur="handleBlur"
-          @focus="handleFocus"
-          @input="handleInput"
-          @change="handleChange"
-          :aria-label="label || $attrs.placeholder"
-          @keyup="$emit('keyup', $event)"
-          @keydown="$emit('keydown', $event)"
-          @paste="$emit('paste', $event)"
-        />
+        <!-- ====== 新增：placeholder tooltip 包裹层 ====== -->
+        <tiny-tooltip
+          v-if="!state.isDisplayOnly"
+          :content="state.placeholderTooltipContent"
+          :disabled="!state.placeholderTooltipVisible"
+          effect="light"
+          placement="top"
+        >
+          <input
+            v-if="type !== 'textarea'"
+            ref="input"
+            :name="name"
+            data-tag="tiny-input-inner"
+            v-bind="a($attrs, ['type', 'class', 'style', '^on[A-Z]', 'id', 'aria-required', 'aria-invalid'])"
+            :class="['tiny-input__inner', mask && state.inputDisabled && !state.maskValueVisible && 'tiny-input__mask']"
+            :tabindex="tabindex"
+            :type="showPassword ? (state.passwordVisible ? 'text' : 'password') : type"
+            :disabled="state.inputDisabled"
+            :readonly="readonly"
+            :unselectable="readonly ? 'on' : 'off'"
+            :autocomplete="autocomplete"
+            @compositionend="handleCompositionEnd"
+            @compositionupdate="handleCompositionUpdate"
+            @compositionstart="handleCompositionStart"
+            @blur="handleBlur"
+            @focus="handleFocus"
+            @input="handleInput"
+            @change="handleChange"
+            :aria-label="label || $attrs.placeholder"
+            @mouseenter="checkPlaceholderOverflow"
+            @keyup="$emit('keyup', $event)"
+            @keydown="$emit('keydown', $event)"
+            @paste="$emit('paste', $event)"
+          />
+        </tiny-tooltip>
       </span>
       <tiny-tall-storage
         v-if="isMemoryStorage"


### PR DESCRIPTION
# PR
修复前：
<img width="1677" height="620" alt="ootd" src="https://github.com/user-attachments/assets/ab7659d5-e88a-4372-8046-d161d433fa38" />

修复后：
<img width="1677" height="491" alt="input123" src="https://github.com/user-attachments/assets/dd64ecd5-38e3-4243-bb6b-4cc8f1534a7e" />

<img width="1677" height="620" alt="select" src="https://github.com/user-attachments/assets/341bf2ac-50b2-43a7-8267-bdc03e0402ff" />



## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:
修复：当input框组件的placeholder属性文字超长时，新增Tooltips提示全部的内容。
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
