### PR TITLE
fix(reset.css): restore [class*=~'@{css-prefix}']  in reset.css

### DIFF
--- a/packages/theme-saas/src/base/reset.less
+++ b/packages/theme-saas/src/base/reset.less
@@ -1,7 +1,7 @@
 @import '../custom.less';
 
-// 以下 class 仅含 tiny- 前缀用于布局/锁定，不应作为 reset 作用域根节点，否则会令后代 ul/li 被 m-0/p-0 浸入业务内容
-[class*=~'@{css-prefix}']:not(.@{css-prefix}modal-lockscroll):not(.@{css-prefix}loading__parent-relative):not(.@{css-prefix}loading__parent-hidden) {
+// 以下 class 仅含 tiny- 前缀用于布局/锁定
+[class*=~'@{css-prefix}'] {
   font-family: 'HarmonyOSHans', 'Segoe UI', Arial, 'Microsoft YaHei', -apple-system, BlinkMacSystemFont,
     'Helvetica Neue', 'Helvetica', 'PingFang SC', 'Roboto', 'Noto Sans', sans-serif, 'HMOSColorEmojiCompat',
     'HMOSColorEmojiFlags', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';


### PR DESCRIPTION
# PR
还原[class*=~'@{css-prefix}']的优先级   v81

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling reset rules to apply consistently across layout and lock state components, removing previous exceptions that could result in inconsistent styling behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/tiny-vue/pull/4203)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->