### PR TITLE
fix(date-panel): fix date selection off-by-one day when clicking dates( #4138)

### DIFF
--- a/packages/renderless/src/date-panel/vue.ts
+++ b/packages/renderless/src/date-panel/vue.ts
@@ -152,7 +152,7 @@ const initWatch = ({ watch, state, api, nextTick, props }) => {
         newVal = toDate1(val - localOffset)
       }
       if (newVal) {
-        const newDate = modifyDate(newVal, newVal.getFullYear(), newVal.getMonth(), newVal.getUTCDate() + 1)
+        const newDate = modifyDate(newVal, newVal.getFullYear(), newVal.getMonth(), newVal.getDate())
         state.date = newDate
         state.value = newDate
       }


### PR DESCRIPTION
The modelValue watcher in date-panel incorrectly used `getUTCDate() + 1` which caused a double timezone correction, resulting in the selected date being offset by one day. Changed to use `getDate()` which gives the correct local date value, consistent with how date-range and month-range components handle the same logic.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When clicking a date in the DatePanel component, the wrong date is selected. For example, clicking "15" first selects "16". A second click on "15" is required to correctly select it. The bug occurs because the modelValue watcher applies a double timezone correction (`val - localOffset` plus `getUTCDate() + 1`), which shifts the date forward by one day.

Issue Number: N/A

## What is the new behavior?

Clicking any date in DatePanel selects the correct date immediately, with no off-by-one error.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Only one line changed in `packages/renderless/src/date-panel/vue.ts`. The fix aligns with how `date-range` and `month-range` already handle the same logic using `getDate()` instead of `getUTCDate() + 1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date selection normalization across time zones.
  * Fixed displayed dates that could shift by one day for certain time zone offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->