### PR TITLE
docs(date-picker): 收窄 align demo 输入框，清晰展示左中右对齐效果 

### DIFF
--- a/examples/sites/demos/pc/app/date-picker/align-composition-api.vue
+++ b/examples/sites/demos/pc/app/date-picker/align-composition-api.vue
@@ -31,6 +31,7 @@ const value = ref('')
 
 <style scoped>
 .demo-date-picker-wrap {
-  width: 360px;
+  /* 输入框收窄到 240px，比面板默认宽度 360px 窄，宽度差让 left/center/right 对齐效果清晰可见 */
+  width: 240px;
 }
 </style>

--- a/examples/sites/demos/pc/app/date-picker/align.vue
+++ b/examples/sites/demos/pc/app/date-picker/align.vue
@@ -39,6 +39,7 @@ export default {
 
 <style scoped>
 .demo-date-picker-wrap {
-  width: 360px;
+  /* 输入框收窄到 240px，比面板默认宽度 360px 窄，宽度差让 left/center/right 对齐效果清晰可见 */
+  width: 240px;
 }
 </style>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
<img width="663" height="364" alt="image" src="https://github.com/user-attachments/assets/68f379de-2e48-409d-88d4-575c49334f29" />

`date-picker` 的 `align` demo 展示了 `left` / `center` / `right` 三种对齐方式，但 demo 容器宽度为 360px，恰好等于日期面板的默认宽度（主题变量 `--tv-DatePanel-width: 360px`）。当面板与输入框等宽时，三种对齐的偏移校正结果在几何上完全相同（`bottom-start`、`bottom`、`bottom-end` 均等于 `reference.left`），用户无法观察到对齐差异，demo 失去展示意义。

Issue Number: N/A

## What is the new behavior?

将 demo 输入框容器宽度从 360px 收窄到 240px，与面板默认宽度产生 120px 的宽度差，使三种对齐方式清晰可辨：

- `align="left"`：面板左边缘与输入框左边缘对齐
- `align="center"`：面板与输入框水平中线对齐
- `align="right"`：面板右边缘与输入框右边缘对齐

该改动仅影响 demo 展示（docs 站点），使用 scoped 样式，不影响组件库代码、主题样式及既有 E2E 测试（`align.spec.ts` 仅断言面板的 `x-placement` 属性，与宽度无关）。

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted the date-picker demo layout to use a narrower wrapper for improved presentation.
  * Applied the updated sizing consistently across both date-picker examples.
  * Added clarification explaining the revised layout dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->