### PR TITLE
fix(common): inject design into child components and add a fallback variable.

### DIFF
--- a/packages/vue-common/src/index.ts
+++ b/packages/vue-common/src/index.ts
@@ -169,7 +169,8 @@ export const customDesignConfig: CustomDesignConfig = {
 
 const getDesignConfig = () => {
   // 获取组件级配置和全局配置（inject需要带有默认值，否则控制台会报警告）
-  let globalDesignConfig: DesignConfig = customDesignConfig.designConfig || hooks.inject(design.configKey, {})
+  let globalDesignConfig: DesignConfig =
+    customDesignConfig.designConfig || hooks.inject(design.configKey, null) || design.configInstance
 
   // globalDesignConfig 可能是响应式对象，比如 computed
   globalDesignConfig = globalDesignConfig?.value || globalDesignConfig || {}


### PR DESCRIPTION
# PR
fix(common): 为子组件注入design添加兜底变量

## 目的
为createComponent的方式创建组件时， 也能使用design中的变量

## 带来风险
由于增加了兜底变量， 所以只要页面上，有 configeProvider组件注入了一个design变量，
那么任意位置的组件，都会接收到这个design的值（因为兜底的原因）

需要评估一下。





## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved design configuration resolution by also using the stored configuration when custom or injected settings are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->