### PR TITLE
fix(fluent-editor): solve the problem of some title prompts disappearing from the toolbar

### DIFF
--- a/examples/sites/demos/pc/app/fluent-editor/options.spec.ts
+++ b/examples/sites/demos/pc/app/fluent-editor/options.spec.ts
@@ -6,4 +6,7 @@ test('编辑器配置', async ({ page }) => {
   const demo = page.locator('#options')
   const cls = demo.locator('.tiny-editor-wrapper .ql-toolbar.ql-snow .ql-formats > button')
   await expect(cls).toHaveCount(14)
+  await expect(demo.locator('.ql-align[value=""]')).toHaveAttribute('title', '居左对齐')
+  await expect(demo.locator('.ql-align[value="center"]')).toHaveAttribute('title', '居中对齐')
+  await expect(demo.locator('.ql-align[value="right"]')).toHaveAttribute('title', '居右对齐')
 })

--- a/packages/renderless/src/fluent-editor/index.ts
+++ b/packages/renderless/src/fluent-editor/index.ts
@@ -1090,6 +1090,7 @@ const getToolbarTitle = (t) => {
     { selector: '.ql-header[value="2"]', title: t('ui.richText.header2') },
     { selector: '.ql-list[value="ordered"]', title: t('ui.richText.listOrdered') },
     { selector: '.ql-list[value="bullet"]', title: t('ui.richText.listBullet') },
+    { selector: '.ql-list[value="check"]', title: t('ui.richText.listCheck') },
     { selector: '.ql-script[value="sub"]', title: t('ui.richText.subScript') },
     { selector: '.ql-script[value="super"]', title: t('ui.richText.superScript') },
     { selector: '.ql-indent[value="-1"]', title: t('ui.richText.indent1') },
@@ -1097,10 +1098,16 @@ const getToolbarTitle = (t) => {
     { selector: '.ql-direction[value="rtl"]', title: t('ui.richText.directionRTL') },
     { selector: '.ql-color', title: t('ui.richText.color') },
     { selector: '.ql-background', title: t('ui.richText.background') },
-    { selector: '.ql-align', title: t('ui.richText.align') },
-    { selector: '.ql-align .ql-picker-item', title: t('ui.richText.alignPicker1') },
+    { selector: '.ql-align.ql-picker', title: t('ui.richText.align') },
+    { selector: '.ql-align[value=""]', title: t('ui.richText.alignPicker1') },
+    { selector: 'button.ql-align:not([value])', title: t('ui.richText.alignPicker1') },
+    { selector: '.ql-align[value="center"]', title: t('ui.richText.alignPicker2') },
+    { selector: '.ql-align[value="right"]', title: t('ui.richText.alignPicker3') },
+    { selector: '.ql-align[value="justify"]', title: t('ui.richText.alignPicker4') },
+    { selector: '.ql-align .ql-picker-item:not([data-value])', title: t('ui.richText.alignPicker1') },
     { selector: '.ql-align .ql-picker-item[data-value="center"]', title: t('ui.richText.alignPicker2') },
     { selector: '.ql-align .ql-picker-item[data-value="right"]', title: t('ui.richText.alignPicker3') },
+    { selector: '.ql-align .ql-picker-item[data-value="justify"]', title: t('ui.richText.alignPicker4') },
     { selector: '.ql-link', title: t('ui.richText.link') },
     { selector: '.ql-image', title: t('ui.richText.image') },
     { selector: '.ql-video', title: t('ui.richText.video') },
@@ -1116,8 +1123,10 @@ export const setToolbarTitle =
     const tips = getToolbarTitle(t)
     const container = state.quill.container.parentNode
     for (let i = 0, l = tips.length; i < l; i++) {
-      const targetDom = container.querySelector(`.ql-formats ${tips[i].selector}`)
-      targetDom && targetDom.setAttribute('title', tips[i].title)
+      const targetDoms = container.querySelectorAll(`.ql-formats ${tips[i].selector}`)
+      for (let j = 0; j < targetDoms.length; j++) {
+        targetDoms[j].setAttribute('title', tips[i].title)
+      }
     }
   }
 

--- a/packages/vue-locale/src/lang/en.ts
+++ b/packages/vue-locale/src/lang/en.ts
@@ -636,6 +636,7 @@ export default {
       size: 'Font Size',
       listOrdered: 'No. List',
       listBullet: 'Project List',
+      listCheck: 'Checklist',
       header1: 'H1',
       header2: 'H2',
       align: 'Alignment Mode',

--- a/packages/vue-locale/src/lang/es-LA.ts
+++ b/packages/vue-locale/src/lang/es-LA.ts
@@ -640,6 +640,7 @@ export default {
       size: 'Tamaño de fuente',
       listOrdered: 'No. Lista',
       listBullet: 'Lista de proyectos',
+      listCheck: 'Lista de verificación',
       header1: 'H1',
       header2: 'H2',
       align: 'Modo de alineación',

--- a/packages/vue-locale/src/lang/pt-BR.ts
+++ b/packages/vue-locale/src/lang/pt-BR.ts
@@ -640,6 +640,7 @@ export default {
       size: 'Tamanho da fonte',
       listOrdered: 'Não. Lista',
       listBullet: 'Lista de projetos',
+      listCheck: 'Lista de verificação',
       header1: 'H1',
       header2: 'H2',
       align: 'Modo de alinhamento',

--- a/packages/vue-locale/src/lang/zh-CN.ts
+++ b/packages/vue-locale/src/lang/zh-CN.ts
@@ -631,6 +631,7 @@ export default {
       size: '字体大小',
       listOrdered: '编号列表',
       listBullet: '项目列表',
+      listCheck: '可勾选',
       header1: 'h1',
       header2: 'h2',
       align: '对齐方式',

--- a/packages/vue/src/fluent-editor/__tests__/fluent-editor.test.ts
+++ b/packages/vue/src/fluent-editor/__tests__/fluent-editor.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test, afterEach } from 'vitest'
+import { setToolbarTitle } from '@opentiny/vue-renderless/fluent-editor'
+
+const t = (key: string) => key
+
+const createToolbar = (innerHTML: string) => {
+  const wrapper = document.createElement('div')
+  wrapper.innerHTML = `
+    <div class="ql-toolbar">
+      ${innerHTML}
+    </div>
+    <div class="ql-container"></div>
+  `
+  document.body.appendChild(wrapper)
+
+  const setTitle = setToolbarTitle({
+    state: { quill: { container: wrapper.querySelector('.ql-container') } },
+    t
+  })
+
+  return { wrapper, setTitle }
+}
+
+describe('fluent-editor toolbar title', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('should set title on individual align and checklist buttons', () => {
+    const { wrapper, setTitle } = createToolbar(`
+      <span class="ql-formats">
+        <button class="ql-align" value=""></button>
+        <button class="ql-align" value="center"></button>
+        <button class="ql-align" value="right"></button>
+        <button class="ql-list" value="check"></button>
+      </span>
+    `)
+
+    setTitle()
+
+    expect(wrapper.querySelector('.ql-align[value=""]')?.getAttribute('title')).toBe('ui.richText.alignPicker1')
+    expect(wrapper.querySelector('.ql-align[value="center"]')?.getAttribute('title')).toBe('ui.richText.alignPicker2')
+    expect(wrapper.querySelector('.ql-align[value="right"]')?.getAttribute('title')).toBe('ui.richText.alignPicker3')
+    expect(wrapper.querySelector('.ql-list[value="check"]')?.getAttribute('title')).toBe('ui.richText.listCheck')
+  })
+
+  test('should set title on align picker items', () => {
+    const { wrapper, setTitle } = createToolbar(`
+      <span class="ql-formats">
+        <span class="ql-align ql-picker">
+          <span class="ql-picker-options">
+            <span class="ql-picker-item"></span>
+            <span class="ql-picker-item" data-value="center"></span>
+            <span class="ql-picker-item" data-value="right"></span>
+            <span class="ql-picker-item" data-value="justify"></span>
+          </span>
+        </span>
+      </span>
+    `)
+
+    setTitle()
+
+    expect(wrapper.querySelector('.ql-align.ql-picker')?.getAttribute('title')).toBe('ui.richText.align')
+    expect(wrapper.querySelector('.ql-align .ql-picker-item:not([data-value])')?.getAttribute('title')).toBe(
+      'ui.richText.alignPicker1'
+    )
+    expect(wrapper.querySelector('.ql-align .ql-picker-item[data-value="center"]')?.getAttribute('title')).toBe(
+      'ui.richText.alignPicker2'
+    )
+    expect(wrapper.querySelector('.ql-align .ql-picker-item[data-value="right"]')?.getAttribute('title')).toBe(
+      'ui.richText.alignPicker3'
+    )
+    expect(wrapper.querySelector('.ql-align .ql-picker-item[data-value="justify"]')?.getAttribute('title')).toBe(
+      'ui.richText.alignPicker4'
+    )
+  })
+})


### PR DESCRIPTION
解决工具库中部分工具鼠标悬浮后提示消失的问题
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced fluent editor toolbar labels for alignment controls, including the alignment picker, buttons, and individual options.
  - Added a localized “Checklist” toolbar label in English, Spanish, Portuguese, and Simplified Chinese.
  - Toolbar titles are now applied consistently across matching controls, improving clarity and accessibility.

- **Tests**
  - Added coverage to verify alignment and checklist toolbar labels in the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->