### PR TITLE
fix: add the resize and drag functionality for all four edges of the modal on mf template

### DIFF
--- a/examples/sites/demos/mobile-first/app/modal/resize.vue
+++ b/examples/sites/demos/mobile-first/app/modal/resize.vue
@@ -1,5 +1,11 @@
 <template>
-  <tiny-button @click="btnClick" :reset-time="0"> 可以拖动调整窗口大小 </tiny-button>
+  <div>
+    <tiny-button @click="btnClick" :reset-time="0"> 命令式打开 </tiny-button>
+    <tiny-button @click="mainVisible = true" :reset-time="0"> 标签式打开 </tiny-button>
+
+    <tiny-modal v-model="mainVisible" title="Num.1标签式加函数弹窗" message="NO.1标签式加函数内容" resize show-footer>
+    </tiny-modal>
+  </div>
 </template>
 
 <script>
@@ -7,15 +13,19 @@ import { TinyButton, TinyModal } from '@opentiny/vue'
 
 export default {
   components: {
-    TinyButton
+    TinyButton,
+    TinyModal
+  },
+  data() {
+    return {
+      mainVisible: false
+    }
   },
   methods: {
     btnClick() {
       TinyModal.alert({
         message: '可以拖动调整窗口大小',
-        resize: true,
-        height: 188,
-        width: 366
+        resize: true
       })
     }
   }

--- a/examples/sites/demos/mobile-first/app/modal/webdoc/modal.js
+++ b/examples/sites/demos/mobile-first/app/modal/webdoc/modal.js
@@ -40,6 +40,26 @@ export default {
       codeFiles: ['fullscreen.vue']
     },
     {
+      demoId: 'modal-resize',
+      name: {
+        'zh-CN': '弹窗调整大小',
+        'en-US': 'Size control'
+      },
+      desc: {
+        'zh-CN': `
+          通过<code>resize</code>属性，设置是否允许拖动边框调整窗口大小，并且右上角显示切换最大化的按钮。<br>
+          当 <code>resize</code>属性设置为<code>true</code>后，通过 <code>min-height</code>属性设置拖拽后窗口的最小高度，默认值为 200.<br>
+          <code>min-width</code>属性设置拖拽后窗口的最小宽度，默认值为 340。<br>
+        `,
+        'en-US': `
+          With the <code>resize</code> property, set whether to allow dragging the border to resize the window, and the upper right corner shows a button to maximize the switch. <br>
+          When the <code>resize</code> property is set to <code>true</code>, use the <code>min-height</code> property to set the minimum height of the drag-and-drop window. The default is 200.<br>
+          The <code>min-width</code> property sets the minimum width of the drag-and-drop window. The default value is 340. <br>
+        `
+      },
+      codeFiles: ['resize.vue']
+    },
+    {
       demoId: 'esc-closable',
       name: {
         'zh-CN': '按 Esc 键关闭弹出框',

--- a/packages/renderless/src/modal/index.ts
+++ b/packages/renderless/src/modal/index.ts
@@ -1002,6 +1002,81 @@ export const dragEvent =
       }, 50)
     }
   }
+/** 多端与pc端的布局方式不一致，所以多端的拖动代码专门写一份 */
+export const mfDragEvent =
+  ({ api, emit, parent, props }: Pick<IModalRenderlessParams, 'api' | 'emit' | 'parent' | 'props'>) =>
+  (event: MouseEvent): void => {
+    event.preventDefault()
+
+    const modalBoxElement = api.getBox() as HTMLElement
+    const modalRootElement = modalBoxElement.offsetParent as HTMLElement
+    const modalBoxRect = modalBoxElement.getBoundingClientRect()
+    const modalRootRect = modalRootElement?.getBoundingClientRect() || { left: 0, top: 0 }
+    const startLeft = modalBoxRect.left
+    const startTop = modalBoxRect.top
+    const startWidth = modalBoxRect.width
+    const startHeight = modalBoxRect.height
+    const startRight = startLeft + startWidth
+    const startBottom = startTop + startHeight
+    const minWidth = parseFloat(String(props.minWidth)) || 0
+    const minHeight = parseFloat(String(props.minHeight)) || 0
+    const marginSize = parseFloat(String(props.marginSize)) || 0
+    const viewportWidth = document.documentElement.clientWidth || window.innerWidth
+    const viewportHeight = document.documentElement.clientHeight || window.innerHeight
+    const type = (event.target as HTMLElement)?.dataset.type
+    const startX = event.clientX
+    const startY = event.clientY
+    const demMousemove = document.onmousemove
+    const demMouseup = document.onmouseup
+
+    modalBoxElement.style.top = `${startTop - modalRootRect.top}px`
+    modalBoxElement.style.left = `${startLeft - modalRootRect.left}px`
+    modalBoxElement.style.right = 'auto'
+    modalBoxElement.style.bottom = 'auto'
+    modalBoxElement.style.transform = 'none'
+    modalBoxElement.style.width = `${startWidth}px`
+    modalBoxElement.style.height = `${startHeight}px`
+
+    document.onmousemove = (moveEvent: MouseEvent) => {
+      const deltaX = moveEvent.clientX - startX
+      const deltaY = moveEvent.clientY - startY
+      let left = startLeft
+      let top = startTop
+      let width = startWidth
+      let height = startHeight
+
+      if (type === 'wl' || type === 'swst' || type === 'swlb') {
+        left = Math.max(marginSize, Math.min(startLeft + deltaX, startRight - minWidth))
+        width = startRight - left
+      } else if (type === 'wr' || type === 'sest' || type === 'selb') {
+        width = Math.max(minWidth, Math.min(startWidth + deltaX, viewportWidth - startLeft - marginSize))
+      }
+
+      if (type === 'st' || type === 'swst' || type === 'sest') {
+        top = Math.max(marginSize, Math.min(startTop + deltaY, startBottom - minHeight))
+        height = startBottom - top
+      } else if (type === 'sb' || type === 'swlb' || type === 'selb') {
+        height = Math.max(minHeight, Math.min(startHeight + deltaY, viewportHeight - startTop - marginSize))
+      }
+
+      modalBoxElement.style.left = `${left - modalRootRect.left}px`
+      modalBoxElement.style.top = `${top - modalRootRect.top}px`
+      modalBoxElement.style.width = `${width}px`
+      modalBoxElement.style.height = `${height}px`
+
+      emit('custom-mousemove', moveEvent)
+      if (parent.$listeners.zoom) {
+        emit('zoom', { type: 'resize', $modal: parent }, moveEvent)
+      } else if (parent.events?.zoom) {
+        parent.events.zoom.call(parent, { type: 'resize', $modal: parent }, moveEvent)
+      }
+    }
+
+    document.onmouseup = () => {
+      document.onmousemove = demMousemove
+      document.onmouseup = demMouseup
+    }
+  }
 
 export const resetFormTip = (parent: IModalRenderlessParamUtils['parent'], isFormReset = true) => {
   const formList = findFormComponent(parent)

--- a/packages/renderless/src/modal/vue.ts
+++ b/packages/renderless/src/modal/vue.ts
@@ -12,6 +12,7 @@
 
 import {
   dragEvent,
+  mfDragEvent,
   handleEvent,
   mousedownEvent,
   toggleZoomEvent,
@@ -53,6 +54,7 @@ import type { IModalApi, IModalProps, IModalRenderlessParamUtils, ISharedRenderl
 export const api = [
   'state',
   'dragEvent',
+  'mfDragEvent',
   'mousedownEvent',
   'toggleZoomEvent',
   'revert',
@@ -135,6 +137,7 @@ export const renderless = (
     toggleZoomEvent: toggleZoomEvent({ api, emit, parent, state, isMobileFirstMode }),
     mousedownEvent: mousedownEvent({ api, nextTick, props, state, emit, isMobileFirstMode }),
     dragEvent: dragEvent({ api, emit, parent, props, state }),
+    mfDragEvent: mfDragEvent({ api, emit, parent, props }),
     resetDragStyle: resetDragStyle(api),
     resetModalViewPosition: resetModalViewPosition(api),
     computedBoxStyle: computedBoxStyle({ props, isMobileFirstMode }),

--- a/packages/renderless/types/modal.type.ts
+++ b/packages/renderless/types/modal.type.ts
@@ -64,6 +64,7 @@ export interface IModalApi {
   toggleZoomEvent: (event: PointerEvent) => void
   mousedownEvent: (event: MouseEvent) => void
   dragEvent: (event: MouseEvent) => void
+  mfDragEvent: (event: MouseEvent) => void
   resetDragStyle: () => void
   resetModalViewPosition: () => void
 }

--- a/packages/vue/src/modal/src/mobile-first.vue
+++ b/packages/vue/src/modal/src/mobile-first.vue
@@ -4,6 +4,7 @@ import { renderless, api } from '@opentiny/vue-renderless/modal/vue'
 import Button from '@opentiny/vue-button'
 import Checkbox from '@opentiny/vue-checkbox'
 import CheckboxGroup from '@opentiny/vue-checkbox-group'
+import type { IModalApi } from '@opentiny/vue-renderless/types/modal.type'
 import {
   iconHelpSolid,
   iconSuccess,
@@ -105,7 +106,13 @@ export default defineComponent({
     return { dialog: this }
   },
   setup(props, context) {
-    return setup({ props, context, renderless, api, extendOptions: { isMobileFirstMode: true } })
+    return setup({
+      props,
+      context,
+      renderless,
+      api,
+      extendOptions: { isMobileFirstMode: true }
+    }) as unknown as IModalApi
   },
   render() {
     let {
@@ -317,7 +324,7 @@ export default defineComponent({
                 class: [
                   'flex flex-col w-full max-h-full rounded-lg sm:rounded  overflow-hidden',
                   { 'shadow-xl bg-color-bg-1': type !== 'message' },
-                  { 'h-full': zoomLocat }
+                  { 'h-full': !isMsg }
                 ]
               },
               [
@@ -470,13 +477,30 @@ export default defineComponent({
                   !isMsg && resize
                     ? h(
                         'span',
+                        {
+                          attrs: { 'data-tag': 'tiny-modal__resize' }
+                        },
+                        // 左，右，左上，右上，上，左下，右下，下 的8个方位的拖动dom,  统一增加 absolute, z-index:100,  宽度或高度为8px的拖动条
                         ['wl', 'wr', 'swst', 'sest', 'st', 'swlb', 'selb', 'sb'].map((type) => {
                           return h('span', {
+                            class: [
+                              `${type}-resize`,
+                              {
+                                'absolute z-[100] top-0 -left-[3px] w-2 h-full cursor-w-resize': type === 'wl',
+                                'absolute z-[100] top-0 -right-[3px] w-2 h-full cursor-w-resize': type === 'wr',
+                                'absolute z-[101] -top-2 -left-2 w-2.5 h-2.5 cursor-se-resize': type === 'swst',
+                                'absolute z-[101] -top-2 -right-2 w-2.5 h-2.5 cursor-sw-resize': type === 'sest',
+                                'absolute z-[100] -top-[3px] left-0 w-full h-2 cursor-s-resize': type === 'st',
+                                'absolute z-[101] -bottom-2 -left-2 w-2.5 h-2.5 cursor-sw-resize': type === 'swlb',
+                                'absolute z-[101] -bottom-2 -right-2 w-2.5 h-2.5 cursor-se-resize': type === 'selb',
+                                'absolute z-[100] -bottom-[3px] left-0 w-full h-2 cursor-s-resize': type === 'sb'
+                              }
+                            ],
                             attrs: {
                               'data-type': type
                             },
                             on: {
-                              mousedown: this.dragEvent
+                              mousedown: this.mfDragEvent
                             }
                           })
                         })


### PR DESCRIPTION
# PR

fix: 为modal的多端增加resize 拖动4个边的功能


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resizing support for mobile-first modals, including minimum width and height limits.
  * Added eight-direction resize handles for more flexible modal adjustment.
  * Added a demo showing both programmatic and component-based ways to open resizable modals.
  * Added documentation for the new resize options in Chinese and English.

* **Bug Fixes**
  * Improved modal resizing behavior within the viewport and surrounding margins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->