### PR TITLE
fix(grid): fix the issue where table rows occasionally become out of order after dragging

### DIFF
--- a/packages/vue/src/grid/src/dragger/src/rowDrop.ts
+++ b/packages/vue/src/grid/src/dragger/src/rowDrop.ts
@@ -76,6 +76,10 @@ export const createHandlerOnEnd = ({ _vm, refresh }) => {
       _vm.tableFullData = [].concat(tableTreeData)
     }
 
+    if (_vm.tableFullColumn) {
+      _vm.tableFullColumn.forEach((col) => col && (col.order = null))
+    }
+
     // 如果变动了树层级，需要刷新数据
     _vm.$emit('row-drop-end', event, _vm, _vm.scrollYLoad ? tableTreeData : _vm.tableFullData)
     refresh && _vm.rawData && _vm.refreshData(_vm.rawData)


### PR DESCRIPTION
修复表格行拖动后，偶尔会乱序的问题  v81

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed column ordering metadata not being properly reset after row drag-and-drop operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/tiny-vue/pull/4219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->