### PR TITLE
fix(numeric): 移除numeric增减按钮z-index，解决表格内层级冲突问题

### DIFF
--- a/packages/theme/src/numeric/index.less
+++ b/packages/theme/src/numeric/index.less
@@ -103,7 +103,7 @@
   &__decrease,
   &__increase {
     position: absolute;
-    z-index: 1;
+    // z-index: 1; // 注释掉以防止层级冲突，会导致按钮遮挡其他元素
     top: 1px;
     width: var(--tv-Numeric-input-icon-width);
     height: calc(100% - 2px);


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Numeric 步进组件增减按钮自带 `z-index: 1`，当组件嵌入表格单元格内使用时，按钮层级上浮，会异常遮挡表格相邻单元格内容，产生UI层级冲突。

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
<img width="717" height="232" alt="76c882098bb6" src="https://github.com/user-attachments/assets/0f367df3-72d7-47b7-a477-ebe7b8709387" />

Issue Number: N/A

## What is the new behavior?
注释 `increase / decrease` 按钮样式中的 z-index 属性，不再主动抬高按钮层级，依靠正常定位文档流渲染，避免全局z-index互相污染，解决表格场景下按钮遮挡周边元素问题；
组件常规页面使用场景功能、视觉不受影响。
<img width="1677" height="559" alt="488cdc1ea02c" src="https://github.com/user-attachments/assets/0d03349b-b925-452a-a261-e8e878623ee6" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layering behavior for numeric input increase and decrease controls, helping prevent stacking-order conflicts with nearby interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->