### PR TITLE
feat(alert): [alert] add small and medium sizes

### DIFF
--- a/examples/sites/demos/apis/alert.js
+++ b/examples/sites/demos/apis/alert.js
@@ -119,7 +119,7 @@ export default {
             'zh-CN': '是否显示标题，在 size 为 large 时有效',
             'en-US': 'Whether to show title Only valid when size is large'
           },
-          mode: ['pc', 'mobile-first'],
+          mode: ['pc'],
           pcDemo: 'title',
           meta: {
             stable: '3.21.0'

--- a/examples/sites/demos/apis/alert.js
+++ b/examples/sites/demos/apis/alert.js
@@ -138,7 +138,8 @@ export default {
         },
         {
           name: 'size',
-          type: "'normal' | 'large'",
+          typeAnchorName: 'ISize',
+          type: 'ISize',
           defaultValue: "'normal'",
           desc: {
             'zh-CN': '警告的尺寸大小',
@@ -146,7 +147,7 @@ export default {
           },
           mode: ['pc', 'mobile-first'],
           pcDemo: 'size',
-          mfDemo: ''
+          mfDemo: 'size'
         },
         {
           name: 'title',
@@ -279,6 +280,13 @@ export default {
       type: 'type',
       code: `
 type IType = 'success' | 'warning' | 'info' | 'error' | 'simple'
+`
+    },
+    {
+      name: 'ISize',
+      type: 'type',
+      code: `
+type ISize = 'small' | 'medium' | 'normal' | 'large'
 `
     }
   ]

--- a/examples/sites/demos/mobile-first/app/alert/size.vue
+++ b/examples/sites/demos/mobile-first/app/alert/size.vue
@@ -1,7 +1,11 @@
 <template>
   <div>
+    <tiny-alert size="small" title="size 为 small" description="size 为 small"></tiny-alert>
+    <tiny-alert size="medium" title="size 为 medium" description="size 为 medium"></tiny-alert>
     <tiny-alert size="normal" description="size 为 normal"></tiny-alert>
-    <tiny-alert size="large" title="size 为 large"></tiny-alert>
+    <tiny-alert size="large" title="size 为 large">
+      <!-- <span>自定义内容</span> -->
+    </tiny-alert>
   </div>
 </template>
 

--- a/examples/sites/demos/mobile-first/app/alert/webdoc/alert.js
+++ b/examples/sites/demos/mobile-first/app/alert/webdoc/alert.js
@@ -18,13 +18,14 @@ export default {
     {
       demoId: 'size',
       name: {
-        'zh-CN': '大尺寸',
-        'en-US': 'Large size'
+        'zh-CN': '尺寸',
+        'en-US': 'Size'
       },
       desc: {
-        'zh-CN': '<p>通过 <code>size</code> 属性设置不同的尺寸，可选值：nomal、large，默认值：nomal 。</p>',
+        'zh-CN':
+          '<p>通过 <code>size</code> 设置不同的尺寸模式，可选值： <code>small</code> 、<code>medium</code> 、<code>normal</code> 、<code>large</code>。</p>',
         'en-US':
-          '<p>Use the <code>size</code> attribute to set different sizes. The options are nomal and large. The default value is nomal.</p>'
+          '<p>Set different size modes through<code>size</code>, with optional values:< code>small</code> 、<code>medium</code> 、<code>normal</code> 、<code>large</code>.</p>'
       },
       codeFiles: ['size.vue']
     },

--- a/examples/sites/demos/mobile-first/app/alert/webdoc/alert.js
+++ b/examples/sites/demos/mobile-first/app/alert/webdoc/alert.js
@@ -25,7 +25,7 @@ export default {
         'zh-CN':
           '<p>通过 <code>size</code> 设置不同的尺寸模式，可选值： <code>small</code> 、<code>medium</code> 、<code>normal</code> 、<code>large</code>。</p>',
         'en-US':
-          '<p>Set different size modes through<code>size</code>, with optional values:< code>small</code> 、<code>medium</code> 、<code>normal</code> 、<code>large</code>.</p>'
+          '<p>Set different size modes through<code>size</code>, with optional values:<code>small</code> 、<code>medium</code> 、<code>normal</code> 、<code>large</code>.</p>'
       },
       codeFiles: ['size.vue']
     },

--- a/examples/sites/demos/pc/app/alert/center.spec.ts
+++ b/examples/sites/demos/pc/app/alert/center.spec.ts
@@ -4,16 +4,14 @@ test('文字居中', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
   await page.goto('alert#center')
 
-  // 等待网络空闲，确保页面完全加载
-  await page.waitForLoadState('networkidle')
+  // 用文本"文字居中"精确过滤，限定在当前 demo
+  const alert = page.locator('.tiny-alert').filter({ hasText: '文字居中' })
 
-  const alert = page.locator('.tiny-alert')
-
-  // 首先验证基础类存在
+  // 验证基础类
   await expect(alert).toHaveClass(/tiny-alert--info/)
   await expect(alert).toHaveClass(/tiny-alert--normal/)
 
-  // 然后验证居中类
+  // 验证居中类
   await expect(alert).toHaveClass(/is-center/)
   await expect(alert).toHaveCSS('justify-content', 'center')
 })

--- a/examples/sites/demos/pc/app/alert/size-composition-api.vue
+++ b/examples/sites/demos/pc/app/alert/size-composition-api.vue
@@ -1,5 +1,7 @@
 <template>
   <div>
+    <tiny-alert size="small" title="size 为 small" description="size 为 small"></tiny-alert>
+    <tiny-alert size="medium" title="size 为 medium" description="size 为 medium"></tiny-alert>
     <tiny-alert size="normal" description="size 为 normal"></tiny-alert>
     <tiny-alert size="large" title="size 为 large" description="size 为 large"></tiny-alert>
   </div>

--- a/examples/sites/demos/pc/app/alert/size.spec.ts
+++ b/examples/sites/demos/pc/app/alert/size.spec.ts
@@ -4,6 +4,37 @@ test('尺寸', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
   await page.goto('alert#size')
 
-  const largeAlert = page.locator('.tiny-alert').nth(1)
+  // 用文本过滤，精确锁定 size demo 里的 4 个 alert
+  const smallAlert = page.locator('.tiny-alert').filter({ hasText: 'size 为 small' })
+  const mediumAlert = page.locator('.tiny-alert').filter({ hasText: 'size 为 medium' })
+  const normalAlert = page.locator('.tiny-alert').filter({ hasText: 'size 为 normal' })
+  const largeAlert = page.locator('.tiny-alert').filter({ hasText: 'size 为 large' })
+
+  // 1. 验证各尺寸类名
+  await expect(smallAlert).toHaveClass(/tiny-alert--small/)
+  await expect(mediumAlert).toHaveClass(/tiny-alert--medium/)
+  await expect(normalAlert).toHaveClass(/tiny-alert--normal/)
   await expect(largeAlert).toHaveClass(/tiny-alert--large/)
+
+  // 2. 验证 small / medium 的 padding
+  await expect(smallAlert).toHaveCSS('padding-top', '2px')
+  await expect(smallAlert).toHaveCSS('padding-bottom', '2px')
+  await expect(mediumAlert).toHaveCSS('padding-top', '4px')
+  await expect(mediumAlert).toHaveCSS('padding-bottom', '4px')
+
+  // 3. 验证 small / medium / normal 不显示 title，large 显示 title
+  await expect(smallAlert.locator('.tiny-alert__title')).toHaveCount(0)
+  await expect(mediumAlert.locator('.tiny-alert__title')).toHaveCount(0)
+  await expect(normalAlert.locator('.tiny-alert__title')).toHaveCount(0)
+  await expect(largeAlert.locator('.tiny-alert__title')).toHaveCount(1)
+
+  // 4. 验证 small / medium 的 close 按钮样式
+  const smallClose = smallAlert.locator('.tiny-alert__close')
+  const mediumClose = mediumAlert.locator('.tiny-alert__close')
+  await expect(smallClose).toHaveCSS('top', '4px')
+  await expect(smallClose).toHaveCSS('transform', 'none')
+  await expect(smallClose).toHaveCSS('margin-top', '1px')
+  await expect(mediumClose).toHaveCSS('top', '6px')
+  await expect(mediumClose).toHaveCSS('transform', 'none')
+  await expect(mediumClose).toHaveCSS('margin-top', '1px')
 })

--- a/examples/sites/demos/pc/app/alert/size.vue
+++ b/examples/sites/demos/pc/app/alert/size.vue
@@ -1,5 +1,7 @@
 <template>
   <div>
+    <tiny-alert size="small" title="size 为 small" description="size 为 small"></tiny-alert>
+    <tiny-alert size="medium" title="size 为 medium" description="size 为 medium"></tiny-alert>
     <tiny-alert size="normal" description="size 为 normal"></tiny-alert>
     <tiny-alert size="large" title="size 为 large" description="size 为 large"></tiny-alert>
   </div>
@@ -7,6 +9,7 @@
 
 <script>
 import { TinyAlert } from '@opentiny/vue'
+
 export default {
   components: {
     TinyAlert

--- a/examples/sites/demos/pc/app/alert/slot-default.spec.ts
+++ b/examples/sites/demos/pc/app/alert/slot-default.spec.ts
@@ -4,8 +4,28 @@ test('测试 Alert 自定义交互操作', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
   await page.goto('alert#slot-default')
 
-  // size 为 large 时可通过插槽自定义操作
-  const alert = page.locator('.tiny-alert--large').first()
-  const opration = alert.locator('.tiny-alert__opration')
+  // 第1个：slot 自定义内容（有 opration，但里面是 span 文本）
+  const alert1 = page.locator('.tiny-alert').filter({ hasText: 'slot 自定义内容' })
+  await expect(alert1.locator('.tiny-alert__opration')).toHaveCount(1)
+  await expect(alert1.locator('.tiny-alert__opration')).toHaveText('自定义内容')
+
+  // 第2个：slot 自定义交互操作（有 opration，里面是链接）
+  const alert2 = page.locator('.tiny-alert').filter({ hasText: 'slot 自定义交互操作' })
+  const opration = alert2.locator('.tiny-alert__opration')
   await expect(opration).toHaveCount(1)
+  await expect(opration.locator('a')).toHaveCount(2)
+  await expect(opration.locator('a').nth(0)).toHaveText('确定')
+  await expect(opration.locator('a').nth(1)).toHaveText('取消')
+
+  // 第3个：成功（有 opration + 描述）
+  const alert3 = page.locator('.tiny-alert').filter({ hasText: '成功' })
+  await expect(alert3.locator('.tiny-alert__opration')).toHaveCount(1)
+
+  // 第4个：错误（有 opration 但为空）
+  const alert4 = page.locator('.tiny-alert').filter({ hasText: '错误' })
+  await expect(alert4.locator('.tiny-alert__opration')).toHaveCount(1)
+
+  // 第5个：警告（有 opration）
+  const alert5 = page.locator('.tiny-alert').filter({ hasText: '警告' })
+  await expect(alert5.locator('.tiny-alert__opration')).toHaveCount(1)
 })

--- a/examples/sites/demos/pc/app/alert/title.spec.ts
+++ b/examples/sites/demos/pc/app/alert/title.spec.ts
@@ -4,12 +4,15 @@ test('测试 Alert 自定义标题', async ({ page }) => {
   page.on('pageerror', (exception) => expect(exception).toBeNull())
   await page.goto('alert#title')
 
-  // size 为 large 时可设置自定义标题
-  const alert = page.locator('.tiny-alert--large').first()
+  const alert = page.locator('.tiny-alert').filter({ hasText: '通过属性设置自定义 title' })
   const title = alert.locator('.tiny-alert__title')
+
   await expect(title).toHaveCount(1)
   await expect(title).toHaveText('通过属性设置自定义 title')
 
-  const alert1 = page.locator('.tiny-alert--large').nth(2)
+  const alert1 = page
+    .locator('.tiny-alert')
+    .filter({ hasText: /^描述内容$/ })
+    .first()
   await expect(alert1).not.toHaveText('消息')
 })

--- a/examples/sites/demos/pc/app/alert/webdoc/alert.js
+++ b/examples/sites/demos/pc/app/alert/webdoc/alert.js
@@ -26,22 +26,22 @@ export default {
       },
       desc: {
         'zh-CN': `
-          通过 <code>size</code> 设置不同的尺寸模式，可选值： <code>normal</code> 、<code>large</code> 。<br>
+          通过 <code>size</code> 设置不同的尺寸模式，可选值： <code>small</code> 、<code>medium</code> 、<code>normal</code> 、<code>large</code> 。<br>
           <div class="tip custom-block">
             <p class="custom-block-title"> 尺寸模式区别 </p>
             <ul>
-              <li> normal 模式下，不会显示标题和交互操作的区域，相当于简单模式。</li> 
-              <li> large 模式下，显示全部元素，相当于完整模式。</li> 
+              <li> <code>small</code> 、<code>medium</code> 、<code>normal</code> 模式下，不会显示标题和交互操作的区域，相当于简单模式。</li> 
+              <li> <code>large</code> 模式下，显示全部元素，相当于完整模式。</li> 
             </ul>
           </div>
         `,
         'en-US': `
-          Use <code>size</code> to set different size modes, optional values: <code>normal</code>, <code>large</code>. <br>
+          Use <code>size</code> to set different size modes, optional values: <code>small</code>, <code>medium</code>, <code>normal</code>, <code>large</code>. <br>
           <div class="tip custom-block">
           <p class="custom-block-title"> Size pattern difference </p>
           <ul>
-            <li> normal mode, the header and interactive areas are not displayed, which is equivalent to simple mode. </li>
-            <li> large mode, all elements are displayed, equivalent to the full mode. </li>
+            <li> <code>small</code> 、<code>medium</code> 、<code>normal</code> mode, the header and interactive areas are not displayed, which is equivalent to simple mode. </li>
+            <li> <code>large</code> mode, all elements are displayed, equivalent to the full mode. </li>
           </ul>
           </div>
         `

--- a/packages/theme-saas/src/alert/index.less
+++ b/packages/theme-saas/src/alert/index.less
@@ -7,7 +7,7 @@
 .@{alert-prefix-cls} {
   @apply relative;
   @apply border border-solid;
-  @apply rounded;
+  @apply rounded-form;
 
   &&--normal {
     @apply py-3 px-4;
@@ -25,6 +25,26 @@
         @apply pr-0;
         @apply max-w-full;
       }
+    }
+  }
+
+  &&--small {
+    @apply ~'py-0.5';
+
+    .@{alert-prefix-cls}__close {
+      @apply top-1;
+      @apply transform-none;
+      @apply mt-px;
+    }
+  }
+
+  &&--medium {
+    @apply py-1;
+
+    .@{alert-prefix-cls}__close {
+      @apply ~'top-1.5';
+      @apply transform-none;
+      @apply mt-px;
     }
   }
 
@@ -68,19 +88,19 @@
   }
 
   &&--success {
-    .alert-variant(theme('colors.color.text.primary'); theme('colors.color.bg.1'); theme('colors.color.success.DEFAULT'); theme('colors.color.success.DEFAULT'); theme('colors.color.success.subtler'); theme('colors.color.text.primary'));
+    .alert-variant(theme('colors.color.text.primary'); theme('colors.transparent'); theme('colors.color.success.DEFAULT'); theme('colors.color.success.DEFAULT'); theme('colors.color.success.subtler'); theme('colors.color.text.primary'));
   }
 
   &&--info {
-    .alert-variant(theme('colors.color.text.primary'); theme('colors.color.bg.1'); theme('colors.color.info.primary.DEFAULT'); theme('colors.color.info.primary.DEFAULT'); theme('colors.color.info.primary.subtler'); theme('colors.color.text.primary'));
+    .alert-variant(theme('colors.color.text.primary'); theme('colors.transparent'); theme('colors.color.info.primary.DEFAULT'); theme('colors.color.info.primary.DEFAULT'); theme('colors.color.info.primary.subtler'); theme('colors.color.text.primary'));
   }
 
   &&--warning {
-    .alert-variant(theme('colors.color.text.primary'); theme('colors.color.bg.1'); theme('colors.color.warning.DEFAULT'); theme('colors.color.warning.DEFAULT'); theme('colors.color.warning.subtler'); theme('colors.color.text.primary'));
+    .alert-variant(theme('colors.color.text.primary'); theme('colors.transparent'); theme('colors.color.warning.DEFAULT'); theme('colors.color.warning.DEFAULT'); theme('colors.color.warning.subtler'); theme('colors.color.text.primary'));
   }
 
   &&--error {
-    .alert-variant(theme('colors.color.text.primary'); theme('colors.color.bg.1'); theme('colors.color.error.DEFAULT'); theme('colors.color.error.DEFAULT'); theme('colors.color.error.subtler'); theme('colors.color.text.primary'));
+    .alert-variant(theme('colors.color.text.primary'); theme('colors.transparent'); theme('colors.color.error.DEFAULT'); theme('colors.color.error.DEFAULT'); theme('colors.color.error.subtler'); theme('colors.color.text.primary'));
   }
 
   &__icon {

--- a/packages/theme/src/alert/index.less
+++ b/packages/theme/src/alert/index.less
@@ -93,6 +93,32 @@
     font-size: var(--tv-Alert-close-text-font-size);
   }
 
+  /** Small 场景 */
+  &.@{alert-prefix-cls}--small {
+    padding-top: var(--tv-Alert-space-xs);
+    padding-bottom: var(--tv-Alert-space-xs);
+    margin: var(--tv-Alert-margin-y-normal) var(--tv-Alert-margin-x-normal);
+
+    .@{alert-prefix-cls}__close {
+      top: var(--tv-Alert-space-sm);
+      transform: none;
+      margin-top: calc(var(--tv-Alert-space-sm) / 4);
+    }
+  }
+
+  /** Medium 场景 */
+  &.@{alert-prefix-cls}--medium {
+    padding-top: var(--tv-Alert-space-sm);
+    padding-bottom: var(--tv-Alert-space-sm);
+    margin: var(--tv-Alert-margin-y-normal) var(--tv-Alert-margin-x-normal);
+
+    .@{alert-prefix-cls}__close {
+      top: calc(var(--tv-Alert-space-sm) + var(--tv-Alert-space-xs));
+      transform: none;
+      margin-top: calc(var(--tv-Alert-space-sm) / 4);
+    }
+  }
+
   /** Normal 场景 */
   &.@{alert-prefix-cls}--normal {
     padding: var(--tv-Alert-padding-y-normal) var(--tv-Alert-padding-x-normal);

--- a/packages/theme/src/alert/vars.less
+++ b/packages/theme/src/alert/vars.less
@@ -32,6 +32,9 @@
   // 警告的垂直外边距
   --tv-Alert-margin-y: 0;
 
+  --tv-Alert-space-sm: var(--tv-space-sm, 4px);
+  --tv-Alert-space-xs: var(--tv-space-xs, 2px);
+
   // 描述链接文本色
   --tv-Alert-opration-link-color: var(--tv-color-text-link, #1476ff);
   // 描述链接hover文本色

--- a/packages/theme/src/tag/vars.less
+++ b/packages/theme/src/tag/vars.less
@@ -153,17 +153,17 @@
   --tv-Tag-border-color-plain-warning: var(--tv-color-warn-border, #ff8800);
 
   // alerting 主题时标签light的文本色
-  --tv-Tag-text-color-light-alerting: var(--tv-base-color-warn-5);
-  --tv-Tag-bg-color-light-alerting: var(--tv-base-color-warn-1);
-  --tv-Tag-border-color-light-alerting: var(--tv-base-color-warn-3);
+  --tv-Tag-text-color-light-alerting: var(--tv-base-color-warn-5, #ff9a2e);
+  --tv-Tag-bg-color-light-alerting: var(--tv-base-color-warn-1, #fff4e8);
+  --tv-Tag-border-color-light-alerting: var(--tv-base-color-warn-3, #fcd5a4);
 
-  --tv-Tag-text-color-dark-alerting: var(--tv-color-act-warning-text-white);
-  --tv-Tag-bg-color-dark-alerting: var(--tv-base-color-warn-5);
-  --tv-Tag-border-color-dark-alerting: var(--tv-base-color-warn-5);
+  --tv-Tag-text-color-dark-alerting: var(--tv-color-act-warning-text-white, #ffffff);
+  --tv-Tag-bg-color-dark-alerting: var(--tv-base-color-warn-5, #ff9a2e);
+  --tv-Tag-border-color-dark-alerting: var(--tv-base-color-warn-5, #ff9a2e);
 
-  --tv-Tag-text-color-plain-alerting: var(--tv-base-color-warn-5);
+  --tv-Tag-text-color-plain-alerting: var(--tv-base-color-warn-5, #ff9a2e);
   --tv-Tag-bg-color-plain-alerting: transparent;
-  --tv-Tag-border-color-plain-alerting: var(--tv-base-color-warn-5);
+  --tv-Tag-border-color-plain-alerting: var(--tv-base-color-warn-5, #ff9a2e);
 
   // info 主题时标签light的文本色
   --tv-Tag-text-color-light-info: var(--tv-color-info-text-1, #1476ff);

--- a/packages/vue/src/alert/src/index.ts
+++ b/packages/vue/src/alert/src/index.ts
@@ -42,7 +42,8 @@ export const alertProps = {
   },
   size: {
     type: String,
-    default: 'normal'
+    default: 'normal',
+    validator: (val: string) => ['small', 'medium', 'normal', 'large'].includes(val)
   },
   description: {
     type: String,

--- a/packages/vue/src/alert/src/mobile-first.vue
+++ b/packages/vue/src/alert/src/mobile-first.vue
@@ -5,12 +5,16 @@
       v-if="state.show"
       :class="
         m(
-          'min-h-min flex py-2 sm:py-3 px-4 my-2 rounded box-border font-light sm:font-normal text-color-text-primary',
+          { 'min-h-min': size !== 'large' },
+          'flex py-2 px-4 my-2 rounded-form box-border font-light sm:font-normal text-color-text-primary border border-transparent',
+          `tiny-alert--${size || 'normal'}`,
           { 'bg-color-info-primary-subtler': type === 'info' || !type },
           { 'bg-color-error-subtler': type === 'error' },
           { 'bg-color-warning-subtler': type === 'warning' },
           { 'bg-color-success-subtler': type === 'success' },
           { 'text-center': center },
+          [size === 'small' ? 'sm:py-0.5' : size === 'medium' ? 'sm:py-1' : size === 'large' ? 'sm:py-6' : 'sm:py-3'],
+          { 'h-[76px]': size === 'large' },
           customClass
         )
       "
@@ -18,7 +22,8 @@
       <component
         v-if="showIcon"
         :is="state.getIcon"
-        custom-class="h-4.5 w-4.5 mt-1 sm:mt-0.5 sm:h-6 sm:w-5 sm:h-5 fill-current"
+        :data-tag="'tiny-alert-' + type + '-icon'"
+        custom-class="h-4.5 w-4.5 mt-0.5 sm:mt-0 sm:h-6 sm:w-5 sm:h-5 fill-current"
         :class="[
           { 'text-color-info-primary': type === 'info' || !type },
           { 'text-color-error': type === 'error' },
@@ -29,12 +34,12 @@
       <div
         data-tag="tiny-alert-foldable"
         v-if="showFoldable"
-        class="flex-1 leading-6 text-sm overflow-hidden"
+        class="flex-1 leading-5.5 text-sm overflow-hidden"
         :class="showIcon ? 'mx-2' : 'mr-2'"
       >
         <div
           data-tag="tiny-alert-large"
-          v-if="size === 'large' && showTitle"
+          v-if="size === 'large'"
           @click="handleHeaderClick"
           class="inline-flex cursor-pointer font-medium"
         >
@@ -91,10 +96,10 @@
       <div
         data-tag="tiny-alert-notfoldable"
         v-else
-        class="flex-1 leading-6 text-sm overflow-hidden"
+        class="flex-1 leading-5.5 text-sm overflow-hidden cursor-pointer"
         :class="[showIcon ? 'ml-2' : '', closable ? 'mr-2' : '']"
       >
-        <div data-tag="tiny-alert-large" v-if="size === 'large' && showTitle" class="font-medium">
+        <div data-tag="tiny-alert-title" v-if="size === 'large'" class="font-medium">
           <slot name="title">{{ state.getTitle }} </slot>
         </div>
         <div
@@ -114,11 +119,12 @@
             <slot name="description">{{ description }}</slot>
           </div>
         </div>
-        <div v-if="size === 'large' && slots.default" class="pt-2">
+        <div data-tag="tiny-alert-opration" v-if="size === 'large' && slots.default" class="pt-2">
           <slot></slot>
         </div>
       </div>
       <icon-close
+        data-tag="tiny-alert-close-icon"
         v-if="!closeText && closable"
         @click="handleClose"
         class="h-4 w-4 mt-1 cursor-pointer fill-color-text-primary opacity-70"
@@ -127,7 +133,7 @@
         v-else-if="closeText && closable"
         data-tag="tiny-alert-close-text"
         @click="handleClose"
-        class="leading-6 text-sm cursor-pointer"
+        class="leading-5.5 text-sm cursor-pointer"
         >{{ closeText }}</span
       >
     </div>
@@ -152,7 +158,6 @@ export default defineComponent({
     'closable',
     'center',
     'showIcon',
-    'showTitle',
     'closeText',
     'singleLine',
     'scrolling',


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:
新增尺寸：small/medium
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `small` and `medium` alert sizes across desktop and mobile demos, including updated spacing and close-button alignment.
  - Enhanced theme styling for additional size variants.

- **Documentation**
  - Updated alert size examples and localized documentation to cover `small` / `medium` / `normal` / `large`.

- **Tests**
  - Expanded and strengthened Playwright coverage for size, title, slot interactions, and responsive layout checks.

- **Breaking Changes**
  - Removed the public `showTitle` prop from the mobile-first alert component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->