### PR TITLE
fix(tabs): 修复 showMoreTabs 模式下 overflow 计算滞后导致下拉菜单未及时更新(#4279) 

### DIFF
--- a/examples/sites/demos/pc/app/tabs/custom-more-icon.spec.ts
+++ b/examples/sites/demos/pc/app/tabs/custom-more-icon.spec.ts
@@ -18,7 +18,8 @@ test('"定义更多按钮"', async ({ page }) => {
 
   await expect(listWidth).toBeGreaterThan(boxWidth)
   await expect(tabItems).toHaveCount(8)
-  await expect(dropdownItems).toHaveCount(2)
+  // 溢出计算修正后按真实布局计算：容器 400px 减去"更多"按钮占位后，仅 5 个 tab 完整可见，下拉为 Tab 6/7/8 共 3 项
+  await expect(dropdownItems).toHaveCount(3)
   await expect(headerBox).toHaveCSS('overflow', 'hidden')
   await moreIcon.hover()
   await dropdownLastItem.click()

--- a/packages/renderless/src/tab-nav/index.ts
+++ b/packages/renderless/src/tab-nav/index.ts
@@ -229,6 +229,11 @@ export const scrollPrev =
     const newOffset = currentOffset > containerSize ? currentOffset - containerSize : 0
 
     state.navOffset = newOffset
+
+    // 箭头滚动后通知父级 Tabs 重新计算溢出，用 rAF 等待级联 DOM 更新落定
+    requestAnimationFrame(() => {
+      ;(state.rootTabs as Record<string, unknown>)?.calcMorePanes?.()
+    })
   }
 
 export const scrollNext =
@@ -246,6 +251,11 @@ export const scrollNext =
       navSize - currentOffset > containerSize * 2 ? currentOffset + containerSize : navSize - containerSize
 
     state.navOffset = newOffset
+
+    // 箭头滚动后通知父级 Tabs 重新计算溢出，用 rAF 等待级联 DOM 更新落定
+    requestAnimationFrame(() => {
+      ;(state.rootTabs as Record<string, unknown>)?.calcMorePanes?.()
+    })
   }
 
 /* istanbul ignore next */

--- a/packages/renderless/src/tabs/index.ts
+++ b/packages/renderless/src/tabs/index.ts
@@ -121,7 +121,7 @@ export const calcMorePanes =
 
     const el = parent.$el
     const tabs = el.querySelectorAll('.tiny-tabs__item')
-    const tabNavRefs = refs.nav.$refs
+    const navScrollEl = refs.nav.$refs.navScroll as HTMLElement
 
     // 此处不同步aui。新规范适配
     if (props.moreShowAll) {
@@ -129,29 +129,40 @@ export const calcMorePanes =
       return
     }
 
-    if (tabs && tabs.length) {
-      let tabsAllWidth = 0
+    if (!tabs || !tabs.length) {
+      return
+    }
 
-      if (state.currentIndex === -1) {
-        state.currentIndex = state.panes.findIndex((item) => item.state.paneName === state.currentName)
-      }
-      const currentIndex = state.currentIndex < 0 ? 0 : state.currentIndex
-      const tabsHeaderWidth = tabNavRefs.navScroll.offsetWidth
+    if (state.currentIndex === -1) {
+      state.currentIndex = state.panes.findIndex((item) => item.state.paneName === state.currentName)
+    }
 
-      for (let i = 0; i < tabs.length; i++) {
-        const tabItem = tabs[i] as HTMLElement
-        // 遮住元素一半则隐藏
-        tabsAllWidth = tabItem.offsetLeft + tabItem.offsetWidth / 2
-        if (tabsAllWidth > tabsHeaderWidth && currentIndex >= 0) {
-          if (currentIndex >= i + 1) {
-            state.showPanesCount = currentIndex
-          } else {
-            state.showPanesCount = i
-          }
-          break
-        }
+    const navScrollRect = navScrollEl.getBoundingClientRect()
+    const navScrollLeft = navScrollRect.left
+    const navScrollRight = navScrollRect.right
+
+    // nav 元素上有 CSS transition: transform 0.3s，
+    // 导致 scrollToActiveTab 改变 navOffset 后 getBoundingClientRect 返回过渡前的坐标。
+    // 解决方案：用 tab 相对于 nav 的位置差（不受 transition 影响）+ navOffset 推算最终位置。
+    const navEl = refs.nav.$refs.nav as HTMLElement
+    const navRect = navEl.getBoundingClientRect()
+    const stateNavOffset = ((refs.nav?.state as Record<string, unknown>)?.navOffset as number) || 0
+
+    for (let i = 0; i < tabs.length; i++) {
+      const tabRect = tabs[i].getBoundingClientRect()
+      // tabOffsetInNav 不受 CSS transition 影响，因为 tab 和 nav 共享同一个 transform 坐标系
+      const tabOffsetInNav = tabRect.left - navRect.left
+      // 计算 navOffset 完全生效后的最终视口中心位置
+      const finalCenter = navScrollLeft + tabOffsetInNav + tabRect.width / 2 - stateNavOffset
+      // 遮住元素一半则隐藏
+      if (finalCenter > navScrollRight) {
+        state.showPanesCount = i
+        return
       }
     }
+
+    // 所有 tab 都在可视范围内，无需下拉菜单
+    state.showPanesCount = tabs.length
   }
 
 export const calcExpandPanes =

--- a/packages/renderless/src/tabs/vue.ts
+++ b/packages/renderless/src/tabs/vue.ts
@@ -38,6 +38,7 @@ export const api = [
   'state',
   'handleTabAdd',
   'calcPaneInstances',
+  'calcMorePanes',
   'handleTabRemove',
   'handleTabClick',
   'handleTabDragStart',
@@ -83,6 +84,11 @@ const initWatcher = ({
     () => {
       nextTick(() => {
         refs.nav.scrollToActiveTab()
+        // scrollToActiveTab → updated 调整 navOffset 可能触发多轮 DOM 更新，
+        // 用 rAF 确保所有布局计算完成后再读取 getBoundingClientRect，消除滞后
+        requestAnimationFrame(() => {
+          api.calcMorePanes()
+        })
       })
     },
     { deep: true }
@@ -137,12 +143,21 @@ export const renderless = (
     api.calcPaneInstances()
     api.calcMorePanes()
     api.calcExpandPanes()
+    // TabNav 在 render 中通过 $nextTick 异步 $forceUpdate，
+    // 用 rAF 确保所有级联 DOM 更新完成后再重算
+    requestAnimationFrame(() => {
+      api.calcMorePanes()
+    })
   })
 
   onUpdated(() => {
     api.calcPaneInstances()
     api.calcMorePanes()
     api.calcExpandPanes()
+    // 同上
+    requestAnimationFrame(() => {
+      api.calcMorePanes()
+    })
   })
 
   onUnmounted(() => {

--- a/packages/vue/src/tabs/src/pc.vue
+++ b/packages/vue/src/tabs/src/pc.vue
@@ -145,7 +145,13 @@ export default defineComponent({
     const TabNavComponent = h(TabNav, { ...navData })
 
     this.$nextTick(() => {
-      this.$refs.nav && this.$refs.nav.$forceUpdate()
+      if (this.$refs.nav) {
+        this.$refs.nav.$forceUpdate()
+        // 用 rAF 确保级联 DOM 更新完成后再重算溢出
+        requestAnimationFrame(() => {
+          this.calcMorePanes()
+        })
+      }
     })
 
     const header = (


### PR DESCRIPTION
## PR

## PR Checklist

- [x] The commit message follows our Commit Message Guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

<img width="766" height="227" alt="image" src="https://github.com/user-attachments/assets/d25aa2f8-300f-4b60-a426-bb9ee55c6614" />
<img width="755" height="148" alt="image" src="https://github.com/user-attachments/assets/8194d84d-cb75-4c11-b1e3-7a033c841e31" />
<img width="786" height="251" alt="image" src="https://github.com/user-attachments/assets/e281d230-b6b7-42c3-853d-7510da75d923" />



Tabs 组件在 `showMoreTabs` 模式下，"更多"下拉菜单的溢出计算（`calcMorePanes`）存在滞后问题，表现为以下场景：

1. **初始加载时**：不可见的 tab 中，最靠左的一个没有出现在下拉菜单中（例如 tabs 1-5 可见，6-8 不可见，但下拉菜单只有 7、8，缺少 6）

2. **从下拉菜单点击 tab 后**：`scrollToActiveTab` 将 nav 滚动到目标 tab，使其变为可见，但下拉菜单中的内容不会更新——已变为可见的 tab 仍然显示在下拉菜单中

3. **点击可见 tab 后**：上一步下拉菜单中滞留的 tab 此时才消失，表现为"慢一拍"——上一个动作的结果在下一个动作时才结算

4. **连续操作**：从下拉菜单选 tab8 → 点回 tab4 → 点 `<` 箭头 → 下拉菜单打开失败或内容错误

**根因有两点：**

**a) CSS transition 干扰坐标读取**：`nav` 元素上有 `transition: transform 0.3s`。当 `scrollToActiveTab` 改变 `navOffset` 触发滚动时，tab 位置通过 CSS 动画在 0.3s 内逐渐过渡到新位置。但 `calcMorePanes` 在 `requestAnimationFrame` 回调中运行——此时 transition 尚未推进（动画尚未开始或刚处于第 0 帧），`getBoundingClientRect()` 返回的是过渡前的位置，导致溢出判断基于旧坐标。

**b) 级联 DOM 更新未充分等待**：`scrollToActiveTab` 修改 `navOffset` → TabNav 重渲染 → `updated()` 回调可能再次调整 `navOffset`（clamping）→ 再次重渲染。这是一个级联的微任务链，`nextTick`（`Promise.then`）只能等一轮 flush，无法保证所有级联更新都已落定。

## What is the new behavior?

1. **所有场景下下拉菜单内容与可见 tab 保持同步**：初始加载、从下拉菜单点击 tab、点击箭头滚动后，下拉菜单始终只显示真正不可见的 tab

2. **消除"慢一拍"滞后**：点击 tab 后立即正确计算溢出，不再需要下一个动作才结算

**修复方案：**

**a) Transition 不变公式**（`packages/renderless/src/tabs/index.ts`）：用 tab 相对于 nav 的位置差（`tabRect.left - navRect.left`）替代直接使用 `tabRect.left + tabRect.width / 2`。因为 tab 和 nav 共享同一个 `transform` 坐标系，CSS transition 对两者的偏移量始终相同，差值恒定不变。再结合目标 `navOffset` 值推算 transition 完成后的最终视口位置。该公式在有无 transition 的情况下均数学等价于旧公式，但不受 transition 中间状态干扰。

**b) requestAnimationFrame 替代 nextTick**（`packages/renderless/src/tabs/vue.ts`、`packages/vue/src/tabs/src/pc.vue`）：在 4 处异步刷新点（`onMounted`、`onUpdated`、`currentName` watcher、模板 render）用 `requestAnimationFrame` 延迟 `calcMorePanes` 调用。rAF 在所有微任务（包括级联的 Vue 更新）完成后、浏览器绘制前触发，确保读取到的 DOM 状态是最终落定的。

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

改动文件：

| 文件 | 改动说明 |
|---|---|
| `packages/renderless/src/tabs/index.ts` | 重写 `calcMorePanes`：用 transition 不变的几何公式替代直接坐标比较 |
| `packages/renderless/src/tabs/vue.ts` | onMounted/onUpdated/currentName watcher 三处添加 rAF 延迟重算 |
| `packages/vue/src/tabs/src/pc.vue` | render 函数中 $nextTick 内添加 rAF 延迟重算 |

`showPanesCount` 的语义不变（第一个不可见 tab 的索引，等于 tabs.length 时表示无溢出）。新增的 rAF 调用是对即时 `calcMorePanes()` 的补充，即时调用仍然保留以确保首次渲染和 `scrollPrev`/`scrollNext` 等场景的即时响应。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tab overflow detection when “Show more tabs” is enabled.
  - More accurately identifies hidden tabs, including tabs with dynamic widths and the space used by the “More” control.
  - Keeps overflow state synchronized after switching tabs, navigation updates, and previous/next arrow actions.
  - Prevents errors when tab navigation is unavailable.
  - Improves recalculation after layout and animation updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->