### PR TITLE
fix(grid): When switching a multi-device table to mobile mode, it displays as blank.

### DIFF
--- a/packages/vue/src/grid/__tests__/markraw-parent.test.ts
+++ b/packages/vue/src/grid/__tests__/markraw-parent.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import { defineComponent, h, nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import MfTable from '../src/mobile-first/index.vue'
+
+/**
+ * 复现：多端表格在宽屏/移动端之间切换时报错
+ *   Cannot assign to read only property '__v_skip' of object '#<Object>'
+ *
+ * 根因：mobile-first/index.vue 曾通过 `hooks.markRaw(this.$parent)` 标记父组件
+ * 实例代理。Vue3 实例代理的 get 拦截器对 `__v_skip` 无条件返回 true，因此
+ * `reactive(parentProxy)` 本就不会包装父级——markRaw 在此完全冗余。但 markRaw
+ * 内部 `def(proxy, "__v_skip", true)` 会触发实例代理的 defineProperty 拦截器，
+ * 经 set 拦截器执行 `ctx.__v_skip = value`，再由 Reflect.defineProperty 改为
+ * 只读。由于父级 grid 实例在宽度切换时是同一个（只有 MfTable 反复挂载/卸载，
+ * 或 config 因 cardConfig/listConfig 变化而重算），第二次 markRaw 调用会再次
+ * 对只读的 __v_skip 赋值从而抛错。
+ *
+ * 修复：移除冗余且有害的 markRaw 调用，直接使用 `this.$parent`（与 Vue2 下
+ * hooks.markRaw 为 no-op 的行为一致）。
+ *
+ * 以下两个用例分别覆盖两种触发路径，修复前都会抛出该 TypeError。
+ */
+const stubs = ['Exception', 'CustomEmpty', 'Tooltip', 'TableRow', 'ListView', 'GanttView', 'CustomView']
+
+const gridState = () => ({
+  viewType: 'default',
+  mfShow: '',
+  slots: {},
+  renderEmpty: undefined,
+  loading: false,
+  maxHeight: 0,
+  height: 0
+})
+
+const makeParent = () =>
+  defineComponent({
+    inject: ['$grid'],
+    // cardConfig 声明为 prop，使 Root 传递的 cardConfig 能向下流转至 MfTable，
+    // 从而真正触发 MfTable 的 config 计算属性重算（覆盖 markRaw 回归路径）
+    props: {
+      cardConfig: { type: Object, default: () => ({}) }
+    },
+    data: () => ({
+      showMf: true,
+      tableColumn: [],
+      parentHeight: 0,
+      height: 0,
+      currentRow: null
+    }),
+    methods: {
+      viewCls() {
+        return ''
+      }
+    },
+    render() {
+      return this.showMf ? h(MfTable, { cardConfig: this.cardConfig, tableData: [] }) : h('div')
+    }
+  })
+
+describe('mobile-first grid config markRaw on $parent', () => {
+  it('does not throw when config recomputes (cardConfig changed)', async () => {
+    const errors: unknown[] = []
+    const Parent = makeParent()
+    const Root = defineComponent({
+      provide() {
+        return { $grid: gridState() }
+      },
+      data: () => ({ cardConfig: {} }),
+      render() {
+        return h(Parent, { cardConfig: this.cardConfig })
+      }
+    })
+    const wrapper = mount(Root, {
+      global: {
+        stubs,
+        config: { errorHandler: (e: unknown) => errors.push(e) }
+      }
+    })
+
+    expect(errors).toEqual([])
+
+    // cardConfig 变化 -> config 重新计算（修复前第二次 markRaw 抛错）
+    await wrapper.setData({ cardConfig: { a: 1 } })
+    await nextTick()
+
+    expect(errors).toEqual([])
+    // 验证 cardConfig 已传递至 MfTable，确保 config 确实重算
+    expect(wrapper.findComponent(MfTable).props('cardConfig')).toEqual({ a: 1 })
+  })
+
+  it('does not throw when MfTable remounts on the same parent (width toggle)', async () => {
+    const errors: unknown[] = []
+    const Parent = makeParent()
+    const Root = defineComponent({
+      provide() {
+        return { $grid: gridState() }
+      },
+      render() {
+        return h(Parent)
+      }
+    })
+    const wrapper = mount(Root, {
+      global: {
+        stubs,
+        config: { errorHandler: (e: unknown) => errors.push(e) }
+      }
+    })
+
+    expect(errors).toEqual([])
+
+    const parent = wrapper.findComponent(Parent).vm
+    // 卸载 MfTable（宽屏 -> 不渲染移动端表格）
+    parent.showMf = false
+    await nextTick()
+    // 重新挂载 MfTable（切回移动端宽度，复用同一父级实例）
+    parent.showMf = true
+    await nextTick()
+
+    expect(errors).toEqual([])
+  })
+})

--- a/packages/vue/src/grid/src/mobile-first/index.vue
+++ b/packages/vue/src/grid/src/mobile-first/index.vue
@@ -45,7 +45,7 @@
 <script lang="ts">
 import { emitEvent, isScale, getRowid } from '@opentiny/vue-renderless/grid/utils'
 import { toNumber } from '@opentiny/vue-renderless/grid/static'
-import { hooks, defineComponent, mergeClass } from '@opentiny/vue-common'
+import { defineComponent, mergeClass } from '@opentiny/vue-common'
 import Tooltip from '@opentiny/vue-tooltip'
 import Exception from '@opentiny/vue-exception'
 import type { Column, CardConfig, Datas } from './type'
@@ -87,7 +87,7 @@ export default defineComponent({
   computed: {
     config() {
       const { $parent: vm, cardConfig, listConfig } = this as any
-      return { tableVm: hooks.markRaw(vm), cardConfig, listConfig }
+      return { tableVm: vm, cardConfig, listConfig }
     },
     cardView() {
       const { config } = this as any


### PR DESCRIPTION
# PR
fix(grid):多端表格切换到移动端时显示空白

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the mobile-first grid when its configuration updates.
  * Fixed errors that could occur when the table is unmounted and remounted under the same parent component.

* **Tests**
  * Added coverage for configuration recomputation and table remount scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->