### PR TITLE
fix: 恢复指南菜单以及构建open模式，不带业务组件

### DIFF
--- a/examples/sites/src/menus.js
+++ b/examples/sites/src/menus.js
@@ -1,6 +1,5 @@
 import { docMenus, cmpMenus } from '@menu/menus.js'
 import { appData, $split } from './tools'
-import { isSaas } from './const'
 
 /**
  * 聚合doc  / cmp 两个页面的所有菜单.
@@ -27,20 +26,17 @@ function genMenus() {
     }
   ]
 
-  // 使用指南只在DEV下生效
-  const isShowDoc = import.meta.env.DEV || isSaas
-  const docOptions = isShowDoc
-    ? docMenus.map((menu) => ({
-        ...menu,
-        label: `${appData.lang === 'zhCN' ? menu.label : menu.labelEn}${getChildrenStr(menu)}`,
-        children: menu.children.map((page) => ({
-          ...page,
-          id: page.key,
-          label: appData.lang === 'zhCN' ? page.title : page.titleEn,
-          type: 'docs'
-        }))
-      }))
-    : []
+  // 使用指南永远显示 （原来屏蔽了，将指南和组件文档分隔开了)
+  const docOptions = docMenus.map((menu) => ({
+    ...menu,
+    label: `${appData.lang === 'zhCN' ? menu.label : menu.labelEn}${getChildrenStr(menu)}`,
+    children: menu.children.map((page) => ({
+      ...page,
+      id: page.key,
+      label: appData.lang === 'zhCN' ? page.title : page.titleEn,
+      type: 'docs'
+    }))
+  }))
 
   const cmpOptions = cmpMenus.map((menu) => ({
     ...menu,

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "build:hooks": "pnpm -C packages/vue-hooks build",
     "build:internals": "pnpm \"--filter=./internals/*\" build",
     "build:virtual-template": "pnpm --filter @opentiny-internal/unplugin-virtual-template build",
-    "build:site": "pnpm build:theme && pnpm -C examples/sites build",
+    "build:site": "pnpm build:theme && pnpm -C examples/sites build:open",
     "release:aurora": "pnpm -C internals/cli release:aurora",
     "release:alpha": "pnpm -C internals/cli release:alpha",
     "release:e2eConfig": "pnpm -C internals/cli release:e2eConfig",


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documentation menus are now consistently available across site environments.
  * Updated the site build process to use the open-site build command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->