### PR TITLE
fix(slider): numPages not affecting step size in mouse click/drag(#3077)

### DIFF
--- a/packages/renderless/src/slider/index.ts
+++ b/packages/renderless/src/slider/index.ts
@@ -287,7 +287,8 @@ const calcCurrentValue = ({
   } else if (currentValue >= props.max) {
     currentValue = props.max
   } else {
-    const step = props.step > 0 ? props.step : 1
+    const step =
+      props.numPages > 1 ? Math.ceil((props.max - props.min) / props.numPages) : props.step > 0 ? props.step : 1
     // step的精度
     let stepPrecision = 0
     if (step - parseInt(step) > 0) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our Commit Message Guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Slider 组件的 numPages 属性仅在键盘事件（PageUp/PageDown）中生效，
在鼠标点击滑条或拖拽滑块时，步长计算完全忽略 numPages，始终使用 step
（默认值 1）。例如设置 :num-pages="5" 配合 max=100 min=0，期望每次鼠标
拖拽跳动 20（即 100/5），但实际每次只跳动 1。

Issue Number: N/A

## What is the new behavior?

当 numPages > 1 时，鼠标操作（click/drag）的步长按照
Math.ceil((max - min) / numPages) 计算，与键盘 PageUp/PageDown 行为
一致。当 numPages 为默认值 1 时保持原有 step 逻辑，完全向后兼容。

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

修改范围：packages/renderless/src/slider/index.ts 第 290 行，
calcCurrentValue 函数中的步长计算逻辑，仅一行改动。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slider value snapping when multiple pages are configured.
  * Ensured slider values advance using calculated page increments for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->