### PR TITLE
fix(vue-renderless/tab-nav): delay initial mounted to nextTick

### DIFF
--- a/packages/renderless/src/tab-nav/index.ts
+++ b/packages/renderless/src/tab-nav/index.ts
@@ -120,18 +120,21 @@ export const updated =
     }
   }
 
-export const mounted = ({ api, parent }: Pick<ITabNavRenderlessParams, 'api' | 'parent'>) => {
-  const el = parent.$refs.nav.$el
+export const mounted = ({ api, parent, nextTick }: Pick<ITabNavRenderlessParams, 'api' | 'parent' | 'nextTick'>) => {
+  // 等待 DOM 更新完成后再初始化，确保 nav 等 refs 已就绪，避免 scroll/sortable 等逻辑访问不到 DOM
+  nextTick(() => {
+    const el = parent.$refs.nav.$el
 
-  /* istanbul ignore next */
-  addResizeListener(el, api.updated)
-  on(document, 'visibilitychange', api.visibilityChangeHandler)
-  on(window, 'blur', api.windowBlurHandler)
-  on(window, 'focus', api.windowFocusHandler)
+    /* istanbul ignore next */
+    addResizeListener(el, api.updated)
+    on(document, 'visibilitychange', api.visibilityChangeHandler)
+    on(window, 'blur', api.windowBlurHandler)
+    on(window, 'focus', api.windowFocusHandler)
 
-  api.scrollToActiveTab()
-  api.scrollIntoView()
-  api.sortableEvent()
+    api.scrollToActiveTab()
+    api.scrollIntoView()
+    api.sortableEvent()
+  })
 }
 
 export const beforeUnmount = ({ api, parent }: Pick<ITabNavRenderlessParams, 'api' | 'parent'>) => {

--- a/packages/renderless/src/tab-nav/vue.ts
+++ b/packages/renderless/src/tab-nav/vue.ts
@@ -120,7 +120,7 @@ export const renderless = (
 
   Object.assign(api, { updated: updated({ api, vm, state }), changeTab: changeTab(api) })
   onUpdated(() => api.updated())
-  onMounted(() => nextTick(() => api.mounted({ api, parent })))
+  onMounted(() => api.mounted({ api, parent, nextTick }))
   onBeforeUnmount(() => api.beforeUnmount({ api, parent }))
 
   return api

--- a/packages/renderless/src/tab-nav/vue.ts
+++ b/packages/renderless/src/tab-nav/vue.ts
@@ -120,7 +120,7 @@ export const renderless = (
 
   Object.assign(api, { updated: updated({ api, vm, state }), changeTab: changeTab(api) })
   onUpdated(() => api.updated())
-  onMounted(() => api.mounted({ api, parent }))
+  onMounted(() => nextTick(() => api.mounted({ api, parent })))
   onBeforeUnmount(() => api.beforeUnmount({ api, parent }))
 
   return api


### PR DESCRIPTION
## PR

## PR Checklist

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

On first mount, `TabNav` may run the scroll calculation before DOM/layout is stable (active class and element sizes are not ready yet), so `scrollToActiveTab` can occasionally fail and the default active tab is not scrolled into view.
<a href="https://opentiny.design/vue-playground?mode=pc&theme=os#3.30|eyJzcmMvQXBwLnZ1ZSI6IjxzY3JpcHQgbGFuZz1cInRzeFwiPlxyXG4vLyDlvJXlhaUgQG9wZW50aW55L3Z1ZSDnu4Tku7ZcclxuaW1wb3J0IHsgQnV0dG9uLCBMaW5rIH0gZnJvbSAnQG9wZW50aW55L3Z1ZSdcclxuXHJcbmV4cG9ydCBkZWZhdWx0IHtcclxuICBjb21wb25lbnRzOiB7XHJcbiAgICBUaW55QnV0dG9uOiBCdXR0b24sXHJcbiAgICBUaW55TGluazogTGlua1xyXG4gIH0sXHJcbiAgZGF0YSgpIHtcclxuICAgIHJldHVybiB7XHJcbiAgICAgIG1zZzogJ2hlbGxvIHdvcmxkISdcclxuICAgIH1cclxuICB9XHJcbn1cclxuPC9zY3JpcHQ+XHJcblxyXG48dGVtcGxhdGU+XHJcbiAgPFRpbnlCdXR0b24+56Gu5a6aPC9UaW55QnV0dG9uPlxyXG4gIDxoMT57eyBtc2cgfX08L2gxPlxyXG4gIDxkaXYgY2xhc3M9XCJ0aW55dnVlXCI+XHJcbiAgICA8ZGl2IGNsYXNzPVwidGlueXZ1ZS1wYWdlXCI+XHJcbiAgICAgIHRpbnl2dWVcclxuICAgICAgPHRpbnktbGluayB0eXBlPVwic3VjY2Vzc1wiIGhyZWY9J2h0dHBzOi8vZ2l0aHViLmNvbS9vcGVudGlueS90aW55LXZ1ZSc+XHJcbiAgICAgICAgdGlueXZ1ZVxyXG4gICAgICA8L3RpbnktbGluaz5cclxuICAgIDwvZGl2PlxyXG4gIDwvZGl2PlxyXG48L3RlbXBsYXRlPlxyXG5cclxuPHN0eWxlIGxhbmc9XCJsZXNzXCIgc2NvcGVkPlxyXG4gIGgxe1xyXG4gICAgY29sb3I6IzVlN2NlMDtcclxuICB9XHJcbiAgLnRpbnl2dWV7XHJcbiAgICBmb250LXNpemU6IDE4eHA7XHJcbiAgICAmLXBhZ2V7XHJcbiAgICAgIGNvbG9yOiM1ZTdjZTA7XHJcbiAgICB9XHJcbiAgfVxyXG48L3N0eWxlPlxyXG4iLCJzcmMvIjoie1wiaW1wb3J0c1wiOntcInZ1ZVwiOlwiaHR0cHM6Ly9yZWdpc3RyeS5ucG1taXJyb3IuY29tL3Z1ZS8zLjQuMjcvZmlsZXMvZGlzdC92dWUucnVudGltZS5lc20tYnJvd3Nlci5qc1wiLFwiZWNoYXJ0c1wiOlwiaHR0cHM6Ly9yZWdpc3RyeS5ucG1taXJyb3IuY29tL2VjaGFydHMvNS40LjEvZmlsZXMvZGlzdC9lY2hhcnRzLmVzbS5qc1wiLFwiQHZ1ZS9jb21waWxlci1zZmNcIjpcImh0dHBzOi8vcmVnaXN0cnkubnBtbWlycm9yLmNvbS9AdnVlL2NvbXBpbGVyLXNmYy8zLjQuMjcvZmlsZXMvZGlzdC9jb21waWxlci1zZmMuZXNtLWJyb3dzZXIuanNcIixcIkBvcGVudGlueS92dWVcIjpcImh0dHBzOi8vcmVnaXN0cnkubnBtbWlycm9yLmNvbS9Ab3BlbnRpbnkvdnVlLXJ1bnRpbWUvMy4zMC9maWxlcy9kaXN0My90aW55LXZ1ZS1wYy5tanNcIixcIkBvcGVudGlueS92dWUtaWNvblwiOlwiaHR0cHM6Ly9yZWdpc3RyeS5ucG1taXJyb3IuY29tL0BvcGVudGlueS92dWUtcnVudGltZS8zLjMwL2ZpbGVzL2Rpc3QzL3RpbnktdnVlLWljb24ubWpzXCIsXCJAb3BlbnRpbnkvdnVlLWxvY2FsZVwiOlwiaHR0cHM6Ly9yZWdpc3RyeS5ucG1taXJyb3IuY29tL0BvcGVudGlueS92dWUtcnVudGltZS8zLjMwL2ZpbGVzL2Rpc3QzL3RpbnktdnVlLWxvY2FsZS5tanNcIixcIkBvcGVudGlueS92dWUtY29tbW9uXCI6XCJodHRwczovL3JlZ2lzdHJ5Lm5wbW1pcnJvci5jb20vQG9wZW50aW55L3Z1ZS1ydW50aW1lLzMuMzAvZmlsZXMvZGlzdDMvdGlueS12dWUtY29tbW9uLm1qc1wiLFwiQG9wZW50aW55L3Z1ZS1kaXJlY3RpdmVcIjpcImh0dHBzOi8vcmVnaXN0cnkubnBtbWlycm9yLmNvbS9Ab3BlbnRpbnkvdnVlLXJ1bnRpbWUvMy4zMC9maWxlcy9kaXN0My90aW55LXZ1ZS1kaXJlY3RpdmUubWpzXCIsXCJAb3BlbnRpbnkvdnVlLWh1aWNoYXJ0c1wiOlwiaHR0cHM6Ly9yZWdpc3RyeS5ucG1taXJyb3IuY29tL0BvcGVudGlueS92dWUtcnVudGltZS8zLjMwL2ZpbGVzL2Rpc3QzL3RpbnktdnVlLWh1aWNoYXJ0cy5tanNcIixcIkBvcGVudGlueS92dWUtdGhlbWUvXCI6XCJodHRwczovL3JlZ2lzdHJ5Lm5wbW1pcnJvci5jb20vQG9wZW50aW55L3Z1ZS10aGVtZS8zLjMwL2ZpbGVzL1wiLFwiQG9wZW50aW55L3Z1ZS10aGVtZS1tb2JpbGUvXCI6XCJodHRwczovL3JlZ2lzdHJ5Lm5wbW1pcnJvci5jb20vQG9wZW50aW55L3Z1ZS10aGVtZS1tb2JpbGUvMy4zMC9maWxlcy9cIixcIkBvcGVudGlueS92dWUtcmVuZGVybGVzcy9cIjpcImh0dHBzOi8vcmVnaXN0cnkubnBtbWlycm9yLmNvbS9Ab3BlbnRpbnkvdnVlLXJlbmRlcmxlc3MvMy4zMC9maWxlcy9cIixcInNvcnRhYmxlanNcIjpcImh0dHBzOi8vcmVnaXN0cnkubnBtbWlycm9yLmNvbS9zb3J0YWJsZWpzLzEuMTUuMC9maWxlcy9tb2R1bGFyL3NvcnRhYmxlLmVzbS5qc1wiLFwiQG9wZW50aW55L3Z1ZS1zZWFyY2gtYm94XCI6XCIvcGxheWdyb3VuZC9zaGltcy92dWUtc2VhcmNoLWJveC5tanNcIn19IiwidHNjb25maWcuanNvbiI6IntcclxuICBcImNvbXBpbGVyT3B0aW9uc1wiOiB7XHJcbiAgICBcImFsbG93SnNcIjogdHJ1ZSxcclxuICAgIFwiY2hlY2tKc1wiOiB0cnVlLFxyXG4gICAgXCJqc3hcIjogXCJwcmVzZXJ2ZVwiLFxyXG4gICAgXCJ0YXJnZXRcIjogXCJFU05leHRcIixcclxuICAgIFwibW9kdWxlXCI6IFwiRVNOZXh0XCIsXHJcbiAgICBcIm1vZHVsZVJlc29sdXRpb25cIjogXCJCdW5kbGVyXCIsXHJcbiAgICBcImFsbG93SW1wb3J0aW5nVHNFeHRlbnNpb25zXCI6IHRydWVcclxuICB9LFxyXG4gIFwidnVlQ29tcGlsZXJPcHRpb25zXCI6IHtcclxuICAgIFwidGFyZ2V0XCI6IDMuM1xyXG4gIH1cclxufVxyXG4iLCJzcmMvYmFzaWMtdXNhZ2UudnVlIjoiPHRlbXBsYXRlPlxuICA8dGlueS10YWJzIHYtbW9kZWw9XCJhY3RpdmVOYW1lXCI+XG4gICAgPHRpbnktdGFiLWl0ZW0gdGl0bGU9XCLooajljZXnu4Tku7ZcIiBuYW1lPVwiZmlyc3RcIj7ooajljZXnu4Tku7bvvIzlhbfmnInkuI7nlKjmiLfkuqTkupLvvIzlubblj6/lrozmiJDmlbDmja7ph4fpm4blip/og73nmoTmjqfku7bjgII8L3RpbnktdGFiLWl0ZW0+XG4gICAgPHRpbnktdGFiLWl0ZW0gdGl0bGU9XCLmlbDmja7nu4Tku7ZcIiBuYW1lPVwic2Vjb25kXCIgZGlzYWJsZWQ+XG4gICAgICDmlbDmja7nu4Tku7bvvIzmj5DkvpvkuobpnZ7luLjlvLrlpKfmlbDmja7ooajmoLzlip/og73vvIzlnKggR3JpZCDlj6/ku6XlsZXnpLrmlbDmja7liJfooajvvIzlj6/ku6Xlr7nmlbDmja7liJfooajov5vooYzpgInmi6njgIHnvJbovpHnrYnjgIJcbiAgICA8L3RpbnktdGFiLWl0ZW0+XG4gICAgPHRpbnktdGFiLWl0ZW0gdGl0bGU9XCLlr7zoiKrnu4Tku7ZcIiBuYW1lPVwidGhpcmRcIj7lr7zoiKrnu4Tku7bvvIzluK7liqnnvZHnq5norr/pl67ogIXmtY/op4jnq5nngrnnmoTnu4Tku7bjgII8L3RpbnktdGFiLWl0ZW0+XG4gICAgPHRpbnktdGFiLWl0ZW0gdGl0bGU9XCLkuJrliqHnu4Tku7ZcIiBuYW1lPVwiZm91cnRoXCI+5Lia5Yqh57uE5Lu277yM5LiO5Lia5Yqh57Sn5a+G55u45YWz5a6e546w5p+Q56eN5Lia5Yqh5Yqf6IO955qE57uE5Lu26ZuG44CCPC90aW55LXRhYi1pdGVtPlxuXG4gICAgPHRpbnktdGFiLWl0ZW0gdGl0bGU9XCLlsZXnpLrnu4Tku7ZcIiBuYW1lPVwiZmlmdGhcIj7lsZXnpLrnu4Tku7bvvIznlKjkuo7kv6Hmga/lsZXnpLrkuI7nirbmgIHlkYjnjrDjgII8L3RpbnktdGFiLWl0ZW0+XG4gICAgPHRpbnktdGFiLWl0ZW0gdGl0bGU9XCLlj43ppojnu4Tku7ZcIiBuYW1lPVwic2l4dGhcIj7lj43ppojnu4Tku7bvvIznlKjkuo7mtojmga/mj5DnpLrkuI7mk43kvZzlj43ppojjgII8L3RpbnktdGFiLWl0ZW0+XG4gICAgPHRpbnktdGFiLWl0ZW0gdGl0bGU9XCLluIPlsYDnu4Tku7ZcIiBuYW1lPVwic2V2ZW50aFwiPuW4g+WxgOe7hOS7tu+8jOeUqOS6jumhtemdoue7k+aehOS4juWMuuWfn+WIkuWIhuOAgjwvdGlueS10YWItaXRlbT5cbiAgICA8dGlueS10YWItaXRlbSB0aXRsZT1cIuWbvuihqOe7hOS7tlwiIG5hbWU9XCJlaWdodGhcIj7lm77ooajnu4Tku7bvvIznlKjkuo7mlbDmja7lj6/op4bljJblsZXnpLrjgII8L3RpbnktdGFiLWl0ZW0+XG4gICAgPHRpbnktdGFiLWl0ZW0gdGl0bGU9XCLlqpLkvZPnu4Tku7ZcIiBuYW1lPVwibmludGhcIj7lqpLkvZPnu4Tku7bvvIznlKjkuo7lm77niYcv6KeG6aKR562J5YaF5a655ZGI546w44CCPC90aW55LXRhYi1pdGVtPlxuICAgIDx0aW55LXRhYi1pdGVtIHRpdGxlPVwi6YCJ5LitdGFiXCIgbmFtZT1cInRlbnRoXCI+5pyq5rua5Yqo5Yiw6YCJ5LitdGFi5L2N572u44CCPC90aW55LXRhYi1pdGVtPlxuICA8L3RpbnktdGFicz5cbjwvdGVtcGxhdGU+XG5cbjxzY3JpcHQgc2V0dXAgbGFuZz1cImpzeFwiPlxuaW1wb3J0IHsgcmVmIH0gZnJvbSAndnVlJ1xuaW1wb3J0IHsgVGlueVRhYnMsIFRpbnlUYWJJdGVtIH0gZnJvbSAnQG9wZW50aW55L3Z1ZSdcblxuY29uc3QgYWN0aXZlTmFtZSA9IHJlZigndGVudGgnKVxuPC9zY3JpcHQ+XG5cbjxzdHlsZSBzY29wZWQ+XG4ucGMtZGVtbyAudGlueS10YWJzX19jb250ZW50IHtcbiAgbGluZS1oZWlnaHQ6IDI7XG59XG48L3N0eWxlPiIsIiI6IntcImltcG9ydHNcIjp7XCJ2dWVcIjpcImh0dHBzOi8vcmVnaXN0cnkubnBtbWlycm9yLmNvbS92dWUvMy40LjI3L2ZpbGVzL2Rpc3QvdnVlLnJ1bnRpbWUuZXNtLWJyb3dzZXIuanNcIixcImVjaGFydHNcIjpcImh0dHBzOi8vcmVnaXN0cnkubnBtbWlycm9yLmNvbS9lY2hhcnRzLzUuNC4xL2ZpbGVzL2Rpc3QvZWNoYXJ0cy5lc20uanNcIixcIkB2dWUvY29tcGlsZXItc2ZjXCI6XCJodHRwczovL3JlZ2lzdHJ5Lm5wbW1pcnJvci5jb20vQHZ1ZS9jb21waWxlci1zZmMvMy40LjI3L2ZpbGVzL2Rpc3QvY29tcGlsZXItc2ZjLmVzbS1icm93c2VyLmpzXCIsXCJAb3BlbnRpbnkvdnVlXCI6XCJodHRwczovL3JlZ2lzdHJ5Lm5wbW1pcnJvci5jb20vQG9wZW50aW55L3Z1ZS1ydW50aW1lLzMuMzAvZmlsZXMvZGlzdDMvdGlueS12dWUtcGMubWpzXCIsXCJAb3BlbnRpbnkvdnVlLWljb25cIjpcImh0dHBzOi8vcmVnaXN0cnkubnBtbWlycm9yLmNvbS9Ab3BlbnRpbnkvdnVlLXJ1bnRpbWUvMy4zMC9maWxlcy9kaXN0My90aW55LXZ1ZS1pY29uLm1qc1wiLFwiQG9wZW50aW55L3Z1ZS1sb2NhbGVcIjpcImh0dHBzOi8vcmVnaXN0cnkubnBtbWlycm9yLmNvbS9Ab3BlbnRpbnkvdnVlLXJ1bnRpbWUvMy4zMC9maWxlcy9kaXN0My90aW55LXZ1ZS1sb2NhbGUubWpzXCIsXCJAb3BlbnRpbnkvdnVlLWNvbW1vblwiOlwiaHR0cHM6Ly9yZWdpc3RyeS5ucG1taXJyb3IuY29tL0BvcGVudGlueS92dWUtcnVudGltZS8zLjMwL2ZpbGVzL2Rpc3QzL3RpbnktdnVlLWNvbW1vbi5tanNcIixcIkBvcGVudGlueS92dWUtZGlyZWN0aXZlXCI6XCJodHRwczovL3JlZ2lzdHJ5Lm5wbW1pcnJvci5jb20vQG9wZW50aW55L3Z1ZS1ydW50aW1lLzMuMzAvZmlsZXMvZGlzdDMvdGlueS12dWUtZGlyZWN0aXZlLm1qc1wiLFwiQG9wZW50aW55L3Z1ZS1odWljaGFydHNcIjpcImh0dHBzOi8vcmVnaXN0cnkubnBtbWlycm9yLmNvbS9Ab3BlbnRpbnkvdnVlLXJ1bnRpbWUvMy4zMC9maWxlcy9kaXN0My90aW55LXZ1ZS1odWljaGFydHMubWpzXCIsXCJAb3BlbnRpbnkvdnVlLXRoZW1lL1wiOlwiaHR0cHM6Ly9yZWdpc3RyeS5ucG1taXJyb3IuY29tL0BvcGVudGlueS92dWUtdGhlbWUvMy4zMC9maWxlcy9cIixcIkBvcGVudGlueS92dWUtdGhlbWUtbW9iaWxlL1wiOlwiaHR0cHM6Ly9yZWdpc3RyeS5ucG1taXJyb3IuY29tL0BvcGVudGlueS92dWUtdGhlbWUtbW9iaWxlLzMuMzAvZmlsZXMvXCIsXCJAb3BlbnRpbnkvdnVlLXJlbmRlcmxlc3MvXCI6XCJodHRwczovL3JlZ2lzdHJ5Lm5wbW1pcnJvci5jb20vQG9wZW50aW55L3Z1ZS1yZW5kZXJsZXNzLzMuMzAvZmlsZXMvXCIsXCJzb3J0YWJsZWpzXCI6XCJodHRwczovL3JlZ2lzdHJ5Lm5wbW1pcnJvci5jb20vc29ydGFibGVqcy8xLjE1LjAvZmlsZXMvbW9kdWxhci9zb3J0YWJsZS5lc20uanNcIixcIkBvcGVudGlueS92dWUtc2VhcmNoLWJveFwiOlwiL3BsYXlncm91bmQvc2hpbXMvdnVlLXNlYXJjaC1ib3gubWpzXCJ9fSIsIl9vIjp7fX0=">OpenTiny Playground</a>

Issue Number: N/A

## What is the new behavior?

Delay the initial `TabNav` mounted logic to `nextTick`, ensuring DOM/layout stabilizes before running `scrollToActiveTab`, so the default active tab can be scrolled into view more reliably.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- Scope: `vue-renderless/tab-nav`
- This change only delays the first mount handling by one tick.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tab navigation initialization timing so active tabs reliably scroll into view on load, initial visibility and focus behave correctly, and resize/interaction handling is stable during page mount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->