### PR TITLE
fix(vue/grid): [grid] guard requestIdleCallback for Safari

### DIFF
--- a/packages/vue/src/grid/src/table/src/methods.ts
+++ b/packages/vue/src/grid/src/table/src/methods.ts
@@ -460,8 +460,13 @@ const Methods = {
 
     // 可编辑表格默认开启备份，非可编辑表格在开启saveSource时也可备份
     if (backup && (editConfig || saveSource)) {
-      /* 在空闲帧任务中备份数据 */
-      requestIdleCallback(() => {
+      /* 在空闲帧任务中备份数据；Safari 等环境可能无 requestIdleCallback */
+      const scheduleIdle: (cb: () => void) => unknown =
+        typeof requestIdleCallback === 'function'
+          ? (cb) => requestIdleCallback(cb)
+          : (cb) => setTimeout(cb, 1)
+
+      scheduleIdle(() => {
         const rowidCacheMap = new Map()
         // 默认浅层复制，在设置saveSource为deep时开启深层复制
         const callback = (row) =>


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-vue/blob/dev/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

On Safari versions where `requestIdleCallback` is unavailable, TinyGrid with `editConfig` (or `saveSource`) throws `ReferenceError: Can't find variable: requestIdleCallback` inside `updateCache`. The data watcher then aborts before `handleDataChange`, so the grid body stays empty (shows empty/no-data) even when data exists. Chrome/Edge are unaffected because the API exists.

## What is the new behavior?

`updateCache` schedules the row backup via `requestIdleCallback` when available, and falls back to `setTimeout(cb, 1)` otherwise, so Safari no longer throws and data rendering can proceed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
https://caniuse.com/?search=requestidlecallback
<img width="1438" height="600" alt="image" src="https://github.com/user-attachments/assets/fea58d0e-b4a1-4c7d-80b1-fa8908b2cc04" />