### PR TITLE
fix(demos): 多选个数限制示例不再与自定义图标示例共用 v-model(#4285)

### DIFF
--- a/examples/sites/demos/mobile-first/app/base-select/multiple.vue
+++ b/examples/sites/demos/mobile-first/app/base-select/multiple.vue
@@ -41,7 +41,7 @@
     <div>场景 5：自定义图标 + 自定义样式</div>
     <br />
     <tiny-base-select
-      v-model="value4"
+      v-model="value5"
       multiple
       :dropdown-icon="iconPopup"
       :drop-style="{ width: '200px', 'min-width': '200px' }"
@@ -85,6 +85,7 @@ export default {
       value2: ['选项 1', '选项 2'],
       value3: ['选项 1', '选项 2'],
       value4: [],
+      value5: [],
       iconPopup: iconPopup()
     }
   }

--- a/examples/sites/demos/pc/app/base-select/multiple-composition-api.vue
+++ b/examples/sites/demos/pc/app/base-select/multiple-composition-api.vue
@@ -41,7 +41,7 @@
     <div>场景 5：自定义图标 + 自定义样式</div>
     <br />
     <tiny-base-select
-      v-model="value4"
+      v-model="value5"
       multiple
       :dropdown-icon="tinyIconPopup"
       :drop-style="{ width: '200px', 'min-width': '200px' }"
@@ -81,6 +81,7 @@ const value1 = ref(['选项 1', '选项 2'])
 const value2 = ref(['选项 1', '选项 2'])
 const value3 = ref([])
 const value4 = ref([])
+const value5 = ref([])
 const tinyIconPopup = iconPopup()
 </script>
 

--- a/examples/sites/demos/pc/app/base-select/multiple.vue
+++ b/examples/sites/demos/pc/app/base-select/multiple.vue
@@ -41,7 +41,7 @@
     <div>场景 5：自定义图标 + 自定义样式</div>
     <br />
     <tiny-base-select
-      v-model="value4"
+      v-model="value5"
       multiple
       :dropdown-icon="iconPopup"
       :drop-style="{ width: '200px', 'min-width': '200px' }"
@@ -85,6 +85,7 @@ export default {
       value2: ['选项 1', '选项 2'],
       value3: ['选项 1', '选项 2'],
       value4: [],
+      value5: [],
       iconPopup: iconPopup()
     }
   }

--- a/examples/sites/demos/pc/app/select/multiple-composition-api.vue
+++ b/examples/sites/demos/pc/app/select/multiple-composition-api.vue
@@ -43,7 +43,7 @@
     <div>场景 5：自定义图标 + 自定义样式</div>
     <br />
     <tiny-select
-      v-model="value4"
+      v-model="value6"
       multiple
       :options="options1"
       :dropdown-icon="tinyIconPopup"
@@ -129,6 +129,7 @@ const value2 = ref(['选项 1', '选项 2'])
 const value3 = ref(['选项 1', '选项 2'])
 const value4 = ref([])
 const value5 = ref(['选项 1', '选项 2', '选项 3', '选项 4', '选项 5', '选项 6', '选项 7'])
+const value6 = ref([])
 const tinyIconPopup = iconPopup()
 </script>
 

--- a/examples/sites/demos/pc/app/select/multiple.vue
+++ b/examples/sites/demos/pc/app/select/multiple.vue
@@ -43,7 +43,7 @@
     <div>场景 5：自定义图标 + 自定义样式</div>
     <br />
     <tiny-select
-      v-model="value4"
+      v-model="value6"
       multiple
       :options="options1"
       :dropdown-icon="iconPopup"
@@ -133,6 +133,7 @@ export default {
       value3: ['选项 1', '选项 2'],
       value4: [],
       value5: ['选项 1', '选项 2', '选项 3', '选项 4', '选项 5', '选项 6', '选项 7'],
+      value6: [],
       iconPopup: iconPopup()
     }
   }


### PR DESCRIPTION

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4285 

Select 与 BaseSelect 组件的「多选」示例中，场景 4「多选个数限制」（`:multiple-limit="2"`）与场景 5「自定义图标 + 自定义样式」共用同一个 `v-model="value4"`，两者双向绑定同一份选中数据。

当在场景 5 中选中 3 个及以上选项后，场景 4 也会同步显示 3 个以上已选标签，突破了它自身标明的「最多选择 2 个」的限制，与示例描述不符。

## What is the new behavior?

为场景 5 分配独立 model，两个场景互不影响：

- **base-select 示例**：场景 5 改用 `value5`（`value4` 仍由场景 4 独占）
- **select 示例**：场景 5 改用 `value6`（`value5` 仍由场景 6-11 共用，用于展示同一组选中值的不同形态）

现在场景 4 严格遵循 `multiple-limit="2"`，无论场景 5 如何操作，最多只显示/选中 2 个选项。

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

改动仅涉及 5 个示例文件，不影响组件运行时逻辑：

- `examples/sites/demos/pc/app/base-select/multiple.vue`
- `examples/sites/demos/pc/app/base-select/multiple-composition-api.vue`
- `examples/sites/demos/mobile-first/app/base-select/multiple.vue`
- `examples/sites/demos/pc/app/select/multiple.vue`
- `examples/sites/demos/pc/app/select/multiple-composition-api.vue`

未新增测试：现有 E2E（`multiple.spec.ts`）通过 `.nth(3)` 直接操作场景 4，DOM 顺序未变，且依赖组件自身的 multiple-limit 拦截逻辑，不受本次改动影响。组件在用户直接交互时能正确拦截超出限制的选择，本次仅修复示例代码层面问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected multi-select demonstrations so each scenario maintains its own independent selection.
  * Prevented selections in one example scenario from unexpectedly affecting another.
  * Updated both standard and composition API examples across mobile-first and desktop demos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->