### PR TITLE
fix: svg function supports a bottom padding style across multiple devices.

### DIFF
--- a/examples/sites/src/views/layout/layout.vue
+++ b/examples/sites/src/views/layout/layout.vue
@@ -201,8 +201,11 @@ export default defineComponent({
   --layout-content-main-min-width: 200px;
   --layout-content-main-max-width: 1000px;
 }
+
 @media screen and (max-width: 640px) {
-  --layout-content-main-min-width: 600px;
+  .content-layout {
+    --layout-content-main-min-width: 600px;
+  }
 }
 
 .tiny-tooltip.tiny-tooltip__popper.is-light.docs-tooltip {
@@ -222,6 +225,7 @@ export default defineComponent({
   &:hover {
     cursor: pointer;
   }
+
   .lang-btn {
     font-weight: 600;
     font-size: 26px;
@@ -302,15 +306,18 @@ export default defineComponent({
   .tiny-tree-node__content {
     position: relative;
   }
+
   .absolute-tag {
     position: absolute;
     right: 8px;
     top: 13px;
   }
+
   .tiny-tree {
     height: calc(100% - var(--layout-tree-menu-input-height));
     overflow-y: auto;
   }
+
   .tree-node-name {
     line-height: 1.5;
 
@@ -337,10 +344,12 @@ export default defineComponent({
       }
     }
   }
+
   & > .tiny-input .tiny-input__inner {
     height: var(--layout-tree-menu-input-height);
     font-size: 14px;
   }
+
   .tiny-tree-node__content {
     margin-top: 8px;
   }
@@ -372,6 +381,7 @@ export default defineComponent({
     padding-left: 30px;
     background: #fff;
     overflow: hidden;
+
     .api-mode {
       color: rgba(60, 60, 60, 0.33);
 
@@ -383,6 +393,7 @@ export default defineComponent({
     .api-switch {
       margin: 0 5px;
     }
+
     & > .tiny-svg {
       font-size: 18px;
       margin-left: 8px;
@@ -419,10 +430,12 @@ html.dark #layoutSider {
     display: none;
     position: fixed;
     height: 100%;
+
     .tiny-tree-menu__toggle-button {
       display: none;
     }
   }
+
   #layoutSider.showMenu {
     display: block !important;
     z-index: var(--docs-layout-sider-zindex);

--- a/packages/vue-common/src/index.ts
+++ b/packages/vue-common/src/index.ts
@@ -353,7 +353,12 @@ export function svg({ name = 'Icon', component, filledComponent = null, deprecat
           }
 
           if (isMobileFirst) {
-            className = mergeClass('h-4 w-4 inline-block', customClass || '', mergeProps.class || '')
+            className = mergeClass(
+              props.underlay ? 'tiny-svg-underlay' : '',
+              'h-4 w-4 inline-block',
+              customClass || '',
+              mergeProps.class || ''
+            )
           }
 
           const extend = Object.assign(


### PR DESCRIPTION
# PR
svg 函数，支持多端的托底样式
fix: 消除一行css 警告


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile layout styling by scoping responsive CSS variables to the content layout.
  * Improved mobile-first SVG rendering when underlay styling is enabled.
* **Style**
  * Added spacing within style blocks for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->