### PR TITLE
fix(space): remove  reference to fix Vue 3 console warning

### DIFF
--- a/packages/vue/src/space/src/mobile-first.vue
+++ b/packages/vue/src/space/src/mobile-first.vue
@@ -10,11 +10,9 @@ export default defineComponent({
     return setup({ props, context, renderless, api }) as unknown as ISpaceApi
   },
   render() {
-    const hFunc = (this as any).$createElement || h
-
     const children = this.orderedChildren?.length ? this.orderedChildren : this.$slots.default?.() || []
 
-    return hFunc(
+    return h(
       'div',
       {
         class: this.customClass,

--- a/packages/vue/src/space/src/pc.vue
+++ b/packages/vue/src/space/src/pc.vue
@@ -10,12 +10,10 @@ export default defineComponent({
     return setup({ props, context, renderless, api }) as unknown as ISpaceApi
   },
   render() {
-    const hFunc = (this as any).$createElement || h
-
     // 如果 renderless 层有 orderedChildren，就用它，否则 fallback 到默认 slot
     const children = this.orderedChildren?.length ? this.orderedChildren : this.$slots.default?.() || []
 
-    return hFunc(
+    return h(
       'div',
       {
         class: this.customClass,


### PR DESCRIPTION
## Problem

Fixes #4209

In Vue 3, `` is not defined on the component instance. Accessing it in the render function triggers a Vue warning:

```
[Vue warn]: Property "" was accessed during render but is not defined on instance.
  at <TinySpace>
```

## Root Cause

In `pc.vue` and `mobile-first.vue`, the render function uses:

```typescript
const hFunc = (this as any).$createElement || h
```

This attempts to access `this.$createElement` (a Vue 2 API) with a fallback to `h`. In Vue 3, even though the fallback works, the property access itself triggers the warning because Vue 3 detects the undefined property access during render.

## Solution

The `h` function is already imported from `@opentiny/vue-common`, which provides a **cross-version compatible render function** through the adapter layer:

- **Vue 3 adapter**: `h` wraps `hooks.h` with Vue 2-compatible parameter parsing
- **Vue 2 adapter**: `h` is `hooks.h` directly

Simply use `h` directly instead of the `` fallback pattern.

## Changes

- `packages/vue/src/space/src/pc.vue`: Remove `` reference, use `h` directly
- `packages/vue/src/space/src/mobile-first.vue`: Same change

## Testing

- No `` references remain in the Space component
- The `h` function from `@opentiny/vue-common` is the standard cross-version render function used throughout the project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal rendering implementation in Space component for improved code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/tiny-vue/pull/4222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->