### PR TITLE
fix(clickoutside): 修复拖选文本时误触发外部点击关闭的问题 

### DIFF
--- a/examples/sites/demos/pc/app/color-picker/base.spec.ts
+++ b/examples/sites/demos/pc/app/color-picker/base.spec.ts
@@ -10,3 +10,25 @@ test('基本用法', async ({ page }) => {
   await page.locator('.tiny-color-select-panel__inner__color-select').click()
   await page.getByRole('button', { name: '确定' }).click()
 })
+
+test('在 hex 输入框内拖选文本、鼠标移出面板后松开，面板不应误关闭', async ({ page }) => {
+  page.on('pageerror', (exception) => expect(exception).toBeNull())
+  await page.goto('color-picker#basic-usage')
+  await page.locator('.tiny-color-picker__inner').click()
+
+  const panel = page.locator('.tiny-color-select-panel')
+  await expect(panel).toBeVisible()
+
+  const input = panel.locator('.tiny-color-select-panel__tools-hex1 input')
+  const box = await input.boundingBox()
+  expect(box).not.toBeNull()
+
+  // 模拟用户拖选 hex 输入框文本：在输入框内按下，拖出面板后松开
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(box.x - 300, box.y + box.height / 2, { steps: 10 })
+  await page.mouse.up()
+
+  // mousedown 发生在面板内部，拖选不应被误判为「点击外部」而关闭面板
+  await expect(panel).toBeVisible()
+})

--- a/packages/vue-directive/src/clickoutside.ts
+++ b/packages/vue-directive/src/clickoutside.ts
@@ -15,33 +15,51 @@ import { on, isServer } from '@opentiny/utils'
 const nodeList = []
 const nameSpace = '@@clickoutsideContext'
 let startClick
+let startClickPath
 let seed = 0
 
 if (!isServer) {
   on(document, 'mousedown', (event) => {
     startClick = event
+    // composedPath() 在事件派发完成后会返回空数组，这里在派发中缓存 mousedown 的完整路径
+    startClickPath = event.composedPath ? event.composedPath() : [event.target]
     nodeList
       .filter((node) => node[nameSpace].mousedownTrigger)
-      .forEach((node) => node[nameSpace].documentHandler(event, startClick))
+      .forEach((node) => node[nameSpace].documentHandler(event, startClick, startClickPath))
   })
 
   on(document, 'mouseup', (event) => {
     nodeList
       .filter((node) => !node[nameSpace].mousedownTrigger)
-      .forEach((node) => node[nameSpace].documentHandler(event, node[nameSpace]?.mouseupTrigger ? event : startClick))
+      .forEach((node) => {
+        const isMouseupTrigger = node[nameSpace]?.mouseupTrigger
+        node[nameSpace].documentHandler(
+          event,
+          isMouseupTrigger ? event : startClick,
+          // mouseupTrigger 模式下 mousedown 参数即当前派发中的 mouseup 事件，路径仍有效；
+          // 否则 mousedown 已派发完毕，必须使用派发时缓存的路径
+          isMouseupTrigger ? null : startClickPath
+        )
+      })
     startClick = null
+    startClickPath = null
   })
 }
 
 const createDocumentHandler = (el, binding, vnode) =>
-  function (mouseup = {}, mousedown = {}) {
+  function (mouseup = {}, mousedown = {}, cachedMousedownPath) {
     const popperElm = vnode.context.popperElm || (vnode.context.state && vnode.context.state.popperElm)
 
     // 使用 event.composedPath() 来处理 Shadow DOM 场景。
     // composedPath() 会返回事件的完整路径，即使事件穿过了 Shadow DOM 的边界。
     // 这确保了即使 popperElm 在 Shadow DOM 外部（或组件本身在 Shadow DOM 内部），
     // 我们也能准确判断点击是否发生在组件或其 popper 内部。
-    const mousedownPath = mousedown?.composedPath?.() || [mousedown?.target]
+    // 注意：composedPath() 在事件派发完成后会返回空数组，而 mousedown 在 mouseup
+    // 处理时早已派发完毕，因此 mousedown 的路径必须在派发时缓存（cachedMousedownPath）后传入。
+    const mousedownPath =
+      cachedMousedownPath && cachedMousedownPath.length
+        ? cachedMousedownPath
+        : mousedown?.composedPath?.() || [mousedown?.target]
     const mouseupPath = mouseup?.composedPath?.() || [mouseup?.target]
     const isClickInEl = mousedownPath.includes(el) || mouseupPath.includes(el)
     const isClickInPopper = popperElm && (mousedownPath.includes(popperElm) || mouseupPath.includes(popperElm))
@@ -107,6 +125,7 @@ export default {
 
     if (nodeList.length === 0 && startClick) {
       startClick = null
+      startClickPath = null
     }
     delete el[nameSpace]
   }


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

复现场景（以 color-picker 为例）：

<img width="821" height="428" alt="image" src="https://github.com/user-attachments/assets/e1191d48-85f4-495b-b1cb-6c69c930bf7a" />

1. 点击色块打开颜色选择面板
2. 在 hex 输入框中**按住鼠标左键**拖选文本（如全选颜色值）
3. 拖选过程中鼠标移出面板区域，再松开鼠标

结果：面板会被误判为"点击外部"而**直接关闭**。而鼠标全程保持在组件内部拖选，则不会关闭。

根因：

`v-clickoutside` 指令在 document 的 `mousedown` 时把事件对象存入 `startClick`，等到 `mouseup` 时才调用 `startClick.composedPath()` 判断按下位置。但根据 DOM 规范，`Event.composedPath()` 只在**事件派发过程中**返回路径，事件派发完毕后返回空数组 `[]`。因此 mouseup 处理时拿到的 mousedown 路径恒为空数组，`mousedownPath.includes(el)` 永远为 `false`，导致"mousedown 在组件内部"的保护判断失效，最终仅按 mouseup 的位置判断，把"组件内按下 + 组件外松开"的拖选误判为外部点击。

Issue Number: N/A

## What is the new behavior?

修复后，只要 `mousedown` 发生在组件内部（即使鼠标拖到组件外才松开），都不会触发外部点击关闭；只有 mousedown 和 mouseup 都在组件外部时才会关闭。这符合指令的设计意图：*"当没有修饰符时，需要同时满足在目标元素外同步按下和释放鼠标才会触发回调"*。

修复方式：在 mousedown 派发时**立即缓存**完整的 `composedPath`，mouseup 时使用缓存路径，避免事件派发完毕后路径丢失。

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

**影响范围**：修复位于公共指令 `packages/vue-directive/src/clickoutside.ts`，所有使用 `v-clickoutside` 的组件（autocomplete、select、cascader、date-picker、dropdown、input、tree 等）均会受益；行为变化仅针对"组件内按下拖到外部松开"这一此前错误的场景，点击外部关闭、点击内部保持这两个核心行为均不变。

**验证**：新增回归测试 `examples/sites/demos/pc/app/color-picker/base.spec.ts`（拖选后面板不应关闭），修复前失败、修复后通过；另已本地验证拖选不关闭、面板内点击保持、点击外部正常关闭。

**提交**：
- `2a3f75c` fix(clickoutside): 缓存 mousedown 的 composedPath
- `85561c6` test(color-picker): 增加拖选回归测试

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where dragging text from the color input outside the color picker could incorrectly close the panel.
  * Improved click-outside behavior for interactions involving complex event paths.

* **Tests**
  * Added regression coverage to verify the color picker remains open during text dragging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->