### PR TITLE
fix(input): 为密码可见性切换按钮补上 mousedown.prevent，修复连续点击时误选中页面文本

### DIFF
--- a/packages/vue/src/input/src/mobile-first.vue
+++ b/packages/vue/src/input/src/mobile-first.vue
@@ -232,6 +232,7 @@
             role="button"
             :aria-label="state.passwordVisible ? 'hide password' : 'show password'"
             tabindex="0"
+            @mousedown.prevent
             @click.native="handlePasswordVisible"
           ></component>
           <component
@@ -246,6 +247,7 @@
             role="button"
             :aria-label="state.maskValueVisible ? 'hide content' : 'show content'"
             tabindex="0"
+            @mousedown.prevent
             @click.native="state.maskValueVisible = !state.maskValueVisible"
           ></component>
           <span

--- a/packages/vue/src/input/src/pc.vue
+++ b/packages/vue/src/input/src/pc.vue
@@ -143,6 +143,7 @@
                 role="button"
                 :aria-label="state.passwordVisible ? 'hide password' : 'show password'"
                 tabindex="0"
+                @mousedown.prevent
                 @click.native="handlePasswordVisible"
               ></component>
               <component
@@ -152,6 +153,7 @@
                 role="button"
                 :aria-label="state.maskValueVisible ? 'hide content' : 'show content'"
                 tabindex="0"
+                @mousedown.prevent
                 @click.native="state.maskValueVisible = !state.maskValueVisible"
               ></component>
               <span


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

<img width="952" height="533" alt="image" src="https://github.com/user-attachments/assets/06276109-fbae-41a9-b29c-b7e91d933658" />
<img width="841" height="437" alt="image" src="https://github.com/user-attachments/assets/ae60b545-0d59-4c3d-a5d7-1037435e2418" />

连续快速点击 Input 组件 `show-password`（密码可见性切换）按钮时，浏览器会将连续点击识别为双击/三击，触发原生文本选择行为，导致页面上的其他文字（如按钮下方的标题/标签文本）被意外选中——有时选中部分文字，有时全部选中。

清除按钮（`icon-close`）已通过 `@mousedown.prevent` 避免该问题，但眼睛按钮漏掉了同样的防护。

Issue Number: N/A

## What is the new behavior?

为 `show-password` 与 `mask` 的 4 处眼睛按钮补充 `@mousedown.prevent`，阻止浏览器 mousedown 默认的文本选择手势；连续点击不再误选中页面文本，与组件内清除按钮的既有写法保持一致。

`@mousedown.prevent` 不影响 `click`（密码显隐切换正常）、键盘可达性、移动端 tap 与滚动、hover 样式；点击后 `handlePasswordVisible` 仍通过 `nextTick(api.focus)` 将焦点归还输入框。

验证：Input 单元测试套件 53 通过 / 1 跳过 / 4 todo，`show-password` 用例通过；浏览器手动确认连续点击不再选中文本。

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

**根因**：眼睛按钮为 SVG 图标（`role="button"`、`tabindex="0"`），自身无 `user-select: none`，且缺少 `@mousedown.prevent` 时，浏览器连续点击（双击选词/三击选段）会把选区锚定在点击处并吸附到最近的文本节点。

**修改文件**：

- `packages/vue/src/input/src/pc.vue`
- `packages/vue/src/input/src/mobile-first.vue`

**说明**：本次提交未新增单元测试（`show-password` 已有用例覆盖显隐切换逻辑）；如维护者希望补充回归测试，可增加一条断言眼睛按钮 mousedown 处理器调用 `preventDefault` 的用例。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password visibility and masked-content toggles by preventing unintended mouse behavior before activation.
  * Ensured toggle icons respond more reliably without disrupting input focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->