### PR TITLE
fix: fix form-item-inline's padding-top eq 12px

### DIFF
--- a/packages/vue/src/form-item/src/mobile-first.vue
+++ b/packages/vue/src/form-item/src/mobile-first.vue
@@ -83,7 +83,7 @@
             ? state.isDisplayOnly
               ? 'pl-0'
               : 'pl-2 sm:pl-0'
-            : 'pt-2',
+            : 'pt-3',
           state.formItemSize !== 'mini' ? 'sm:text-sm' : 'sm:text-xs'
         )
       "


### PR DESCRIPTION
# PR
修改多端的form-item的值的padding -top =12px, 让它与前面的lable的padding 保持一致   v81,91
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fine-tuned padding spacing on form items for improved visual appearance when labels are positioned at the top.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/tiny-vue/pull/4202)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->