### PR TITLE
Fix(grid): Horizontal scrolling misalignment when window width changes.

### DIFF
--- a/packages/vue/src/grid/src/body/src/body.tsx
+++ b/packages/vue/src/grid/src/body/src/body.tsx
@@ -828,6 +828,15 @@ export default defineComponent({
       }
     })
 
+    // 客户端宽度变化时（窗口缩放、容器尺寸变化或纵向滚动条出现/消失导致 body clientWidth 改变），
+    // 重新计算横向虚拟滚动切片，确保 sticky-wrapper 内表格内容始终填满视口，避免滚动到右侧出现空白。
+    // 父级容器尺寸变化已由 resize 插件触发 recalculate 处理，此处补齐 body 自身宽度变化未重算切片的场景。
+    hooks.watch(bodyClientWidth, (newWidth, oldWidth) => {
+      if ($table.scrollXLoad && newWidth > 0 && newWidth !== oldWidth) {
+        $table.computeScrollLoad()
+      }
+    })
+
     hooks.onMounted(() => {
       // 节流滚动降低滚动事件处理次数
       vm._throttleScrollHandler = throttle($table.optimizeOpts.scrollDelay, vm.handleScroll)

--- a/packages/vue/src/grid/src/table/src/utils/computeScrollLoad.ts
+++ b/packages/vue/src/grid/src/table/src/utils/computeScrollLoad.ts
@@ -69,6 +69,8 @@ export function computeScrollXLoad({ _vm, scrollX, scrollXLoad, scrollXStore, ta
     const clientWidth = tableBodyElem.clientWidth
     let width = 0
     let visibleXSize = 0
+    // 按最窄列累加估算“足以填满视口”所需的列数，用于保证 renderSize 不小于视口宽度
+    let fillSize = 0
     const len = visibleColumn.length
     const colsWidth = visibleColumn?.map((i) => i.renderWidth).sort((a, b) => a - b) || []
     for (let i = 0; i < len; i++) {
@@ -76,6 +78,7 @@ export function computeScrollXLoad({ _vm, scrollX, scrollXLoad, scrollXStore, ta
       // 当虚拟滚动可见列宽度大于表格宽度或者循环结束，保存可见列大小
       if (width > clientWidth || i === len - 1) {
         visibleXSize = i + 1
+        fillSize = i + 1
         break
       }
     }
@@ -88,9 +91,12 @@ export function computeScrollXLoad({ _vm, scrollX, scrollXLoad, scrollXStore, ta
       scrollXStore.offsetSize = visibleXSize
     }
 
-    if (!scrollX.rSize) {
-      scrollXStore.renderSize = visibleXSize + 2
-    }
+    // 横向虚拟滚动下，sticky-wrapper 内表格宽度等于渲染列宽之和(bodyTableWidth)。
+    // 若渲染列宽之和小于视口宽度，表格无法填满视口，滚动到右侧时会出现空白区域。
+    // renderSize 需同时满足两点：不小于填满视口所需列数(fillSize + 2)，且不小于
+    // visibleSize + 2（保证切片范围覆盖滚动索引逻辑所需列数，避免 startIndex 越界）。
+    const fillRenderSize = Math.max(fillSize + 2, visibleXSize + 2)
+    scrollXStore.renderSize = scrollX.rSize ? Math.max(toNumber(scrollX.rSize), fillRenderSize) : fillRenderSize
 
     // 处理x轴虚拟滚动渲染数据
     _vm.updateScrollXData()


### PR DESCRIPTION
# PR
fix:窗口宽度变化横向滚动错位

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved horizontal virtual scrolling when the table width changes (including scrollbar/resizing scenarios).
  * Prevented right-side blank areas by adjusting how many columns are rendered to better fill the viewport.
  * Ensured sticky table content remains correctly populated as available width updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->