### PR TITLE
fix: modify the problem of lazy load root node not triggering in tree-menu component vue3

### DIFF
--- a/packages/renderless/src/tree-menu/index.ts
+++ b/packages/renderless/src/tree-menu/index.ts
@@ -15,6 +15,10 @@ import { xss } from '@opentiny/utils'
 export const initData =
   ({ state, props, service, api }: { state: ITreeMenuState; props: ITreeMenuProps; service: any; api: ITreeMenuApi }) =>
   async () => {
+    if (props.lazy) {
+      return
+    }
+
     if (props.data) {
       state.data = props.data
       return


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:
修复treeMenu组件，Vue3 Lazy Load 根节点不触发问题

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tree menus now respect lazy-loading settings during startup, preventing data from loading too early and keeping menu expansion behavior on demand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->