### PR TITLE
fix: base-select在清除时，hover-expand面板不隐藏收起按钮

### DIFF
--- a/packages/theme/src/base-select/index.less
+++ b/packages/theme/src/base-select/index.less
@@ -248,6 +248,10 @@
       top: 0;
       left: 0;
       right: 0;
+
+      &:hover {
+        z-index: 2;
+      }
     }
 
     &.is-hover {

--- a/packages/theme/src/select/index.less
+++ b/packages/theme/src/select/index.less
@@ -252,6 +252,10 @@
       top: 0;
       left: 0;
       right: 0;
+
+      &:hover {
+        z-index: 2;
+      }
     }
 
     &.is-hover {

--- a/packages/vue/src/base-select/src/pc.vue
+++ b/packages/vue/src/base-select/src/pc.vue
@@ -147,7 +147,7 @@
               <!-- 当非 showAllTextTag 时，原来的模式渲染 -->
               <template v-else>
                 <tiny-tag
-                  v-if="hoverExpand || (clickExpand && !state.showCollapseTag)"
+                  v-if="hoverExpand || clickExpand"
                   :class="[
                     'tiny-base-select__tags-collapse',
                     'cursor-pointer',


### PR DESCRIPTION
# PR
fix: 修复 base-select在清除时，hover-expand面板中的收起按钮不能隐藏的bug

fix: hover-expand面板悬浮时增加zindex值, 这样鼠标在哪个select中，哪个的面板更靠上



## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag stacking on hover so expanded select tags display more consistently above neighboring elements.
  * Updated the collapse indicator behavior so it appears correctly during click-expand interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->