### PR TITLE
fix(color-select-panel): 修复直接输入颜色值时滑块和显示器不同步的问题(#4280) 

### DIFF
--- a/packages/renderless/src/color-select-panel/index.ts
+++ b/packages/renderless/src/color-select-panel/index.ts
@@ -272,6 +272,11 @@ export const initApi = (
     resetColor()
     emit('cancel')
   }
+  // 文本框失焦时将输入同步到颜色对象，反向驱动滑块和颜色显示器更新
+  const onInputBlur = () => {
+    if (!state.input || state.isLinearGradient) return
+    state.color.fromString(state.input)
+  }
   const onHueReady = (update) => {
     state.hue = { update }
   }
@@ -332,7 +337,8 @@ export const initApi = (
     onAlphaReady,
     onPredefineColorClick,
     onHistoryClick,
-    onClickOutside
+    onClickOutside,
+    onInputBlur
   }
 }
 

--- a/packages/renderless/src/color-select-panel/vue.ts
+++ b/packages/renderless/src/color-select-panel/vue.ts
@@ -20,7 +20,8 @@ export const api = [
   'onAlphaReady',
   'onPredefineColorClick',
   'onHistoryClick',
-  'onClickOutside'
+  'onClickOutside',
+  'onInputBlur'
 ]
 
 export const renderless = (
@@ -43,7 +44,8 @@ export const renderless = (
     onAlphaReady,
     onPredefineColorClick,
     onHistoryClick,
-    onClickOutside
+    onClickOutside,
+    onInputBlur
   } = initApi(props, state, utils, hooks, ext)
 
   const api = {
@@ -60,7 +62,8 @@ export const renderless = (
     onAlphaReady,
     onPredefineColorClick,
     onHistoryClick,
-    onClickOutside
+    onClickOutside,
+    onInputBlur
   }
   initWatch(state, props, hooks, utils)
   hooks.onMounted(() => {

--- a/packages/vue/src/color-select-panel/src/pc.vue
+++ b/packages/vue/src/color-select-panel/src/pc.vue
@@ -25,7 +25,12 @@
           class="tiny-color-select-panel__tools-hex"
           v-if="state.currentFormat === 'hex' || state.currentFormat === 'css' || !state.currentFormat"
         >
-          <tiny-input class="tiny-color-select-panel__tools-hex1" v-model="state.input" />
+          <tiny-input
+            class="tiny-color-select-panel__tools-hex1"
+            v-model="state.input"
+            @blur="onInputBlur"
+            @keyup.enter="$event.target.blur()"
+          />
           <div class="tiny-color-select-panel__tools-deg" v-if="state.isLinearGradient">
             <tiny-numeric v-model="state.ctx.deg" unit="deg" mouse-wheel />
           </div>


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)

## What is the current behavior?

在颜色选择面板中，拖动滑块可以同步更新文本框的颜色值（slider → text），但直接在文本框输入 hex 颜色值时，滑块和颜色显示器不会同步更新（text → slider）。用户必须通过外部传入 modelValue 才能触发更新。

Issue Number: N/A

## What is the new behavior?

在 hex 输入框上添加 `@blur` 事件处理，当用户输入完颜色值后点击别处或按 Enter 键，自动将输入同步到颜色对象，反向驱动滑块和颜色显示器更新。同时添加 `@keyup.enter` 让用户按 Enter 即可触发同步，无需多按一次鼠标。

技术细节：
- `onInputBlur` 函数位于 `initApi` 中，仅在输入非空且非渐变色模式下执行 `color.fromString(input)`
- 纯增量改动，不修改任何已有逻辑

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

改动仅 3 个文件，均为 color-select-panel 模块内部改动，不影响其他组件。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color input handling when editing HEX/CSS values.
  * Color selections now update correctly after leaving the input field or pressing Enter.
  * Related sliders and color displays stay synchronized with the entered value.
  * Linear-gradient editing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->