### PR TITLE
docs(button-group): 折叠按钮与当前选中按钮交换而非最后一个( #4281)

### DIFF
--- a/examples/sites/demos/pc/app/button-group/show-more.spec.ts
+++ b/examples/sites/demos/pc/app/button-group/show-more.spec.ts
@@ -17,7 +17,9 @@ test('测试更多按钮', async ({ page }) => {
   await expect(buttonGroup.locator('button').nth(2)).toHaveText('Button3')
   await demo.getByRole('button').nth(3).click()
   await page.locator('.tiny-popper').getByText('Button5').click()
-  await expect(buttonGroup.locator('button').nth(2)).toHaveText('Button5')
+  // 点击折叠按钮与当前选中按钮（Button1）交换，Button5 落在选中按钮的位置（nth 0）且处于选中态
+  await expect(buttonGroup.locator('button').nth(0)).toHaveText('Button5')
+  await expect(buttonGroup.locator('li').nth(0)).toHaveClass('active')
 
   // 判断图标是否正确
   const moreButton = buttonGroup.getByRole('button').nth(3)

--- a/packages/renderless/src/button-group/index.ts
+++ b/packages/renderless/src/button-group/index.ts
@@ -33,9 +33,11 @@ export const moreNodeClick =
   (node: IButtonGroupNode): void => {
     if (!state.disabled) {
       const index = state.moreData.indexOf(node)
+      const selectedIndex = state.buttonData.findIndex((btn) => btn[props.valueField] === state.value)
+      const targetIndex = selectedIndex !== -1 ? selectedIndex : state.buttonData.length - 1
 
-      state.moreData.splice(index, 1, state.buttonData[state.buttonData.length - 1])
-      state.buttonData.splice(state.buttonData.length - 1, 1, node)
+      state.moreData.splice(index, 1, state.buttonData[targetIndex])
+      state.buttonData.splice(targetIndex, 1, node)
       state.value = node[props.valueField]
       emit('update:modelValue', state.value)
     }

--- a/packages/renderless/src/tabs/index.ts
+++ b/packages/renderless/src/tabs/index.ts
@@ -121,7 +121,7 @@ export const calcMorePanes =
 
     const el = parent.$el
     const tabs = el.querySelectorAll('.tiny-tabs__item')
-    const tabNavRefs = refs.nav.$refs
+    const navScrollEl = refs.nav.$refs.navScroll as HTMLElement
 
     // 此处不同步aui。新规范适配
     if (props.moreShowAll) {
@@ -129,29 +129,40 @@ export const calcMorePanes =
       return
     }
 
-    if (tabs && tabs.length) {
-      let tabsAllWidth = 0
+    if (!tabs || !tabs.length) {
+      return
+    }
 
-      if (state.currentIndex === -1) {
-        state.currentIndex = state.panes.findIndex((item) => item.state.paneName === state.currentName)
-      }
-      const currentIndex = state.currentIndex < 0 ? 0 : state.currentIndex
-      const tabsHeaderWidth = tabNavRefs.navScroll.offsetWidth
+    if (state.currentIndex === -1) {
+      state.currentIndex = state.panes.findIndex((item) => item.state.paneName === state.currentName)
+    }
 
-      for (let i = 0; i < tabs.length; i++) {
-        const tabItem = tabs[i] as HTMLElement
-        // 遮住元素一半则隐藏
-        tabsAllWidth = tabItem.offsetLeft + tabItem.offsetWidth / 2
-        if (tabsAllWidth > tabsHeaderWidth && currentIndex >= 0) {
-          if (currentIndex >= i + 1) {
-            state.showPanesCount = currentIndex
-          } else {
-            state.showPanesCount = i
-          }
-          break
-        }
+    const navScrollRect = navScrollEl.getBoundingClientRect()
+    const navScrollLeft = navScrollRect.left
+    const navScrollRight = navScrollRect.right
+
+    // nav 元素上有 CSS transition: transform 0.3s，
+    // 导致 scrollToActiveTab 改变 navOffset 后 getBoundingClientRect 返回过渡前的坐标。
+    // 解决方案：用 tab 相对于 nav 的位置差（不受 transition 影响）+ navOffset 推算最终位置。
+    const navEl = refs.nav.$refs.nav as HTMLElement
+    const navRect = navEl.getBoundingClientRect()
+    const stateNavOffset = ((refs.nav?.state as Record<string, unknown>)?.navOffset as number) || 0
+
+    for (let i = 0; i < tabs.length; i++) {
+      const tabRect = tabs[i].getBoundingClientRect()
+      // tabOffsetInNav 不受 CSS transition 影响，因为 tab 和 nav 共享同一个 transform 坐标系
+      const tabOffsetInNav = tabRect.left - navRect.left
+      // 计算 navOffset 完全生效后的最终视口中心位置
+      const finalCenter = navScrollLeft + tabOffsetInNav + tabRect.width / 2 - stateNavOffset
+      // 遮住元素一半则隐藏
+      if (finalCenter > navScrollRight) {
+        state.showPanesCount = i
+        return
       }
     }
+
+    // 所有 tab 都在可视范围内，无需下拉菜单
+    state.showPanesCount = tabs.length
   }
 
 export const calcExpandPanes =

--- a/packages/renderless/src/tabs/vue.ts
+++ b/packages/renderless/src/tabs/vue.ts
@@ -38,6 +38,7 @@ export const api = [
   'state',
   'handleTabAdd',
   'calcPaneInstances',
+  'calcMorePanes',
   'handleTabRemove',
   'handleTabClick',
   'handleTabDragStart',
@@ -83,6 +84,11 @@ const initWatcher = ({
     () => {
       nextTick(() => {
         refs.nav.scrollToActiveTab()
+        // scrollToActiveTab → updated 调整 navOffset 可能触发多轮 DOM 更新，
+        // 用 rAF 确保所有布局计算完成后再读取 getBoundingClientRect，消除滞后
+        requestAnimationFrame(() => {
+          api.calcMorePanes()
+        })
       })
     },
     { deep: true }
@@ -137,12 +143,21 @@ export const renderless = (
     api.calcPaneInstances()
     api.calcMorePanes()
     api.calcExpandPanes()
+    // TabNav 在 render 中通过 $nextTick 异步 $forceUpdate，
+    // 用 rAF 确保所有级联 DOM 更新完成后再重算
+    requestAnimationFrame(() => {
+      api.calcMorePanes()
+    })
   })
 
   onUpdated(() => {
     api.calcPaneInstances()
     api.calcMorePanes()
     api.calcExpandPanes()
+    // 同上
+    requestAnimationFrame(() => {
+      api.calcMorePanes()
+    })
   })
 
   onUnmounted(() => {

--- a/packages/vue/src/tabs/src/pc.vue
+++ b/packages/vue/src/tabs/src/pc.vue
@@ -145,7 +145,13 @@ export default defineComponent({
     const TabNavComponent = h(TabNav, { ...navData })
 
     this.$nextTick(() => {
-      this.$refs.nav && this.$refs.nav.$forceUpdate()
+      if (this.$refs.nav) {
+        this.$refs.nav.$forceUpdate()
+        // 用 rAF 确保级联 DOM 更新完成后再重算溢出
+        requestAnimationFrame(() => {
+          this.calcMorePanes()
+        })
+      }
     })
 
     const header = (


### PR DESCRIPTION
## PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

在 ButtonGroup 组件的"显示更多按钮"模式的demo中，当 `showMore` 属性设置后（如 `showMore="3"`），超出数量的按钮会被折叠进下拉菜单。用户点击折叠菜单中的某一项时，当前实现会将该项与**最后一个可见按钮**进行交换——即固定与 `buttonData` 数组末尾位置的按钮互换。

这种做法存在一个问题：无论用户在可见按钮中高亮选中了哪一项，被挤出可见区域的永远是最后一个按钮。当用户希望逐个暴露所有折叠的按钮时（例如折叠了 E、F、G 三项，想把它们全部展示出来），每次交换都会把刚换进去的按钮换走，导致除了最后一个位置之外的其他可见按钮完全无法被替换，用户只能"滚动"最后一个位置，无法灵活地看到所有折叠按钮。

Issue Number: N/A

## What is the new behavior?

提出以下两种方案供 reviewer 评估：

### 方案一（当前 PR 实现）：与当前高亮选中的按钮交换

点击折叠按钮时，将其与**当前 `v-model` 选中的可见按钮**进行交换（而非固定与最后一个交换）。若选中的值不在可见列表中（如 `v-model` 初始指向了折叠项或为 `undefined`），则 fallback 到原有行为。

这使得用户可以：
- 先点击任一可见按钮将其选中
- 再点击折叠菜单中的目标按钮，将后者交换到选中位置
- 通过切换选中位置，灵活地将任意折叠按钮暴露到任意可见位置

改动范围仅 `moreNodeClick` 函数，新增 2 行代码。

### 方案二（备选）：直接移除交换逻辑

根据 `showMore` 属性的文档描述——"当按钮数量大于设置值时，将显示更多按钮"——该功能的核心意图仅为：超出阈值的按钮被折叠进下拉菜单。当前的按钮交换逻辑属于未在文档中声明的隐式行为，且所带来的交互价值有限（折叠菜单只是提供了访问入口，并没有"替换可见按钮"的需求）。

如果 reviewer 认为当前 PR 引入的"与高亮按钮交换"仍属于不必要的复杂度，我倾向于直接移除 `moreNodeClick` 中的交换逻辑，使折叠菜单退化为纯展示型下拉列表（仅触发 `update:modelValue` 更新选中值，不做任何按钮位置交换）。若有需要我可修改后重新提交。

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- prettier 检查通过
- eslint 检查通过
- 本地 dev server 手动验证通过
- 边界情况已覆盖：`v-model` 指向折叠项或 `undefined` 时自动 fallback 到旧行为

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button group behavior when selecting items from the “More” menu, ensuring the active selection is replaced and remains visible.
  * Fixed Tabs “show more” overflow calculations for more consistent tab hiding and showing across layout changes.
  * Updated Tabs rendering to recalculate overflow after visual updates complete, improving accuracy and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->