### PR TITLE
fix(vue-renderless/file-upload): accept 支持 video/*、audio/* 通配符 (fixes #4237)

### DIFF
--- a/packages/renderless/src/file-upload/index.ts
+++ b/packages/renderless/src/file-upload/index.ts
@@ -206,9 +206,18 @@ const onBeforeIsPromise = ({
 }
 
 const isAcceptType = (acceptArray, file, constants, fileType) => {
+  // MIME 通配符（image/*、video/*、audio/*）需按扩展名白名单校验，
+  // 否则 type 里的 * 会被当作正则量词，导致 video/*、audio/* 无法匹配到对应文件
+  const mimeWildcardMap = {
+    [constants.IMAGE_TYPE]: constants.FILE_TYPE.PICTURE,
+    'video/*': constants.FILE_TYPE.VIDEO,
+    'audio/*': constants.FILE_TYPE.AUDIO
+  }
+
   return acceptArray.some((type) => {
-    if (type.toLowerCase() === constants.IMAGE_TYPE) {
-      return constants.FILE_TYPE.PICTURE.split('/').includes(fileType)
+    const whitelist = mimeWildcardMap[type.trim().toLowerCase()]
+    if (whitelist) {
+      return whitelist.split('/').includes(fileType)
     }
     return new RegExp(`(${type.trim()})$`, 'i').test(file.name)
   })

--- a/packages/vue/src/file-upload/__tests__/accept-type.test.ts
+++ b/packages/vue/src/file-upload/__tests__/accept-type.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test, vi } from 'vitest'
+import { beforeUpload } from '@opentiny/vue-renderless/file-upload'
+import { $constants as constants } from '../src/index'
+
+/**
+ * accept 使用 MIME 通配符（image/*、video/*、audio/*）时的校验。
+ * 修复 #4237：此前仅 image/* 走扩展名白名单，video/*、audio/* 会落入正则分支，
+ * 通配符 * 被当作正则量词，导致 mp4、mp3 等合法文件被误拦截。
+ */
+
+const t = (_key: string, params?: { format?: string }) =>
+  params?.format ? `格式（.${params.format}）暂不支持` : '暂不支持'
+
+type BeforeUploadOptions = Parameters<typeof beforeUpload>[0]
+
+const createUploadFn = (accept: string, modalMessage = vi.fn()) =>
+  beforeUpload({
+    props: { accept },
+    api: { handleRemove: vi.fn() },
+    Modal: { message: modalMessage },
+    constants,
+    t,
+    state: { isEdm: false, triggerClickType: '' }
+    // 单测仅构造 accept 校验所需的最小依赖，props/api/state 为部分 mock
+  } as BeforeUploadOptions)
+
+const makeFile = (name: string, type: string) => ({
+  name,
+  raw: new File([], name, { type })
+})
+
+describe('file-upload accept 通配符校验', () => {
+  test('accept=video/* 时 mp4 应通过校验并上传', () => {
+    const modalMessage = vi.fn()
+    const doUpload = vi.fn()
+
+    createUploadFn('video/*', modalMessage)(makeFile('测试.mp4', 'video/mp4'), false, doUpload)
+
+    expect(modalMessage).not.toHaveBeenCalled()
+    expect(doUpload).toHaveBeenCalled()
+  })
+
+  test('accept=video/* 时非视频文件仍应被拦截', () => {
+    const modalMessage = vi.fn()
+    const doUpload = vi.fn()
+
+    createUploadFn('video/*', modalMessage)(makeFile('测试.txt', 'text/plain'), false, doUpload)
+
+    expect(modalMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: '格式（.txt）暂不支持',
+        status: 'warning'
+      })
+    )
+    expect(doUpload).not.toHaveBeenCalled()
+  })
+
+  test('accept=audio/* 时 mp3 应通过校验并上传', () => {
+    const modalMessage = vi.fn()
+    const doUpload = vi.fn()
+
+    createUploadFn('audio/*', modalMessage)(makeFile('测试.mp3', 'audio/mpeg'), false, doUpload)
+
+    expect(modalMessage).not.toHaveBeenCalled()
+    expect(doUpload).toHaveBeenCalled()
+  })
+
+  test('对照：accept=image/* 时 jpg 可通过校验', () => {
+    const modalMessage = vi.fn()
+    const doUpload = vi.fn()
+
+    createUploadFn('image/*', modalMessage)(makeFile('测试.jpg', 'image/jpeg'), false, doUpload)
+
+    expect(modalMessage).not.toHaveBeenCalled()
+    expect(doUpload).toHaveBeenCalled()
+  })
+
+  test('对照：accept=.mp4 精确扩展名仍可通过校验', () => {
+    const modalMessage = vi.fn()
+    const doUpload = vi.fn()
+
+    createUploadFn('.mp4', modalMessage)(makeFile('测试.mp4', 'video/mp4'), false, doUpload)
+
+    expect(modalMessage).not.toHaveBeenCalled()
+    expect(doUpload).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
fixes #4237

isAcceptType 此前仅对 image/* 走扩展名白名单校验，video/*、audio/* 会落入 正则分支，其中的通配符 * 被当作正则量词，导致 mp4、mp3 等合法文件被误拦截。
改为统一的 MIME 通配符映射，复用 FILE_TYPE.VIDEO / FILE_TYPE.AUDIO 白名单。

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4237

## What is the new behavior?

accept="video/*" / audio/* 可正常上传对应格式文件

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file upload `accept` handling to correctly support MIME wildcards like `video/*` and `audio/*` (in addition to existing `image/*` support), ensuring only compatible files proceed and mismatches are blocked.

* **Tests**
  * Added automated tests covering `accept` wildcard acceptance/rejection for `video/*` and `audio/*`, plus existing `image/*` behavior and validation of exact extension `accept` values (e.g., `.mp4`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->