### PR TITLE
feat(modal): [modal] added the before-close attribute

### DIFF
--- a/examples/sites/demos/apis/modal.js
+++ b/examples/sites/demos/apis/modal.js
@@ -10,12 +10,16 @@ export default {
           type: 'Function',
           defaultValue: '',
           desc: {
-            'zh-CN': '可以配置一个拦截弹窗关闭的方法。如果方法返回 false 值，则拦截弹窗关闭；否则不拦截',
+            'zh-CN': '设置关闭前的回调函数（仅点击关闭按钮或遮罩区域时被调用），如果回调函数返回 false 则阻止窗口关闭',
             'en-US':
-              'Configure a method to intercept modal closing. If the method returns false, the modal closing is intercepted; otherwise it is not intercepted'
+              'Set the callback function before closing (only called when clicking the close button or mask area). If the callback function returns false, the modal will not be closed'
           },
-          mode: ['mobile-first'],
-          mfDemo: ''
+          mode: ['pc', 'mobile-first'],
+          mfDemo: '',
+          pcDemo: 'before-close',
+          meta: {
+            stable: '3.31.0'
+          }
         },
         {
           name: 'cancel-btn-props',

--- a/examples/sites/demos/mobile-first/app/modal/webdoc/modal.js
+++ b/examples/sites/demos/mobile-first/app/modal/webdoc/modal.js
@@ -325,8 +325,8 @@ export default {
       },
       desc: {
         'zh-CN':
-          '<p>通过 `before-close` 属性可以配置一个拦截弹窗关闭的方法。如果方法返回 false 值，则拦截弹窗关闭；否则不拦截<br> 可以通过该拦截方法传入的参数获取关闭的操作类型<br>confirm 弹窗有以下关闭类型：<br> - confirm：点击确认时关闭<br>- cancel：点击取消时关闭<br> - close：点击关闭按钮时关闭<br>- mask: 点击遮罩时关闭<br>- esc：通过按钮 esc 时关闭<br>alert 弹窗比 confirm 弹窗少了 `confirm` 类型<br> message 弹窗只有 `show` 一种关闭类型<p>',
-        'en-US': '<p>bbutton click</p>'
+          '<p>通过 `before-close` 属性设置关闭前的回调函数（仅点击关闭按钮或遮罩区域时被调用）。函数入参有type弹窗类型、instance弹窗实例、done回调函数。</p>',
+        'en-US': ''
       },
       codeFiles: ['before-close.vue']
     }

--- a/examples/sites/demos/pc/app/modal/before-close-composition-api.vue
+++ b/examples/sites/demos/pc/app/modal/before-close-composition-api.vue
@@ -1,0 +1,156 @@
+<template>
+  <div>
+    <h2>函数式调用：</h2>
+    <div class="content">
+      <tiny-button @click="messageClick"> 函数式弹窗1 </tiny-button>
+    </div>
+
+    <h2>标签式调用</h2>
+    <div class="content">
+      <!-- 1：所有关闭操作都触发 beforeClose -->
+      <tiny-modal
+        v-model="mainVisible"
+        :width="600"
+        :height="300"
+        :before-close="handleBeforeClose"
+        title="Num.1标签式弹窗"
+        message="NO.1标签式内容"
+        show-footer
+      >
+      </tiny-modal>
+
+      <!-- 2：关闭前确认弹窗 -->
+      <tiny-modal
+        v-model="confirmVisible"
+        title="Num.2弹窗关闭前确认"
+        message="NO.2---确定要关闭NO.1窗口吗？未保存的内容将丢失。"
+        @confirm="onConfirmClose"
+        @cancel="onCancelClose"
+        show-footer
+      >
+      </tiny-modal>
+      <tiny-button @click="mainVisible = true"> 标签式弹窗</tiny-button>
+    </div>
+
+    <h2>标签式 + 函数调用</h2>
+    <div class="content">
+      <tiny-modal
+        v-model="mainVisible2"
+        :width="600"
+        :height="300"
+        :before-close="handleBeforeClose1"
+        title="Num.1标签式加函数弹窗"
+        message="NO.1标签式加函数内容"
+        show-footer
+      >
+      </tiny-modal>
+      <tiny-button @click="mainVisible2 = true"> 标签式 + 函数式弹窗</tiny-button>
+    </div>
+
+    <h2>点击确认按钮 + 拦截弹窗</h2>
+    <div class="content">
+      <tiny-modal
+        v-model="mainVisible1"
+        :width="600"
+        :height="300"
+        :before-close="handleBeforeClose1"
+        title="Num.1确认按钮加拦截弹窗"
+        message="点击确认按钮，出现拦截弹窗"
+        show-footer
+      >
+        <template #footer>
+          <tiny-button type="primary" @click="onCancelClose1">取消</tiny-button>
+          <tiny-button style="margin-left: 12px" @click="onConfirmClose1">确定</tiny-button>
+        </template>
+      </tiny-modal>
+      <tiny-button @click="mainVisible1 = true"> 其他</tiny-button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="jsx">
+import { Button as TinyButton, Modal } from '@opentiny/vue'
+import { ref } from 'vue'
+
+const TinyModal = Modal
+const mainVisible = ref(false)
+const mainVisible1 = ref(false)
+const mainVisible2 = ref(false)
+const confirmVisible = ref(false)
+let pendingDone = null
+
+const handleBeforeClose = (type, instance, done) => {
+  confirmVisible.value = true
+  pendingDone = done
+  return false // 阻止原弹窗立即关闭
+}
+
+const onConfirmClose = () => {
+  confirmVisible.value = false
+  pendingDone && pendingDone() // 调用 done() 关闭原弹窗
+  pendingDone = null
+}
+
+// 点击取消/关闭 -> 只关闭确认弹窗，保留原弹窗
+const onCancelClose = () => {
+  confirmVisible.value = false
+  pendingDone = null // 不调用 done()，原弹窗保持打开
+}
+
+// 函数式调用：
+const messageClick = () => {
+  Modal.confirm({
+    message: 'Num.1函数式弹窗内容',
+    title: '函数式弹窗Num.1',
+    status: 'warning',
+    width: '600',
+    height: '300',
+    beforeClose: (type, instance, done) => {
+      Modal.confirm({
+        title: '关闭前确认Num.2',
+        message: '确认弹窗关闭Num.1？',
+        events: {
+          confirm: () => done && done(), // 确认 -> 关闭所有弹窗
+          cancel: () => {} // 取消 -> 保留原弹窗
+        }
+      })
+      return false
+    }
+  })
+}
+
+const handleBeforeClose1 = (type, instance, done) => {
+  Modal.confirm({
+    title: '关闭前确认Num.2',
+    message: '确认弹窗关闭Num.1？',
+    events: {
+      confirm: () => done && done(), // 确认 -> 关闭所有弹窗
+      cancel: () => {} // 取消 -> 保留原弹窗
+    }
+  })
+  return false // 阻止原弹窗立即关闭
+}
+
+// 其他
+const onConfirmClose1 = () => {
+  // 手动调用 beforeClose，传入关闭回调
+  handleBeforeClose1('confirm', null, () => {
+    mainVisible1.value = false
+  })
+}
+
+const onCancelClose1 = () => {
+  mainVisible1.value = false
+}
+</script>
+
+<style scoped>
+h2 {
+  font-size: 16px;
+  font-weight: bold;
+  margin: 20px 0 12px;
+}
+.content {
+  margin: 8px;
+}
+</style>

--- a/examples/sites/demos/pc/app/modal/before-close.spec.ts
+++ b/examples/sites/demos/pc/app/modal/before-close.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect } from '@playwright/test'
+
+test('关闭前的回调', async ({ page }) => {
+  page.on('pageerror', (exception) => expect(exception).toBeNull())
+  await page.goto('modal#before-close')
+
+  // 场景1：标签式弹窗关闭 -> 标签式拦截弹窗确认 -> 原弹窗关闭
+  await test.step('标签式弹窗：关闭按钮触发 beforeClose，拦截弹窗确认后关闭原弹窗', async () => {
+    await page.getByRole('button', { name: '标签式弹窗' }).click()
+
+    const modal1 = page.locator('.tiny-modal__box').filter({ hasText: 'Num.1标签式弹窗' })
+    await expect(modal1).toBeVisible()
+
+    // 点击右上角关闭按钮
+    await modal1.locator('.tiny-modal__close-btn').click()
+
+    // 标签式拦截弹窗出现（confirmVisible）
+    const modal2 = page.locator('.tiny-modal__box').filter({ hasText: 'Num.2弹窗关闭前确认' })
+    await expect(modal2).toBeVisible()
+
+    // 原弹窗保留
+    await expect(modal1).toBeVisible()
+
+    // 拦截弹窗点击"确定" -> 调用 done() -> 关闭原弹窗
+    await modal2.getByRole('button', { name: '确定' }).click()
+    await expect(modal2).not.toBeVisible()
+    await expect(modal1).not.toBeVisible()
+  })
+
+  // 场景2：标签式弹窗关闭 -> 标签式拦截弹窗取消 -> 原弹窗保留
+  await test.step('标签式弹窗：拦截弹窗取消后保留原弹窗，默认footer取消按钮直接关闭', async () => {
+    await page.getByRole('button', { name: '标签式弹窗' }).click()
+
+    const modal1 = page.locator('.tiny-modal__box').filter({ hasText: 'Num.1标签式弹窗' })
+    await expect(modal1).toBeVisible()
+
+    await modal1.locator('.tiny-modal__close-btn').click()
+
+    const modal2 = page.locator('.tiny-modal__box').filter({ hasText: 'Num.2弹窗关闭前确认' })
+    await expect(modal2).toBeVisible()
+
+    // 拦截弹窗点击"取消" → 不调用 done() → 保留原弹窗
+    await modal2.locator('.tiny-modal__close-btn').click()
+    await expect(modal2).not.toBeVisible()
+    await expect(modal1).toBeVisible()
+
+    // 点击默认 footer 的"取消"按钮 → cancel 事件 → 直接关闭（不触发 beforeClose）
+    await modal1.getByRole('button', { name: '确定' }).click()
+    await expect(modal1).not.toBeVisible()
+  })
+
+  // 场景3：标签式+函数式弹窗关闭 -> 函数式拦截弹窗确认 -> 关闭
+  await test.step('标签式加函数式弹窗：关闭按钮触发 beforeClose，函数式拦截弹窗确认后关闭', async () => {
+    await page.getByRole('button', { name: '标签式 + 函数式弹窗' }).click()
+
+    const modal1 = page.locator('.tiny-modal__box').filter({ hasText: 'Num.1标签式加函数弹窗' })
+    await expect(modal1).toBeVisible()
+
+    await modal1.locator('.tiny-modal__close-btn').click()
+
+    // 函数式拦截弹窗出现（Modal.confirm）
+    const modal2 = page.locator('.tiny-modal__box').filter({ hasText: '关闭前确认Num.2' })
+    await expect(modal2).toBeVisible()
+
+    // 原弹窗保留
+    await expect(modal1).toBeVisible()
+
+    // 拦截弹窗确认 → 关闭所有
+    await modal2.getByRole('button', { name: '确定' }).click()
+    await expect(modal2).not.toBeVisible()
+    await expect(modal1).not.toBeVisible()
+  })
+
+  //  场景4：标签式+函数式弹窗关闭 -> 函数式拦截弹窗取消 -> 保留
+  await test.step('标签式加函数式弹窗：拦截弹窗取消后保留原弹窗，默认footer取消按钮直接关闭', async () => {
+    await page.getByRole('button', { name: '标签式 + 函数式弹窗' }).click()
+
+    const modal1 = page.locator('.tiny-modal__box').filter({ hasText: 'Num.1标签式加函数弹窗' })
+    await expect(modal1).toBeVisible()
+
+    await modal1.locator('.tiny-modal__close-btn').click()
+
+    const modal2 = page.locator('.tiny-modal__box').filter({ hasText: '关闭前确认Num.2' })
+    await expect(modal2).toBeVisible()
+
+    // 拦截弹窗取消 → 保留原弹窗
+    await modal2.getByRole('button', { name: '取消' }).click()
+    await expect(modal2).not.toBeVisible()
+    await expect(modal1).toBeVisible()
+
+    // 默认 footer 取消按钮直接关闭
+    await modal1.getByRole('button', { name: '确定' }).click()
+    await expect(modal1).not.toBeVisible()
+  })
+
+  //  场景5：自定义footer弹窗 -> 右上角X -> 函数式拦截弹窗确认 -> 关闭
+  await test.step('自定义footer弹窗：右上角X触发 beforeClose，拦截弹窗确认后关闭', async () => {
+    await page.getByRole('button', { name: '其他' }).click()
+
+    const modal1 = page.locator('.tiny-modal__box').filter({ hasText: 'Num.1确认按钮加拦截弹窗' })
+    await expect(modal1).toBeVisible()
+
+    // 右上角关闭按钮触发 beforeClose1
+    await modal1.locator('.tiny-modal__close-btn').click()
+
+    const modal2 = page.locator('.tiny-modal__box').filter({ hasText: '关闭前确认Num.2' })
+    await expect(modal2).toBeVisible()
+
+    await expect(modal1).toBeVisible()
+
+    await modal2.getByRole('button', { name: '确定' }).click()
+    await expect(modal2).not.toBeVisible()
+    await expect(modal1).not.toBeVisible()
+  })
+
+  //  场景6：自定义footer弹窗 -> 点"确定" -> 函数式拦截弹窗确认 -> 关闭
+  await test.step('自定义footer弹窗：点击确定触发 beforeClose，拦截弹窗确认后关闭', async () => {
+    await page.getByRole('button', { name: '其他' }).click()
+
+    const modal1 = page.locator('.tiny-modal__box').filter({ hasText: 'Num.1确认按钮加拦截弹窗' })
+    await expect(modal1).toBeVisible()
+
+    // 点击自定义 footer 的"确定"按钮 -> 触发 beforeClose1
+    await modal1.getByRole('button', { name: '确定' }).click()
+
+    const modal2 = page.locator('.tiny-modal__box').filter({ hasText: '关闭前确认Num.2' })
+    await expect(modal2).toBeVisible()
+
+    await expect(modal1).toBeVisible()
+
+    // 拦截弹窗确认 -> 关闭所有
+    await modal2.getByRole('button', { name: '确定' }).click()
+    await expect(modal2).not.toBeVisible()
+    await expect(modal1).not.toBeVisible()
+  })
+
+  //  场景7：函数式弹窗关闭 -> 函数式拦截弹窗确认 -> 全部关闭
+  await test.step('函数式弹窗：关闭触发 beforeClose，拦截弹窗确认后全部关闭', async () => {
+    await page.getByRole('button', { name: '函数式弹窗1' }).click()
+
+    const modal1 = page.locator('.tiny-modal__box').filter({ hasText: '函数式弹窗Num.1' })
+    await expect(modal1).toBeVisible()
+
+    await modal1.locator('.tiny-modal__close-btn').click()
+
+    const modal2 = page.locator('.tiny-modal__box').filter({ hasText: '关闭前确认Num.2' })
+    await expect(modal2).toBeVisible()
+
+    await expect(modal1).toBeVisible()
+
+    await modal2.getByRole('button', { name: '确定' }).click()
+    await expect(modal2).not.toBeVisible()
+    await expect(modal1).not.toBeVisible()
+  })
+})

--- a/examples/sites/demos/pc/app/modal/before-close.vue
+++ b/examples/sites/demos/pc/app/modal/before-close.vue
@@ -1,9 +1,41 @@
 <template>
   <div>
+    <h2>函数式调用：</h2>
+    <div class="content">
+      <tiny-button @click="messageClick"> 函数式弹窗1 </tiny-button>
+    </div>
+
+    <h2>标签式调用</h2>
+    <div class="content">
+      <!-- 1：所有关闭操作都触发 beforeClose -->
+      <tiny-modal
+        v-model="mainVisible"
+        :width="600"
+        :height="300"
+        :before-close="handleBeforeClose"
+        title="Num.1标签式弹窗"
+        message="NO.1标签式内容"
+        show-footer
+      >
+      </tiny-modal>
+
+      <!-- 2：关闭前确认弹窗 -->
+      <tiny-modal
+        v-model="confirmVisible"
+        title="Num.2弹窗关闭前确认"
+        message="NO.2---确定要关闭NO.1窗口吗？未保存的内容将丢失。"
+        @confirm="onConfirmClose"
+        @cancel="onCancelClose"
+        show-footer
+      >
+      </tiny-modal>
+      <tiny-button @click="mainVisible = true"> 标签式弹窗</tiny-button>
+    </div>
+
     <h2>标签式 + 函数调用</h2>
     <div class="content">
       <tiny-modal
-        v-model="mainVisible"
+        v-model="mainVisible2"
         :width="600"
         :height="300"
         :before-close="handleBeforeClose1"
@@ -12,7 +44,7 @@
         show-footer
       >
       </tiny-modal>
-      <tiny-button @click="mainVisible = true"> 标签式 + 函数式弹窗</tiny-button>
+      <tiny-button @click="mainVisible2 = true"> 标签式 + 函数式弹窗</tiny-button>
     </div>
 
     <h2>点击确认按钮 + 拦截弹窗</h2>
@@ -48,6 +80,7 @@ export default {
     return {
       mainVisible: false,
       mainVisible1: false,
+      mainVisible2: false,
       confirmVisible: false,
       pendingDone: null
     }
@@ -69,6 +102,28 @@ export default {
     onCancelClose() {
       this.confirmVisible = false
       this.pendingDone = null // 不调用 done()，原弹窗保持打开
+    },
+
+    // 函数式调用：
+    messageClick() {
+      Modal.confirm({
+        message: 'Num.1函数式弹窗内容',
+        title: '函数式弹窗Num.1',
+        status: 'warning',
+        width: '600',
+        height: '300',
+        beforeClose: (type, instance, done) => {
+          Modal.confirm({
+            title: '关闭前确认Num.2',
+            message: '确认弹窗关闭Num.1？',
+            events: {
+              confirm: () => done && done(), // 确认 -> 关闭所有弹窗
+              cancel: () => {} // 取消 -> 保留原弹窗
+            }
+          })
+          return false
+        }
+      })
     },
 
     handleBeforeClose1(type, instance, done) {

--- a/examples/sites/demos/pc/app/modal/modal-event.spec.ts
+++ b/examples/sites/demos/pc/app/modal/modal-event.spec.ts
@@ -11,5 +11,5 @@ test('弹窗的事件', async ({ page }) => {
   await page.getByRole('button', { name: '打开带事件弹窗' }).nth(1).click()
   await page.getByRole('button', { name: '确定' }).click()
   await expect(content.nth(2)).toHaveText(/hide 事件触发了/)
-  await expect(content.nth(1)).toHaveText(/confirm 事件触发了/)
+  await expect(content.nth(2)).toHaveText(/confirm 事件触发了/)
 })

--- a/examples/sites/demos/pc/app/modal/webdoc/modal.js
+++ b/examples/sites/demos/pc/app/modal/webdoc/modal.js
@@ -68,7 +68,20 @@ export default {
       },
       codeFiles: ['status.vue']
     },
-
+    {
+      demoId: 'before-close',
+      name: {
+        'zh-CN': '关闭前的回调',
+        'en-US': 'Callback before closing'
+      },
+      desc: {
+        'zh-CN':
+          '通过<code>before-close</code>属性设置关闭前的回调函数（仅点击关闭按钮或遮罩区域时被调用），函数入参有<code>type</code>弹窗类型、<code>instance</code>弹窗实例、<code>done</code>回调函数。',
+        'en-US':
+          'Use the <code>before-close</code> property to set the callback function before closing (only called when clicking the close button or the mask area of the dialog), the function parameters include <code>type</code> pop-up type, <code>instance</code> pop-up instance, and <code>done</code> callback function.'
+      },
+      codeFiles: ['before-close.vue']
+    },
     {
       demoId: 'modal-header',
       name: {

--- a/packages/renderless/src/modal/index.ts
+++ b/packages/renderless/src/modal/index.ts
@@ -75,10 +75,11 @@ export const computedBoxStyle =
     return { width, height }
   }
 
+// ========== watchValue 直接调用 doClose，不再触发 beforeClose ==========
 export const watchValue =
   (api: IModalApi) =>
   (visible: boolean): void =>
-    visible ? api.open() : api.close('hide')
+    visible ? api.open() : api.doClose('hide')
 
 export const watchVisible =
   ({ api, props }) =>
@@ -178,24 +179,52 @@ export const updateZindex =
     state.modalZindex = props.zIndex || PopupManager.nextZIndex()
   }
 
-export const handleEvent =
+// 新增：执行实际关闭逻辑（动画 + emit hide）此方法不触发 beforeClose，用于程序内部直接关闭
+export const doClose =
+  ({ emit, parent, props, state }: Pick<IModalRenderlessParams, 'emit' | 'parent' | 'props' | 'state'>) =>
+  (type: string): void => {
+    // 如果已经在关闭动画中，直接返回，防止重复触发
+    if (state.isClosingAnimation) {
+      return
+    }
+    state.isClosingAnimation = true
+
+    let { events = {} } = parent
+    state.emitter.emit('boxclose', props.isFormReset)
+
+    if (state.visible) {
+      state.contentVisible = false
+      setTimeout(() => {
+        state.visible = false
+        let params = { type, $modal: parent }
+        if (events.hide) {
+          events.hide.call(parent, params)
+        } else {
+          emit('update:modelValue', false)
+          emit('hide', params)
+        }
+        // 关闭动画完成后清理所有标记
+        state.isClosingAnimation = false
+        state.isClosing = false
+        state.beforeCloseDoneCalled = false
+      }, 150)
+    } else {
+      // 如果已经不可见，直接清理标记
+      state.isClosingAnimation = false
+      state.isClosing = false
+      state.beforeCloseDoneCalled = false
+    }
+  }
+
+// 先执行 doClose 开始关闭动画，然后异步执行 events 回调
+export const doEmitAndClose =
   ({
     api,
     emit,
     parent,
-    props,
     isMobileFirstMode
-  }: Pick<IModalRenderlessParams, 'api' | 'emit' | 'parent' | 'props' | 'isMobileFirstMode'>) =>
-  (type: string, event: Event, options?: any[]) => {
-    // close,confirm,cancel
-    if (
-      ~['close', 'confirm', 'cancel'].indexOf(type) &&
-      typeof props.beforeClose === 'function' &&
-      props.beforeClose(type) === false
-    ) {
-      return
-    }
-
+  }: Pick<IModalRenderlessParams, 'api' | 'emit' | 'parent' | 'isMobileFirstMode'>) =>
+  (type: string, event?: Event, options?: any[]): void => {
     const { events = {} } = parent
 
     const params: IModalEmitParam = {
@@ -207,9 +236,87 @@ export const handleEvent =
       params.options = options
     }
 
+    // 先 emit Vue 事件
     emit(type, params, event)
-    events[type] && events[type].call(parent, params)
-    api.close(type)
+
+    // 立即开始关闭动画
+    api.doClose(type)
+
+    setTimeout(() => {
+      events[type] && events[type].call(parent, params)
+    }, 0)
+  }
+
+// 新增：统一的 beforeClose 处理逻辑
+export const runBeforeClose =
+  ({ api, props, state }: Pick<IModalRenderlessParams, 'api' | 'props' | 'state'>) =>
+  async (type: string, onConfirm: () => void): Promise<boolean> => {
+    // confirm 和 cancel 不触发 beforeClose，直接允许关闭
+    if (type === 'confirm' || type === 'cancel') {
+      return true
+    }
+
+    if (typeof props.beforeClose !== 'function') {
+      return true
+    }
+
+    // 如果 done() 已经被调用过，说明关闭流程已确认，直接执行
+    if (state.beforeCloseDoneCalled) {
+      return true
+    }
+
+    const done = () => {
+      state.beforeCloseDoneCalled = true
+      onConfirm()
+    }
+
+    const result = props.beforeClose(type, api.getBox ? api.getBox() : null, done)
+
+    // 处理 Promise 返回值
+    if (result && typeof result.then === 'function') {
+      try {
+        const shouldClose = await result
+        return shouldClose !== false
+      } catch (e) {
+        return false
+      }
+    }
+
+    // 处理同步返回值
+    if (result === false) {
+      return false
+    }
+
+    return true
+  }
+
+// 修改后的 handleEvent —— 按钮触发（close/confirm/cancel）
+export const handleEvent =
+  ({ api, state }: Pick<IModalRenderlessParams, 'api' | 'state'>) =>
+  async (type: string, event: Event, options?: any[]) => {
+    // confirm 和 cancel 直接关闭，不触发 beforeClose
+    if (type === 'confirm' || type === 'cancel') {
+      api.doEmitAndClose(type, event, options)
+      return
+    }
+
+    // close 触发 beforeClose
+    if (state.isClosing) {
+      return
+    }
+
+    state.isClosing = true
+
+    const shouldClose = await api.runBeforeClose(type, () => {
+      api.doEmitAndClose(type, event, options)
+    })
+
+    if (shouldClose) {
+      api.doEmitAndClose(type, event, options)
+    } else {
+      // beforeClose 返回 false，清理标记
+      state.isClosing = false
+    }
   }
 
 export const closeEvent =
@@ -353,34 +460,36 @@ export const updateStyle =
     })
   }
 
+// 修改后的 close —— 非按钮触发（esc/mask/hide/timer）
 export const close =
-  ({ emit, parent, props, state }: Pick<IModalRenderlessParams, 'emit' | 'parent' | 'props' | 'state'>) =>
-  (type: string): void => {
-    // esc,hide,mask,show,...
-    if (
-      !~['close', 'confirm', 'cancel'].indexOf(type) &&
-      typeof props.beforeClose === 'function' &&
-      props.beforeClose(type) === false
-    ) {
+  ({ api, state }: Pick<IModalRenderlessParams, 'api' | 'state'>) =>
+  async (type: string): Promise<void> => {
+    // 如果 done() 已经被调用过，直接执行关闭，不再触发 beforeClose
+    if (state.beforeCloseDoneCalled) {
+      api.doClose(type)
       return
     }
 
-    let { events = {} } = parent
+    // 如果正在关闭动画中，直接返回
+    if (state.isClosingAnimation) {
+      return
+    }
 
-    state.emitter.emit('boxclose', props.isFormReset)
+    // 如果正在关闭流程中，阻止重复触发
+    if (state.isClosing) {
+      return
+    }
 
-    if (state.visible) {
-      state.contentVisible = false
-      setTimeout(() => {
-        state.visible = false
-        let params = { type, $modal: parent }
-        if (events.hide) {
-          events.hide.call(parent, params)
-        } else {
-          emit('update:modelValue', false)
-          emit('hide', params)
-        }
-      }, 400)
+    state.isClosing = true
+
+    const shouldClose = await api.runBeforeClose(type, () => {
+      api.doClose(type)
+    })
+
+    if (shouldClose) {
+      api.doClose(type)
+    } else {
+      state.isClosing = false
     }
   }
 
@@ -388,7 +497,7 @@ export const handleGlobalKeydownEvent =
   (api: IModalApi) =>
   (event: KeyboardEvent): void => {
     if (event.keyCode === KEY_CODE.Escape) {
-      api.close('esc')
+      api.doClose('esc')
     }
   }
 
@@ -914,11 +1023,11 @@ export const showScrollbar = (lockScrollClass) => () => {
   addClass(document.body, lockScrollClass)
 }
 
-export const hideScrollbar = (lockScrollClass) => () => {
+export const hideScrollbar = (lockScrollClass) => (): void => {
   removeClass(document.body, lockScrollClass)
 }
 
-export const resetModalViewPosition = (api: IModalApi) => () => {
+export const resetModalViewPosition = (api: IModalApi) => (): void => {
   const modalBoxElement = api.getBox()
   const viewportWindow = getViewportWindow()
   const clientVisibleWidth =

--- a/packages/renderless/src/modal/index.ts
+++ b/packages/renderless/src/modal/index.ts
@@ -311,7 +311,7 @@ export const handleEvent =
       api.doEmitAndClose(type, event, options)
     })
 
-    if (shouldClose) {
+    if (shouldClose && !state.beforeCloseDoneCalled) {
       api.doEmitAndClose(type, event, options)
     } else {
       // beforeClose 返回 false，清理标记
@@ -486,7 +486,7 @@ export const close =
       api.doClose(type)
     })
 
-    if (shouldClose) {
+    if (shouldClose && !state.beforeCloseDoneCalled) {
       api.doClose(type)
     } else {
       state.isClosing = false

--- a/packages/renderless/src/modal/vue.ts
+++ b/packages/renderless/src/modal/vue.ts
@@ -42,7 +42,10 @@ import {
   handleHashChange,
   showScrollbar,
   hideScrollbar,
-  watchVisible
+  watchVisible,
+  doClose,
+  doEmitAndClose,
+  runBeforeClose
 } from './index'
 import { nanoid } from '@opentiny/utils'
 import type { IModalApi, IModalProps, IModalRenderlessParamUtils, ISharedRenderlessParamHooks } from '@/types'
@@ -67,7 +70,10 @@ export const api = [
   'open',
   'beforeUnmouted',
   'resetDragStyle',
-  'resetModalViewPosition'
+  'resetModalViewPosition',
+  'doClose',
+  'doEmitAndClose',
+  'runBeforeClose'
 ]
 
 export const renderless = (
@@ -93,7 +99,11 @@ export const renderless = (
     options: [],
     theme: props.tiny_theme,
     boxStyle: computed(() => api.computedBoxStyle()),
-    timer: 0
+    timer: 0,
+    // 新增状态标记
+    isClosing: false,
+    isClosingAnimation: false,
+    beforeCloseDoneCalled: false
   })
 
   Object.assign(api, {
@@ -110,14 +120,14 @@ export const renderless = (
     mouseEnterEvent: mouseEnterEvent(state),
     mouseLeaveEvent: mouseLeaveEvent({ api, props, state }),
     updateZindex: updateZindex({ state, props }),
-    handleEvent: handleEvent({ api, emit, parent, props, isMobileFirstMode }),
+    handleEvent: handleEvent({ api, state }),
     closeEvent: closeEvent(api),
     confirmEvent: confirmEvent({ api, state }),
     cancelEvent: cancelEvent(api),
     open: open({ api, emit, nextTick, parent, props, state, isMobileFirstMode }),
     addMsgQueue: addMsgQueue({ api, parent }),
     removeMsgQueue: removeMsgQueue({ api, parent }),
-    close: close({ emit, parent, props, state }),
+    close: close({ api, state }),
     handleGlobalKeydownEvent: handleGlobalKeydownEvent(api),
     handleHashChange: handleHashChange(api),
     maximize: maximize({ api, nextTick, props, state, isMobileFirstMode }),
@@ -130,7 +140,10 @@ export const renderless = (
     computedBoxStyle: computedBoxStyle({ props, isMobileFirstMode }),
     watchVisible: watchVisible({ api, props }),
     hideScrollbar: hideScrollbar(lockScrollClass),
-    showScrollbar: showScrollbar(lockScrollClass)
+    showScrollbar: showScrollbar(lockScrollClass),
+    doClose: doClose({ emit, parent, props, state }),
+    doEmitAndClose: doEmitAndClose({ api, emit, parent, props, state, isMobileFirstMode }),
+    runBeforeClose: runBeforeClose({ api, props, state })
   })
 
   watch(() => props.modelValue, api.watchValue)


### PR DESCRIPTION
# PR
效果1：
<img width="1817" height="856" alt="before-close1" src="https://github.com/user-attachments/assets/b8b45507-76ce-4190-8dd4-222bbd95100a" />

效果2：
<img width="1817" height="856" alt="before-close00" src="https://github.com/user-attachments/assets/e4ef749b-6044-4341-85eb-d63f43a7bf46" />



## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:
新增before-close属性，设置关闭前的回调函数（仅点击关闭按钮或遮罩区域时被调用）
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2189

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated before-close API descriptions with clearer callback guidance (zh-CN and en-US).

* **New Features**
  * Added interactive demos showing before-close interception patterns on PC and mobile-first demos.

* **Behavior Changes**
  * Improved modal before-close flow and Escape/close handling for more consistent confirmation interactions.

* **Tests**
  * Added end-to-end tests validating multiple before-close closure workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/tiny-vue/pull/4204)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->