### PR TITLE
fix(nav-menu): [nav-menu] fix the occasional issue of menu hiding when refreshing the page

### DIFF
--- a/packages/renderless/src/nav-menu/index.ts
+++ b/packages/renderless/src/nav-menu/index.ts
@@ -53,8 +53,10 @@ export const computedSubMenus = (state: INavMenuState) => (): menuItemType[] => 
 export const computedMenuStyle =
   ({ props, state }: Pick<INavMenuRenderlessParams, 'props' | 'state'>) =>
   (): Object => {
-    let result = {
-      maxWidth: `${state.width}px`
+    const result: Record<string, string> = {}
+
+    if (state.width >= 0) {
+      result.maxWidth = `${state.width}px`
     }
 
     if (props.overflow === 'retract') {
@@ -207,13 +209,18 @@ export const initData =
 export const mounted =
   ({
     api,
+    nextTick,
     props,
     router,
     route,
     state
-  }: Pick<INavMenuRenderlessParams, 'api' | 'props' | 'router' | 'route' | 'state'>) =>
+  }: Pick<INavMenuRenderlessParams, 'api' | 'nextTick' | 'props' | 'router' | 'route' | 'state'>) =>
   (): void => {
-    api.calcWidth()
+    nextTick(() => {
+      requestAnimationFrame(() => {
+        api.calcWidth()
+      })
+    })
 
     on(window, 'resize', api.calcWidth)
 
@@ -523,10 +530,21 @@ export const classify =
 export const calcWidth =
   ({ parent, props, state }: Pick<INavMenuRenderlessParams, 'parent' | 'props' | 'state'>) =>
   (): void => {
-    let el = parent.$el
-    let logoWidth = parent.$slots.logo ? el.querySelector('.slot-logo').offsetWidth : 0
-    let toolbarWidth = parent.$slots.toolbar ? el.querySelector('.slot-toolbar').offsetWidth : 0
-    let menuWidth = el.offsetWidth
+    const el = parent.$el
+
+    if (!el) {
+      return
+    }
+
+    const menuWidth = el.offsetWidth
+
+    // DOM 未就绪时不更新 width，避免误设为 0 导致菜单隐藏
+    if (!menuWidth && props.overflow !== 'retract') {
+      return
+    }
+
+    const logoWidth = parent.$slots.logo ? el.querySelector('.slot-logo')?.offsetWidth || 0 : 0
+    const toolbarWidth = parent.$slots.toolbar ? el.querySelector('.slot-toolbar')?.offsetWidth || 0 : 0
     let width = props.overflow === 'retract' ? 0 : menuWidth - toolbarWidth - logoWidth
 
     width = width - 90 // 预留更多的位置

--- a/packages/renderless/src/nav-menu/vue.ts
+++ b/packages/renderless/src/nav-menu/vue.ts
@@ -142,7 +142,7 @@ const initApi = ({ api, state, props, parent, fetchMenuData, fields, router, rou
     getPoint: getPoint({ api, parent }),
     clickMenu: clickMenu({ api, props, state }),
     unMounted: unMounted({ api, state, router }),
-    mounted: mounted({ api, props, router, route, state }),
+    mounted: mounted({ api, nextTick, props, router, route, state }),
     classify: classify({ api, props, state }),
     watchWidth: watchWidth({ api, nextTick }),
     willHideSubMenu: willHideSubMenu({ api, state }),

--- a/packages/vue/src/nav-menu/__tests__/nav-menu.test.tsx
+++ b/packages/vue/src/nav-menu/__tests__/nav-menu.test.tsx
@@ -237,4 +237,17 @@ describe('PC Mode', () => {
     const iconTotalSvg = wrapper.find('.slot-logo')
     expect(iconTotalSvg.exists()).toBeTruthy()
   })
+
+  test('should not hide menu with max-width 0px on mount', async () => {
+    const wrapper = mount(() => <NavMenu data={navMenuMockData}></NavMenu>)
+    await wrapper.vm.$nextTick()
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    const menu = wrapper.find('.menu')
+    expect(menu.exists()).toBeTruthy()
+    expect(menu.isVisible()).toBeTruthy()
+
+    const maxWidth = menu.element.style.maxWidth
+    expect(maxWidth).not.toBe('0px')
+  })
 })


### PR DESCRIPTION
修复TinyNavMenu 在页面刷新时偶尔隐藏的问题，问题表现为菜单 ul 被设置 max-width:0px，触发 window.resize 后恢复正常。

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4167 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation menu potentially displaying incorrectly or hiding unexpectedly on initial page load by improving width calculation timing and adding guards against DOM initialization issues.
  * Enhanced menu rendering behavior to ensure proper display during component mounting and layout readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->