### PR TITLE
fix: events cannot be broadcast into when a component is in a slot.

### DIFF
--- a/packages/vue-common/src/adapter/vue3/index.ts
+++ b/packages/vue-common/src/adapter/vue3/index.ts
@@ -88,7 +88,19 @@ const setInstanceEmitter = (instance) => {
 
 const emitEvent = (vm) => {
   const broadcast = (vm, componentName, eventName, params) => {
-    const children = (vm.subTree && vm.subTree.children) || vm.children
+    const subTree = vm.subTree
+
+    if (subTree) {
+      const subTreeName = subTree.type && subTree.type.componentName
+
+      if (subTreeName === componentName && subTree.component) {
+        subTree.component.emit(eventName, params)
+        subTree.component.$emitter && subTree.component.$emitter.emit(eventName, params)
+        return
+      }
+    }
+
+    const children = (subTree && subTree.children) || vm.children
 
     Array.isArray(children) &&
       children.forEach((child) => {
@@ -99,7 +111,7 @@ const emitEvent = (vm) => {
           component.emit(eventName, params)
           component.$emitter && component.$emitter.emit(eventName, params)
         } else {
-          broadcast(child, componentName, eventName, params)
+          broadcast(child.component ?? child, componentName, eventName, params)
         }
       })
   }


### PR DESCRIPTION
# PR

fix: 修复当组件在插槽中时，无法广播事件进入的bug

待验证测试是否通过


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event broadcasting in Vue 3 components.
  * Events are now delivered more reliably to matching nested components and their child components.
  * Added fallback handling for component hierarchies where standard child traversal is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->