### PR TITLE
fix(uploader): fix webkitGetAsEntry() return null cause error

### DIFF
--- a/packages/renderless/src/upload-dragger/index.ts
+++ b/packages/renderless/src/upload-dragger/index.ts
@@ -25,7 +25,10 @@ export const onDrop =
 
     const accept = state.uploader.accept
     let files = event.dataTransfer.files
-    const isDirectory = event.dataTransfer.items && event.dataTransfer.items[0].webkitGetAsEntry().isDirectory
+
+    // webkitGetAsEntry() 只支持本地文件，文件夹。 比如从邮箱拖入的场景，它一定返回null
+    const isDirectory =
+      (event.dataTransfer.items && event.dataTransfer.items[0].webkitGetAsEntry()?.isDirectory) || false
 
     state.uploadFiles = []
     state.dragover = false
@@ -100,10 +103,10 @@ async function readFiles(directory, state) {
 
     // 如果条目是文件，则将文件的信息添加到数组中
     if (entry.isFile) {
-      await new Promise((resolve) => {
+      await new Promise<void>((resolve) => {
         entry.file((file) => {
           state.uploadFiles.push(file)
-          resolve(void 0)
+          resolve()
         })
       })
     }


### PR DESCRIPTION
# PR
修复 webkitGetAsEntry() 返回Null时，控制台报错     v81，91
 
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved robustness of drag-drop file detection with enhanced error handling
  * Strengthened type safety in file processing operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->