### PR TITLE
fix: fix the issue where the menu cannot be collapsed due to the simultaneous activation of the attributes "menu-collapsible" and "width-adapt"

### DIFF
--- a/examples/sites/demos/pc/app/tree-menu/width-adapt.spec.ts
+++ b/examples/sites/demos/pc/app/tree-menu/width-adapt.spec.ts
@@ -9,5 +9,6 @@ test('宽度自适应', async ({ page }) => {
 
   const wrap = page.locator('#width-adapt')
   const treeMenu = wrap.locator('.tiny-tree-menu')
-  await expect(treeMenu).toHaveAttribute('style', 'width: 100%;')
+  await expect(treeMenu).toHaveClass(/is-width-adapt/)
+  await expect(treeMenu).not.toHaveAttribute('style', /width/)
 })

--- a/packages/theme-saas/src/tree-menu/index.less
+++ b/packages/theme-saas/src/tree-menu/index.less
@@ -36,6 +36,10 @@
     }
   }
 
+  &.is-width-adapt {
+    @apply w-full;
+  }
+
   &.is-collapsed {
     @apply w-0;
     .@{tree-menu-prefix-cls}__toggle-button {

--- a/packages/theme/src/tree-menu/index.less
+++ b/packages/theme/src/tree-menu/index.less
@@ -86,6 +86,10 @@
     }
   }
 
+  &.is-width-adapt {
+    width: 100%;
+  }
+
   &.is-collapsed {
     width: 0;
     .@{tree-menu-prefix-cls}__toggle-button {

--- a/packages/vue/src/tree-menu/src/pc.vue
+++ b/packages/vue/src/tree-menu/src/pc.vue
@@ -18,10 +18,10 @@
     :class="{
       'is-collapsed': state.isCollapsed,
       'is-expand': state.isExpand,
+      'is-width-adapt': widthAdapt,
       'tiny-tree-menu__show-filter': showFilter,
       'tiny-tree-menu__show-expand': showExpand
     }"
-    :style="widthAdapt ? { width: '100%' } : {}"
   >
     <div v-if="menuCollapsible" class="tiny-tree-menu__toggle-button" @click.stop="collapseChange">
       <icon-arrow></icon-arrow>


### PR DESCRIPTION
解决tiny-tree-menu 同时开启属性menu-collapsible width-adapt导致不能收起，width-adapt开启，样式设置width:100%,menu-collapsible收起的时候width:0,但是权重低于width:100%，导致没有生效

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3511 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Tree menu's width-adaptive behavior refactored to use CSS-based styling via the `is-width-adapt` class instead of inline style declarations.

* **Tests**
  * Updated width-adaptive tree menu tests to validate CSS class presence and absence of inline width style attributes instead of specific style values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->