### PR TITLE
feat(switch): [switch] add display-only attribute

### DIFF
--- a/examples/sites/demos/apis/switch.js
+++ b/examples/sites/demos/apis/switch.js
@@ -147,6 +147,21 @@ export default {
           },
           mode: ['mobile-first'],
           mfDemo: ''
+        },
+        {
+          name: 'display-only',
+          type: 'boolean',
+          defaultValue: 'false',
+          desc: {
+            'zh-CN': '设置开关为只读状态',
+            'en-US': 'Set the switch to read-only status'
+          },
+          meta: {
+            stable: '3.31.0'
+          },
+          mode: ['pc', 'mobile-first'],
+          pcDemo: 'display-only',
+          mfDemo: 'display-only'
         }
       ],
       events: [

--- a/examples/sites/demos/mobile-first/app/switch/display-only.vue
+++ b/examples/sites/demos/mobile-first/app/switch/display-only.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="switch-demo">
+    <div class="demo-item">
+      <p>开关1：只显示文字</p>
+      <br />
+      <tiny-switch v-model="val1" display-only></tiny-switch>
+      <br />
+      <br />
+      <p>开关2：可交互，设置val1的值</p>
+      <br />
+      <tiny-switch v-model="val1"></tiny-switch>
+    </div>
+  </div>
+</template>
+
+<script>
+import { TinySwitch } from '@opentiny/vue'
+
+export default {
+  components: {
+    TinySwitch
+  },
+  data() {
+    return {
+      val1: true
+    }
+  }
+}
+</script>
+
+<style scoped>
+.demo-item {
+  padding: 15px;
+}
+
+.demo-title {
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 10px;
+}
+</style>

--- a/examples/sites/demos/mobile-first/app/switch/webdoc/switch.js
+++ b/examples/sites/demos/mobile-first/app/switch/webdoc/switch.js
@@ -108,9 +108,9 @@ export default {
       },
       desc: {
         'zh-CN':
-          '<p>`<code>display-only</code>属性表示开关为只读状态，默认值为 <code>false</code>。当设置 <code>display-only</code> 为 <code>true</code> 时，开关为只读状态，无法进行交互操作。<p>',
+          '<p>`<code>display-only</code>属性表示开关为只读状态，默认值为 <code>false</code>。当设置 <code>display-only</code> 为 <code>true</code> 时，开关为只读状态，无法进行交互操作。</p>',
         'en-US':
-          '<p><code>display-only</code> property indicates that the switch is in read-only mode, with a default value of <code>false</code>. When set to <code>true</code>, the switch is in read-only mode and cannot be interacted with.<p>'
+          '<p><code>display-only</code> property indicates that the switch is in read-only mode, with a default value of <code>false</code>. When set to <code>true</code>, the switch is in read-only mode and cannot be interacted with.</p>'
       },
       codeFiles: ['display-only.vue']
     }

--- a/examples/sites/demos/mobile-first/app/switch/webdoc/switch.js
+++ b/examples/sites/demos/mobile-first/app/switch/webdoc/switch.js
@@ -99,6 +99,20 @@ export default {
         'en-US': '<p>bbutton click</p>'
       },
       codeFiles: ['custom-true-false-value.vue']
+    },
+    {
+      demoId: 'display-only',
+      name: {
+        'zh-CN': '只读状态',
+        'en-US': 'Display Only'
+      },
+      desc: {
+        'zh-CN':
+          '<p>`<code>display-only</code>属性表示开关为只读状态，默认值为 <code>false</code>。当设置 <code>display-only</code> 为 <code>true</code> 时，开关为只读状态，无法进行交互操作。<p>',
+        'en-US':
+          '<p><code>display-only</code> property indicates that the switch is in read-only mode, with a default value of <code>false</code>. When set to <code>true</code>, the switch is in read-only mode and cannot be interacted with.<p>'
+      },
+      codeFiles: ['display-only.vue']
     }
   ]
 }

--- a/examples/sites/demos/pc/app/switch/display-only-composition-api.vue
+++ b/examples/sites/demos/pc/app/switch/display-only-composition-api.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="switch-demo">
+    <div class="demo-item">
+      <p>开关1：只显示文字</p>
+      <br />
+      <tiny-switch v-model="val1" display-only></tiny-switch>
+      <br />
+      <br />
+      <p>开关2：可交互，设置val1的值</p>
+      <br />
+      <tiny-switch v-model="val1"></tiny-switch>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { TinySwitch } from '@opentiny/vue'
+
+const val1 = ref(true)
+</script>
+
+<style scoped>
+.demo-item {
+  padding: 15px;
+}
+
+.demo-title {
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 10px;
+}
+</style>

--- a/examples/sites/demos/pc/app/switch/display-only.spec.ts
+++ b/examples/sites/demos/pc/app/switch/display-only.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test'
+
+test('display-only 只显示文字，正常模式可交互', async ({ page }) => {
+  page.on('pageerror', (exception) => expect(exception).toBeNull())
+
+  await page.goto('switch#display-only')
+  await page.waitForLoadState('networkidle')
+
+  const demo = page.locator('.switch-demo')
+
+  const displayOnlyText = demo.getByText('是')
+  await expect(displayOnlyText).toBeVisible()
+
+  await expect(displayOnlyText).not.toHaveClass(/tiny-switch/)
+
+  const normalSwitch = demo.locator('.tiny-switch')
+  await expect(normalSwitch).toHaveCount(1)
+
+  await expect(normalSwitch).toHaveAttribute('role', 'switch')
+  await expect(normalSwitch).toHaveAttribute('aria-checked', 'true')
+  await expect(normalSwitch).toHaveAttribute('aria-disabled', 'false')
+  await expect(normalSwitch).toHaveAttribute('tabindex', '1')
+  await expect(normalSwitch).toHaveClass(/tiny-switch-checked/)
+
+  await normalSwitch.click()
+  await expect(normalSwitch).toHaveAttribute('aria-checked', 'false')
+  await expect(normalSwitch).not.toHaveClass(/tiny-switch-checked/)
+
+  await normalSwitch.click()
+  await expect(normalSwitch).toHaveAttribute('aria-checked', 'true')
+  await expect(normalSwitch).toHaveClass(/tiny-switch-checked/)
+})

--- a/examples/sites/demos/pc/app/switch/display-only.vue
+++ b/examples/sites/demos/pc/app/switch/display-only.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="switch-demo">
+    <div class="demo-item">
+      <p>开关1：只显示文字</p>
+      <br />
+      <tiny-switch v-model="val1" display-only></tiny-switch>
+      <br />
+      <br />
+      <p>开关2：可交互，设置val1的值</p>
+      <br />
+      <tiny-switch v-model="val1"></tiny-switch>
+    </div>
+  </div>
+</template>
+
+<script>
+import { TinySwitch } from '@opentiny/vue'
+
+export default {
+  components: {
+    TinySwitch
+  },
+  data() {
+    return {
+      val1: true
+    }
+  }
+}
+</script>
+
+<style scoped>
+.demo-item {
+  padding: 15px;
+}
+
+.demo-title {
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 10px;
+}
+</style>

--- a/examples/sites/demos/pc/app/switch/webdoc/switch.js
+++ b/examples/sites/demos/pc/app/switch/webdoc/switch.js
@@ -129,6 +129,20 @@ export default {
         'en-US': '<p>When the switch value changes, the <code>change</code> event will be triggered.</p>'
       },
       codeFiles: ['event-change.vue']
+    },
+    {
+      demoId: 'display-only',
+      name: {
+        'zh-CN': '只读状态',
+        'en-US': 'Display only'
+      },
+      desc: {
+        'zh-CN':
+          '<p>通过 <code>display-only</code> 设置开关为只读状态。当设置 <code>display-only</code> 为 <code>true</code> 时，开关为只读状态，无法进行交互操作。</p>',
+        'en-US':
+          '<p><code>display-only</code> property indicates that the switch is in read-only mode, with a default value of <code>false</code>. When set to <code>true</code>, the switch is in read-only mode and cannot be interacted with.</p>'
+      },
+      codeFiles: ['display-only.vue']
     }
   ],
   features: [

--- a/packages/vue/src/switch/src/mobile-first.vue
+++ b/packages/vue/src/switch/src/mobile-first.vue
@@ -1,5 +1,6 @@
 <template>
   <span
+    v-if="!state.isDisplayOnly"
     :class="
       m(
         gcls('switch-default'),
@@ -134,6 +135,10 @@
         </slot>
       </div> </span
   ></span>
+  <span v-else :style="state.displayOnlyStyle">
+    <slot v-if="state.currentValue === trueValue" name="open">{{ t('yes') }}</slot>
+    <slot v-if="state.currentValue === falseValue" name="close">{{ t('no') }}</slot>
+  </span>
 </template>
 
 <script lang="ts">
@@ -143,7 +148,7 @@ import { classes } from './token'
 
 export default defineComponent({
   emits: ['change', 'update:modelValue'],
-  props: [...props, 'modelValue', 'trueValue', 'falseValue', 'disabled', 'size', 'tabindex', 'types'],
+  props: [...props, 'modelValue', 'trueValue', 'falseValue', 'disabled', 'size', 'tabindex', 'types', 'displayOnly'],
   setup(props, context) {
     return setup({ props, context, renderless, api, classes })
   }


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:
pc/mf：新增display-only属性
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a display-only mode for Switch via a new `displayOnly` prop, presenting the current state as non-interactive text.
  * Added updated localized documentation and new PC/mobile-first examples for the display-only mode.
  * Retained the interactive Switch behavior alongside the display-only presentation (including a composition-style example).

* **Tests**
  * Added Playwright coverage for display-only rendering, accessibility attributes, and interactive state toggling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->