### PR TITLE
fix(vue-renderless/dialog-select):[dialog-select] 修复首次打开多选勾选不同步

### DIFF
--- a/packages/renderless/src/dialog-select/index.ts
+++ b/packages/renderless/src/dialog-select/index.ts
@@ -520,11 +520,12 @@ export const computedConfig =
     const { selectConfig = {}, radioConfig = {} } = gridOp || {}
     const { selectedValues } = state
     let config = {}
+    const checkRowKeys = selectedValues.length ? selectedValues : selectConfig.checkRowKeys
 
     if (popseletor === 'grid') {
       // 单选和多选同时使用computedConfig来获取配置，因此需要加type区分，否则单选和多选返回的是一模一样的配置
       if (multi && type === 'select') {
-        config = Object.assign(config, selectConfig, { checkRowKeys: selectedValues })
+        config = Object.assign(config, selectConfig, { checkRowKeys: state.selectedChanged ? [] : checkRowKeys })
       }
       if (!multi && type === 'radio') {
         config = Object.assign(config, radioConfig, { checkRowKey: selectedValues[0] })


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
目前在 DialogSelect 多选场景中，首次打开弹窗时左侧表格的勾选状态无法正确显示，右侧已选列表虽然有数据，但左侧没有同步勾选；在翻页或重新渲染后，左侧勾选才恢复正常。
Issue Number: #3702 

## What is the new behavior?
修复首次打开时左侧表格勾选不同步的问题，让弹窗打开后左侧勾选状态与右侧已选列表保持一致。
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected multi-select behavior in grid mode: selection now prefers existing selected items when present, falls back to configured keys otherwise, and resets when a selection change is detected. Single-select (radio) behavior remains unchanged.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/tiny-vue/pull/4201)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->