### PR TITLE
fix(alert): remove the height restriction for the large mode of the alert component.

### DIFF
--- a/packages/vue/src/alert/src/mobile-first.vue
+++ b/packages/vue/src/alert/src/mobile-first.vue
@@ -5,8 +5,7 @@
       v-if="state.show"
       :class="
         m(
-          { 'min-h-min': size !== 'large' },
-          'flex py-2 px-4 my-2 rounded-form box-border font-light sm:font-normal text-color-text-primary border border-transparent',
+          'min-h-minflex py-2 px-4 my-2 rounded-form box-border font-light sm:font-normal text-color-text-primary border border-transparent',
           `tiny-alert--${size || 'normal'}`,
           { 'bg-color-info-primary-subtler': type === 'info' || !type },
           { 'bg-color-error-subtler': type === 'error' },
@@ -14,7 +13,6 @@
           { 'bg-color-success-subtler': type === 'success' },
           { 'text-center': center },
           [size === 'small' ? 'sm:py-0.5' : size === 'medium' ? 'sm:py-1' : size === 'large' ? 'sm:py-6' : 'sm:py-3'],
-          { 'h-[76px]': size === 'large' },
           customClass
         )
       "

--- a/packages/vue/src/alert/src/mobile-first.vue
+++ b/packages/vue/src/alert/src/mobile-first.vue
@@ -5,7 +5,7 @@
       v-if="state.show"
       :class="
         m(
-          'min-h-minflex py-2 px-4 my-2 rounded-form box-border font-light sm:font-normal text-color-text-primary border border-transparent',
+          'min-h-min flex py-2 px-4 my-2 rounded-form box-border font-light sm:font-normal text-color-text-primary border border-transparent',
           `tiny-alert--${size || 'normal'}`,
           { 'bg-color-info-primary-subtler': type === 'info' || !type },
           { 'bg-color-error-subtler': type === 'error' },


### PR DESCRIPTION
# PR

fix: 移除 alert组件的large模式的高度限制


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated alert component sizing and spacing behavior for a more consistent layout across alert sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->