### PR TITLE
feat(form-item): [form-item] add no-style support

### DIFF
--- a/examples/sites/demos/apis/form.js
+++ b/examples/sites/demos/apis/form.js
@@ -430,6 +430,18 @@ export default {
           pcDemo: 'message-type'
         },
         {
+          name: 'no-style',
+          type: 'boolean',
+          defaultValue: 'false',
+          desc: {
+            'zh-CN': '是否移除表单项的内置布局样式，仅渲染默认插槽内容',
+            'en-US': 'Whether to remove the built-in layout and render only the default slot content'
+          },
+          mode: ['pc', 'mobile-first'],
+          pcDemo: '',
+          mfDemo: ''
+        },
+        {
           name: 'prop',
           type: 'string',
           defaultValue: '',

--- a/examples/sites/demos/apis/form.js
+++ b/examples/sites/demos/apis/form.js
@@ -433,6 +433,9 @@ export default {
           name: 'no-style',
           type: 'boolean',
           defaultValue: 'false',
+          meta: {
+            stable: '3.32.0'
+          },
           desc: {
             'zh-CN': '是否移除表单项的内置布局样式，仅渲染默认插槽内容',
             'en-US': 'Whether to remove the built-in layout and render only the default slot content'

--- a/packages/vue/src/form-item/__tests__/form-item.test.tsx
+++ b/packages/vue/src/form-item/__tests__/form-item.test.tsx
@@ -39,13 +39,17 @@ describe('PC Mode', () => {
 })
 
 describe('Mobile-first Mode', () => {
-  test('should remove built-in layout when no-style is true', () => {
+  test('should remove built-in layout while preserving validation when no-style is true', async () => {
+    const model = { name: '' }
+    const rules = { name: [{ required: true, message: 'Name is required' }] }
     const wrapper = mountMobilefirstMode({
-      components: { TinyForm: Form, TinyFormItem: FormItem },
+      components: { TinyForm: Form, TinyFormItem: FormItem, TinyInput: Input },
+      data: () => ({ model, rules }),
       template: `
-        <tiny-form>
-          <tiny-form-item no-style>
+        <tiny-form :model="model" :rules="rules">
+          <tiny-form-item prop="name" no-style>
             <span data-testid="content">Content</span>
+            <tiny-input v-model="model.name"></tiny-input>
           </tiny-form-item>
         </tiny-form>
       `
@@ -54,5 +58,15 @@ describe('Mobile-first Mode', () => {
     expect(wrapper.find('[data-tag="tiny-form-item"]').exists()).toBe(false)
     expect(wrapper.find('[data-tag="tiny-form-item-inline"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="content"]').text()).toBe('Content')
+    expect(wrapper.findComponent(Input).exists()).toBe(true)
+
+    const formWrapper = wrapper.findComponent(Form)
+    const form = formWrapper.componentVM || formWrapper.vm
+    const valid = await form
+      .validate()
+      .then(() => true)
+      .catch(() => false)
+
+    expect(valid).toBe(false)
   })
 })

--- a/packages/vue/src/form-item/__tests__/form-item.test.tsx
+++ b/packages/vue/src/form-item/__tests__/form-item.test.tsx
@@ -1,0 +1,58 @@
+import { mountMobilefirstMode, mountPcMode } from '@opentiny-internal/vue-test-utils'
+import { describe, expect, test } from 'vitest'
+import Form from '@opentiny/vue-form'
+import FormItem from '@opentiny/vue-form-item'
+import Input from '@opentiny/vue-input'
+
+describe('PC Mode', () => {
+  test('should remove built-in layout while preserving validation when no-style is true', async () => {
+    const model = { name: '' }
+    const rules = { name: [{ required: true, message: 'Name is required' }] }
+    const wrapper = mountPcMode({
+      components: { TinyForm: Form, TinyFormItem: FormItem, TinyInput: Input },
+      data: () => ({ model, rules }),
+      template: `
+        <tiny-form :model="model" :rules="rules">
+          <tiny-form-item label="Name" prop="name" no-style>
+            <tiny-input v-model="model.name"></tiny-input>
+          </tiny-form-item>
+        </tiny-form>
+      `
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.tiny-form-item').exists()).toBe(false)
+    expect(wrapper.find('.tiny-form-item__label').exists()).toBe(false)
+    expect(wrapper.find('.tiny-form-item__content').exists()).toBe(false)
+    expect(wrapper.findComponent(Input).exists()).toBe(true)
+
+    const formWrapper = wrapper.findComponent(Form)
+    const form = formWrapper.componentVM || formWrapper.vm
+    const valid = await form
+      .validate()
+      .then(() => true)
+      .catch(() => false)
+
+    expect(valid).toBe(false)
+  })
+})
+
+describe('Mobile-first Mode', () => {
+  test('should remove built-in layout when no-style is true', () => {
+    const wrapper = mountMobilefirstMode({
+      components: { TinyForm: Form, TinyFormItem: FormItem },
+      template: `
+        <tiny-form>
+          <tiny-form-item no-style>
+            <span data-testid="content">Content</span>
+          </tiny-form-item>
+        </tiny-form>
+      `
+    })
+
+    expect(wrapper.find('[data-tag="tiny-form-item"]').exists()).toBe(false)
+    expect(wrapper.find('[data-tag="tiny-form-item-inline"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="content"]').text()).toBe('Content')
+  })
+})

--- a/packages/vue/src/form-item/src/index.ts
+++ b/packages/vue/src/form-item/src/index.ts
@@ -33,6 +33,7 @@ export const formItemProps = {
   },
   labelWidth: String,
   manual: Boolean,
+  noStyle: Boolean,
   popperOptions: {
     type: Object,
     default: () => ({})

--- a/packages/vue/src/form-item/src/mobile-first.vue
+++ b/packages/vue/src/form-item/src/mobile-first.vue
@@ -1,5 +1,9 @@
 <template>
+  <div v-if="noStyle">
+    <slot></slot>
+  </div>
   <div
+    v-else
     data-tag="tiny-form-item"
     role="group"
     :aria-labelledby="state.labelId"
@@ -189,6 +193,7 @@ export default defineComponent({
     },
     labelWidth: String,
     manual: Boolean,
+    noStyle: Boolean,
     popperOptions: {
       type: Object,
       default: () => ({})

--- a/packages/vue/src/form-item/src/pc.vue
+++ b/packages/vue/src/form-item/src/pc.vue
@@ -65,6 +65,7 @@ export default defineComponent({
     label: String,
     labelWidth: String,
     manual: Boolean,
+    noStyle: Boolean,
     popperOptions: {
       type: Object,
       default: () => ({})
@@ -114,6 +115,7 @@ export default defineComponent({
       inlineMessage,
       ellipsis,
       vertical,
+      noStyle,
       handleLabelMouseenter,
       handleMouseleave
     } = this as unknown as IFormItemInstance
@@ -121,8 +123,13 @@ export default defineComponent({
     const { validateIcon, isErrorInline, isErrorBlock, tooltipType } = state
     const isMobile = state.mode === 'mobile'
     const classPrefix = isMobile ? 'tiny-mobile-' : 'tiny-'
-    const labelSlot = slots.label ? slots.label() : null
     const defaultSlots = slots.default ? slots.default() : null
+
+    if (noStyle) {
+      return h('div', defaultSlots)
+    }
+
+    const labelSlot = slots.label ? slots.label() : null
     const errorSlot = scopedSlots.error && scopedSlots.error(state.validateMessage)
     const formItemClass = `${classPrefix}form-item--${state.sizeClass ? state.sizeClass : 'default'}`
     const isShowError = state.validateState === 'error' && showMessage && state.form.showMessage


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

FormItem always renders its built-in label, content, validation-message layout, and related styling.

Fixes #4233

## What is the new behavior?

Adds a `no-style` boolean prop for PC and mobile-first modes. When enabled, FormItem renders only its default slot inside an unstyled container while keeping the renderless FormItem instance mounted, so field registration and form validation continue to work.

The public API documentation is updated and unit tests cover layout removal in PC/mobile-first modes plus validation preservation in both modes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Validation

- Vue 3 targeted FormItem tests, including mobile-first validation: 2 passed
- Prettier check: passed
- `git diff --check`: passed
- Vue 2 targeted re-run is pending repository CI; the local workspace currently stops before test collection because Vue and `vue-template-compiler` resolve to mismatched versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `no-style` option to form items, defaulting to disabled.
  * When enabled, form items render slot content without built-in labels, wrappers, layout styling, or validation UI.
  * Supported in both PC and mobile-first modes.

* **Documentation**
  * Documented the new option and its default behavior.

* **Tests**
  * Added coverage for rendering, input and slot content, and required-field validation in both modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->