### PR TITLE
fix: the table height remains unchanged when modifying maxheight

### DIFF
--- a/packages/vue/src/grid/src/table/src/methods.ts
+++ b/packages/vue/src/grid/src/table/src/methods.ts
@@ -1184,6 +1184,8 @@ const Methods = {
     if (!_tableVisible) {
       return
     }
+    // 先更新 bodyWrapperMaxHeight，minHeight/height,确保之后用新值
+    this.updateStyle()
 
     if (!bodyWrapper) {
       return this.computeScrollLoad()

--- a/packages/vue/src/grid/src/table/src/table.ts
+++ b/packages/vue/src/grid/src/table/src/table.ts
@@ -531,6 +531,12 @@ export default defineComponent({
     height() {
       this.$nextTick(this.recalculate)
     },
+    maxHeight() {
+      this.$nextTick(this.recalculate)
+    },
+    minHeight() {
+      this.$nextTick(this.recalculate)
+    },
     syncResize(value) {
       // 是否自动根据状态属性去更新响应式表格宽高
       value && this.$nextTick(this.recalculate)


### PR DESCRIPTION
# PR
表格max高度响应变化   v81,91
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Grid table layout now properly recalculates when `maxHeight` and `minHeight` properties change, ensuring responsive behavior with dynamic height constraints.
  * Optimized style and layout update timing to occur earlier in the recalculation process for improved rendering consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/tiny-vue/pull/4216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->