### PR TITLE
fix(form-item): solve the problem that the size attribute of the button in the form component does not take effect

### DIFF
--- a/packages/vue/src/form-item/src/pc.vue
+++ b/packages/vue/src/form-item/src/pc.vue
@@ -185,7 +185,7 @@ export default defineComponent({
           }
 
           Object.assign(item.props, {
-            size: state.formItemSize,
+            size: state.formItemSize || item.props.size,
             mini: state.formItemSize === 'mini' || Boolean(item.props.mini)
           })
 


### PR DESCRIPTION
…ton in the form component does not take effect

# PR

修改 form-item 中包含的button的size属性不生效. 
原来： button的size会丢失， 
修改后： 优先级form-item的size  >  button.size   

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form item size property assignment with proper fallback handling to ensure correct sizing when default values are not explicitly set.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/tiny-vue/pull/4206)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->