### PR TITLE
fix(slider-button-group): lost ref in pc.vue

### DIFF
--- a/packages/vue/src/slider-button-group/src/pc.vue
+++ b/packages/vue/src/slider-button-group/src/pc.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tiny-slider-button-group">
+  <div class="tiny-slider-button-group" ref="sliderButtonGroup">
     <component v-if="!pageTurn" :is="state.tag" class="tiny-slider-button-group-inline-flex" role="sliderButtonGroup">
       <div class="tiny-slider-button-group-box">
         <div


### PR DESCRIPTION
# PR
修复Pc模板缺少ref引用 
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved access to the slider button group container for more reliable interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->