### PR TITLE
fix(vue-renderless/fluent-editor): Fix lineheight formatting to use '…

### DIFF
--- a/packages/renderless/src/fluent-editor/index.ts
+++ b/packages/renderless/src/fluent-editor/index.ts
@@ -291,7 +291,7 @@ export const redoHandler =
 export const lineheightHandler =
   ({ state, FluentEditor }) =>
   (value) => {
-    state.quill.format('lineheight', value, FluentEditor.sources.USER)
+    state.quill.format('line-height', value, FluentEditor.sources.USER)
   }
 
 export const fileHandler =


### PR DESCRIPTION
Fix the issue where the line height setting for the rich text editor does not take effect

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

[<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->](https://github.com/opentiny/tiny-vue/issues/4211)

Issue Number: 4211

## What is the new behavior?
Fix the bug
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed line height formatting functionality to apply correctly when adjusting text line heights.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/tiny-vue/pull/4212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->