### PR TITLE
fix(date-picker,date-panel):fix the issue where the selected date is offset by one day in multi-time zone scenarios.

### DIFF
--- a/packages/renderless/src/date-panel/vue.ts
+++ b/packages/renderless/src/date-panel/vue.ts
@@ -145,14 +145,13 @@ const initWatch = ({ watch, state, api, nextTick, props }) => {
   watch(
     () => props.modelValue,
     (value) => {
-      let newVal
       const val = toDate1(value)
       if (val) {
-        const localOffset = val.getTimezoneOffset() * 60000
-        newVal = toDate1(val - localOffset)
-      }
-      if (newVal) {
-        const newDate = modifyDate(newVal, newVal.getFullYear(), newVal.getMonth(), newVal.getUTCDate() + 1)
+        const isString = typeof value === 'string'
+        const year = isString ? val.getUTCFullYear() : val.getFullYear()
+        const month = isString ? val.getUTCMonth() : val.getMonth()
+        const day = isString ? val.getUTCDate() : val.getDate()
+        const newDate = modifyDate(val, year, month, day)
         state.date = newDate
         state.value = newDate
       }


### PR DESCRIPTION
删除 modelValue watcher 中错误的 val - localOffset 时区偏移，改为按输入类型（字符串取 UTC 分量、Date/Number 取本地分量）正确提取日历日期，修复西半球时区下日期选中与高亮偏移一天的问题。

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date panel value handling to better preserve the selected month and year across time zones.
  * Prevented UTC-based inputs from being normalized in a way that could cause dates to shift or land on the wrong day.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->