### PR TITLE
fix(nav-menu):  fix the issue where before-skip returns false, but the component still updates its active state

### DIFF
--- a/packages/renderless/src/nav-menu/index.ts
+++ b/packages/renderless/src/nav-menu/index.ts
@@ -434,36 +434,57 @@ export const hidePopmenu = (api: INavMenuApi) => (item: menuItemType) => {
   }
 }
 
+const updateMenuSelectedState = (
+  state: INavMenuState,
+  api: INavMenuApi,
+  item: menuItemType,
+  index: number,
+  parentIndex: number
+): void => {
+  if (state.defaultActiveId) {
+    state.defaultActiveId = item.id
+    state.selectedIndex = -1
+  }
+  if (state.enterMenu) {
+    state.subIndex = -1
+    state.subItemSelectedIndex = -1
+    api.setActiveMenu(index)
+  }
+  if (state.enterMoreMenu) {
+    state.selectedIndex = -1
+    state.moreItemSelectedIndex = index
+  } else {
+    state.subItemSelectedIndex = index
+    state.subIndex = parentIndex
+  }
+}
+
 export const clickMenu =
   ({ api, props, state }: Pick<INavMenuRenderlessParams, 'api' | 'props' | 'state'>) =>
   (item: menuItemType, index: number, parentIndex: number): void => {
     if (index === undefined) {
       return
     }
-    if (state.defaultActiveId) {
-      state.defaultActiveId = item.id
-      state.selectedIndex = -1
-    }
-    if (state.enterMenu) {
-      state.subIndex = -1
-      state.subItemSelectedIndex = -1
-      api.setActiveMenu(index)
-    }
-    if (state.enterMoreMenu) {
-      state.selectedIndex = -1
-      state.moreItemSelectedIndex = index
-    } else {
-      state.subItemSelectedIndex = index
-      state.subIndex = parentIndex
-    }
     if (item.url || item.route) {
+      const canSkip = props.beforeSkip ? props.beforeSkip(item) : true
+
+      if (!canSkip) {
+        api.hideSubMenu()
+        return
+      }
+
+      updateMenuSelectedState(state, api, item, index, parentIndex)
+
       if (props.beforeSkip) {
-        props.beforeSkip(item) && api.skip(item, true)
+        api.skip(item, true)
       } else {
         api.skip(item, false)
       }
       api.hidePopmenu(item)
+      return
     }
+
+    updateMenuSelectedState(state, api, item, index, parentIndex)
   }
 
 export const skip =

--- a/packages/vue/src/nav-menu/__tests__/nav-menu.test.tsx
+++ b/packages/vue/src/nav-menu/__tests__/nav-menu.test.tsx
@@ -217,7 +217,24 @@ describe('PC Mode', () => {
     'overflow 设置一级菜单无法在当前菜单容器里显示完全时的处理策略。可选项有 auto / retract / fixed / hidden。默认为 auto'
   )
 
-  test.todo('before-skip 点击菜单跳转前的钩子函数，返回 false 将无法跳转')
+  test('before-skip 返回 false 时不更新激活状态', async () => {
+    const menuData = [
+      { title: '首页', url: '/overview', id: '1' },
+      { title: '其他', url: 'crop', id: '2' }
+    ]
+    const beforeSkip = () => false
+    const wrapper = mount(() => <NavMenu data={menuData} beforeSkip={beforeSkip}></NavMenu>)
+    const navMenu = wrapper.findComponent({ name: 'TinyNavMenu' })
+
+    navMenu.vm.setActiveMenu(0)
+    expect(navMenu.vm.state.selectedIndex).toBe(0)
+
+    navMenu.vm.clickMenu(navMenu.vm.state.data[1], 1)
+
+    expect(navMenu.vm.state.selectedIndex).toBe(0)
+    expect(navMenu.vm.state.subItemSelectedIndex).toBe(-1)
+    expect(navMenu.vm.state.moreItemSelectedIndex).toBe(-1)
+  })
 
   test.todo('fetch-menu-data 自定义菜单数据加载服务，返回一个Promise对象')
 


### PR DESCRIPTION
修复tiny-nav-menu组件即使 before-skip 返回 false ，组件内部还是会更新激活状态，导致点击的菜单项和原来的菜单项都显示为激活状态
 
<img width="787" height="488" alt="2026-06-04_061430" src="https://github.com/user-attachments/assets/32c75d72-128d-4ef3-bd7c-7dc6b5869464" />


# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4143

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
