### PR TITLE
fix(docs): close body poppers on doc layout scroll (opentiny#4290)

### DIFF
--- a/examples/sites/src/views/components-doc/common.vue
+++ b/examples/sites/src/views/components-doc/common.vue
@@ -381,7 +381,17 @@ const loadPage = () => {
   })
 }
 
-const onDocLayoutScroll = debounce(100, false, () => {
+const closeBodyPoppersOnScroll = () => {
+  // Body-mounted poppers (select/datepicker/…) stay fixed while #doc-layout-scroller moves,
+  // so they can cover .docs-header. Closing on scroll matches expected docs UX and avoids
+  // raising header z-index above PopupManager (which would break dialog/DocSearch/notify).
+  // Dispatch on an Element (not document): touch-emulator calls Element.matches via closest().
+  const target = document.body
+  target.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+  target.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+}
+
+const updateAnchorAffixOnScroll = debounce(100, false, () => {
   const docLayout = scrollRef.value
   const { scrollTop, scrollHeight, clientHeight: layoutHeight } = docLayout
   const headerHeight = document.querySelector('.docs-header')?.clientHeight || 0
@@ -390,6 +400,11 @@ const onDocLayoutScroll = debounce(100, false, () => {
   const remainHeight = scrollHeight - scrollTop - layoutHeight // doc-layout-scroller视口下隐藏的部分高度
   state.anchorAffix = layoutHeight - headerHeight - (footerHeight - remainHeight) > anchorHeight
 })
+
+const onDocLayoutScroll = () => {
+  closeBodyPoppersOnScroll()
+  updateAnchorAffixOnScroll()
+}
 
 const setScrollListener = () => {
   nextTick(() => {


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

文档站点中，Select / DatePicker 等挂在 `body` 上的下拉面板打开后，滚动 `#doc-layout-scroller` 时面板会随 Popper 上移，遮挡顶部固定的组件介绍（`.docs-header`）。根因是弹层 `z-index`（PopupManager 从 2000 起）远高于介绍区域有效层高，且不宜简单抬高 header（会盖住 Dialog / DocSearch / Notify 等）。

Issue Number: #4290

## What is the new behavior?

文档内容区滚动时，通过向 `document.body` 派发 `mousedown` / `mouseup` 触发组件已有的 `v-clickoutside`，自动关闭 body 挂载的下拉浮层，避免遮挡顶部介绍；锚点 affix 逻辑仍按原 debounce 更新。不改动组件库弹层全局 z-index，不影响 Dialog / DocSearch / Notify。

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

- 仅改动文档站点：`examples/sites/src/views/components-doc/common.vue`
- 合成事件派发在 `document.body`（Element）上，避免派发到 `document` 时 touch-emulator 的 `closest` 触发 `Illegal invocation`
- 建议自测：打开 BaseSelect 下拉 → 滚动文档区 → 面板关闭且无控制台报错；打开 Dialog demo 确认遮罩/弹窗层级正常