### PR TITLE
fix: add getStateSelection api for old code

### DIFF
--- a/packages/vue/src/grid/src/table/src/methods.ts
+++ b/packages/vue/src/grid/src/table/src/methods.ts
@@ -2179,8 +2179,14 @@ const Methods = {
 
     return columnIds.join(',')
   },
-  // 获取所有多选数据状态
+  /** 获取所有多选数据状态, Tiny 规范后的名字 */
   getAllSelection() {
+    return this.selection
+  },
+  /** 获取所有多选数据状态的历史名字，仅用于兼容老代码。
+   * @deprecated
+   * */
+  getStateSelection() {
     return this.selection
   },
   // 尝试恢复滚动位置，规范了最大滚动位置的取值


### PR DESCRIPTION
# PR
grid重构后， getStateSelection 改为了 getAllSelection。  为了兼容旧代码，恢复getStateSelection 的名字，   v81,v91
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * Added deprecated selection method for backward compatibility with previous versions; standard selection method remains the recommended approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/tiny-vue/pull/4214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->