### PR TITLE
fix(tag-group): delayed calculation of the tag's height

### DIFF
--- a/packages/renderless/src/tag-group/vue.ts
+++ b/packages/renderless/src/tag-group/vue.ts
@@ -16,8 +16,6 @@ export const renderless = (
   { onMounted, onBeforeUnmount, reactive, watch }: ISharedRenderlessParamHooks,
   { vm, emit }: ITagGroupRenderlessParamUtils
 ): ITagGroupApi => {
-  const delay = 100
-
   const state = reactive<ITagGroupState>({
     showMore: false,
     hiddenTags: []
@@ -30,9 +28,11 @@ export const renderless = (
   }
 
   onMounted(() => {
-    api.getHiddenTags()
+    const delay = 100
     api.debouncedGetHiddenTags = debounce(delay, api.getHiddenTags)
-    addResizeListener(vm.$refs.tagGroup, debounce(delay, api.debouncedGetHiddenTags))
+    api.debouncedGetHiddenTags()
+
+    addResizeListener(vm.$refs.tagGroup, api.debouncedGetHiddenTags)
   })
 
   // Tiny 新增，当标签组的数量发生变化也需要动态计算tip框中的tag标签数量

--- a/packages/renderless/src/tag-group/vue.ts
+++ b/packages/renderless/src/tag-group/vue.ts
@@ -39,7 +39,7 @@ export const renderless = (
   watch(
     () => props.data.length,
     () => {
-      api.getHiddenTags()
+      api.debouncedGetHiddenTags?.()
     }
   )
 


### PR DESCRIPTION
# PR
fix(tag-group): 延时计算tag的高度.   在表格中使用时，偶发的计算出高度为0， 造成tag不显示。


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag visibility updates when content changes or the viewport is resized.
  * Ensured hidden tags are recalculated consistently during component mounting and subsequent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->