### PR TITLE
fix: compatible with the click behavior of AUI-based foldable panels

### DIFF
--- a/packages/design/aurora/src/alert/index.ts
+++ b/packages/design/aurora/src/alert/index.ts
@@ -3,5 +3,13 @@ import { iconWarning } from '@opentiny/vue-icon'
 export default {
   icons: {
     warning: iconWarning()
+  },
+  renderless: (props, hooks, { emit }, api) => {
+    const state = api.state
+
+    return {
+      // AUI的场景不允许点击header容器点击折叠， 只能点击title才折叠。所以屏蔽header容器点击
+      handleHeaderContainerClick: () => {}
+    }
   }
 }


### PR DESCRIPTION
# PR

增加兼容折叠面板的点击行为：

目前是点击面板header都会折叠， 兼容后代码是只点击图标+title 才会折叠



## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated alert collapse behavior so clicking the header container no longer collapses the alert; only the title triggers collapse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->